### PR TITLE
add 413 to failure status codes

### DIFF
--- a/shared/attributes/failure_status_code.yml
+++ b/shared/attributes/failure_status_code.yml
@@ -4,6 +4,7 @@ enum:
   - 401
   - 403
   - 404
+  - 413
   - 422
   - 429
   - 500
@@ -13,6 +14,7 @@ description: >
     * 401 - Authorization error with your API key or account
     * 403 - Forbidden error with your API key or account
     * 404 - The requested item does not exist
+    * 413 - Payload too large
     * 422 - The query or body parameters did not pass validation
     * 429 - Too many requests have been sent with an API key in a given amount of time
     * 500 - An internal server error occurred, please contact support@lob.com


### PR DESCRIPTION
What it says :slightly_smiling_face: 

No, seriously. I realized, during the Atlas standup this morning, that our failure list was missing [413](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml), which Dora may return.