### PR TITLE
Fix failing contract tests for create and list addresses responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Lob [OpenAPI v3](https://github.com/OAI/OpenAPI-Specification) Specification
 
-  - [How the spec is organized](#how-the-spec-is-organized)
-  - [Style Guide and Linting](#style-guide-and-linting)
-  - [Previewing the spec as docs (aka QAing your work)](#previewing-the-spec-as-docs-aka-qaing-your-work)
-  - [Local Contract Testing](#local-contract-testing)
-  - [Compatibility with Community Tooling](#compatibility-with-community-tooling)
-  - [See Also](#see-also)
+- [How the spec is organized](#how-the-spec-is-organized)
+- [Style Guide and linting](#style-guide-and-linting)
+- [Future proofing](#future-proofing)
+- [Previewing the spec as docs (aka QAing your work)](#previewing-the-spec-as-docs-aka-qaing-your-work)
+- [Local contract testing](#local-contract-testing)
+- [Compatibility with community tooling](#compatibility-with-community-tooling)
+- [See also](#see-also)
 
 ## How the spec is organized
 
@@ -37,7 +38,7 @@ Our spec is organized semantically, by *resource*, instead of syntactically, by 
             └── list.yml
 ```
 
-## Style Guide and Linting
+## Style Guide and linting
 
 Our style guide is an extension of
 [Spectral's](https://meta.stoplight.io/docs/spectral/README.md) [OpenAPI
@@ -54,6 +55,9 @@ For those editing in VS Code, additional linting can be provided by
 [42crunch.vscode-openapi](https://github.com/42Crunch/vscode-openapi). A second
 linter will be added to CI, as a backup to Spectral.
 
+## Future proofing
+
+As of January 2021, OpenAPI v3.1 is in [rc1](https://www.openapis.org/blog) with final expected any day. 3.1 includes many [extremely useful changes](https://github.com/OAI/OpenAPI-Specification/releases/tag/3.1.0-rc0), including full JSON schema compatibility and the ability to extend discriminators with specification extensions. As we anticipate moving to v3.1 soon after release, we're working to minimize the changes we'll need to make. Some changes, like switching from `nullable` to `null`, are both unavoidable and easy. Others, like using `ReadOnly` and `WriteOnly` with `required`, can and should be avoided.
 ## Previewing the spec as docs (aka QAing your work)
 
 To preview the spec using redoc:
@@ -67,7 +71,7 @@ To preview the spec using redoc:
 * Run the code samples to be sure they are correct.
 * Compare the response you get to the example response.
 
-## Local Contract Testing
+## Local contract testing
 
 You can run [Prism](https://meta.stoplight.io/docs/prism/README.md) locally as a
 [validation proxy](https://meta.stoplight.io/docs/prism/docs/getting-started/03-cli.md#proxy)
@@ -133,7 +137,7 @@ contain a JSON object with all violations found in the response. You can also
 use the `--errors` flag which will turn any request or response violation found
 into a [RFC7807](https://tools.ietf.org/html/rfc7807) machine readable error.
 
-## Compatibility with Community Tooling
+## Compatibility with community tooling
 
 A lot of tooling for working with OpenAPI specs does not support the full
 specification. In particular, many tools do not support multiple files specs. To
@@ -143,7 +147,7 @@ The tool used by `make bundle` can do much more than bundle a multiple file spec
 into a single file. It can convert specs between `YAML` and `JSON`, fully
 dereference a spec, and more.
 
-## See Also
+## See also
 
 * [Lob API documentation](https://docs.lob.com/)
 * [Lobsters](https://www.lob.com/careers) only

--- a/resources/addresses/addresses.yml
+++ b/resources/addresses/addresses.yml
@@ -39,15 +39,15 @@ post:
     content:
       application/json:
         schema:
-          $ref: 'models/address.yml'
+          $ref: 'models/address_writable.yml'
 
       application/x-www-form-urlencoded:
         schema:
-          $ref: 'models/address.yml'
+          $ref: 'models/address_writable.yml'
 
       multipart/form-data:
         schema:
-          $ref: 'models/address.yml'
+          $ref: 'models/address_writable.yml'
 
   responses:
     '200':

--- a/resources/addresses/addresses.yml
+++ b/resources/addresses/addresses.yml
@@ -51,7 +51,7 @@ post:
 
   responses:
     '200':
-      $ref: responses/address.yml
+      $ref: responses/address_writable.yml
 
     default:
       $ref: '../../shared/responses/error.yml'

--- a/resources/addresses/models/address.yml
+++ b/resources/addresses/models/address.yml
@@ -1,147 +1,42 @@
-type: object
+allOf:
+  - $ref: 'address_writable.yml'
 
-required:
-  - id
-  - address_line1
-  - date_created
-  - date_modified
-  - deleted
-  - object
+  - type: object
 
-properties:
-  id:
-    $ref: '../attributes/adr_id.yml'
+    required:
+      - id
+      - date_created
+      - date_modified
+      - object
 
-  description:
-    type: string
-    description: >
-      An internal description that identifies this resource. Must be
-      no longer than 255 characters.
-    maxLength: 255
-    nullable: true
-    example: Harry - Office
+    properties:
+      id:
+        $ref: '../attributes/adr_id.yml'
 
-  name:
-    type: string
-    description: >
-      Either <code>name</code> or <code>company</code> is required,
-      you may also add both. Must be no longer than 40 characters.
-      If both <code>name</code> and <code>company</code> are provided,
-      they will be printed on two separate lines above the rest of the address.
-    maxLength: 40
-    nullable: true
-    example: HARRY ZHANG
+      recipient_moved:
+        type: boolean
+        description: >
+          Only returned for accounts on certain
+          <a href="https://dashboard.lob.com/#/settings/editions">Print
+          &amp; Mail Editions</a>. Value is <code>true</code> if the address was
+          altered because the recipient filed for a <a href="#ncoa">National Change
+          of Address (NCOA)</a>, <code>false</code> if the NCOA check was run but
+          no altered address was found, and <code>null</code> if the NCOA check
+          was not run. The NCOA check does not happen for non-US addresses, for
+          non-deliverable US addresses, or for addresses created before the NCOA
+          feature was added to your account.
+        nullable: true
+        readOnly: true
+        example: false
 
-  company:
-    type: string
-    description: >
-      Either <code>name</code> or <code>company</code> is required,
-      you may also add both. Must be no longer than 40 characters.
-      If both <code>name</code> and <code>company</code> are provided,
-      they will be printed on two separate lines above the rest of the address.
-      This field can be used for any secondary recipient information which is
-      not part of the actual mailing address (Company Name, Department,
-      Attention Line, etc).
-    maxLength: 40
-    nullable: true
-    example: LOB
+      deleted:
+        $ref: '../../../shared/attributes/deleted.yml'
 
-  phone:
-    type: string
-    description: Must be no longer than 40 characters.
-    maxLength: 40
-    nullable: true
-    example: "5555555555"
+      date_created:
+        $ref: '../../../shared/attributes/timestamps.yml#/date_created'
 
-  email:
-    type: string
-    description: Must be no longer than 100 characters.
-    maxLength: 100
-    nullable: true
-    example: harry@lob.com
+      date_modified:
+        $ref: '../../../shared/attributes/timestamps.yml#/date_modified'
 
-  address_line1:
-    type: string
-    description: >
-      Must be no longer than 64 characters for US addresses or 200 characters
-      for international addresses.
-    maxLength: 200
-    example: 185 BERRY ST STE 6100
-
-  address_line2:
-    type: string
-    description: >
-      Must be no longer than 64 characters for US addresses or 200 characters
-      for international addresses.
-    maxLength: 200
-    nullable: true
-    example: null
-
-  address_city:
-    type: string
-    description: >
-      Required if address_country is US, otherwise optional.
-      Must be no longer than 200 characters.
-    maxLength: 200
-    nullable: true
-    example: SAN FRANCISCO
-
-  address_state:
-    type: string
-    description: >
-      Required as a 2 letter state short-name code if <code>address_country</code>
-      is <code>US</code>, otherwise optional and no longer than 200 characters.
-    maxLength: 200
-    nullable: true
-    example: CA
-
-  address_zip:
-    type: string
-    description: >
-      Required and must follow the ZIP format of <code>12345</code> or
-      ZIP+4 format of <code>12345-1234</code> if <code>address_country</code>
-      is <code>US</code>, otherwise optional and not any longer than 40 characters.
-    maxLength: 40
-    nullable: true
-    example: 94107-1741
-
-  address_country:
-    type: string
-    description: >
-      Must be a 2 letter country short-name code (ISO 3166). Defaults to <code>US</code>.
-    minLength: 2
-    example: US
-
-  send_date:
-    $ref: '../../../shared/attributes/send_date.yml'
-
-  metadata:
-    $ref: '../../../shared/models/metadata.yml'
-
-  recipient_moved:
-    type: boolean
-    description: >
-      Only returned for accounts on certain
-      <a href="https://dashboard.lob.com/#/settings/editions">Print
-      &amp; Mail Editions</a>. Value is <code>true</code> if the address was
-      altered because the recipient filed for a <a href="#ncoa">National Change
-      of Address (NCOA)</a>, <code>false</code> if the NCOA check was run but
-      no altered address was found, and <code>null</code> if the NCOA check
-      was not run. The NCOA check does not happen for non-US addresses, for
-      non-deliverable US addresses, or for addresses created before the NCOA
-      feature was added to your account.
-    nullable: true
-    readOnly: true
-    example: false
-
-  deleted:
-    $ref: '../../../shared/attributes/deleted.yml'
-
-  date_created:
-    $ref: '../../../shared/attributes/timestamps.yml#/date_created'
-
-  date_modified:
-    $ref: '../../../shared/attributes/timestamps.yml#/date_modified'
-
-  object:
-    $ref: '../../../shared/attributes/object.yml'
+      object:
+        $ref: '../../../shared/attributes/object.yml'

--- a/resources/addresses/models/address_writable.yml
+++ b/resources/addresses/models/address_writable.yml
@@ -1,0 +1,111 @@
+type: object
+
+required:
+  - address_line1
+
+properties:
+  description:
+    type: string
+    description: >
+      An internal description that identifies this resource. Must be
+      no longer than 255 characters.
+    maxLength: 255
+    nullable: true
+    example: Harry - Office
+
+  name:
+    type: string
+    description: >
+      Either <code>name</code> or <code>company</code> is required,
+      you may also add both. Must be no longer than 40 characters.
+      If both <code>name</code> and <code>company</code> are provided,
+      they will be printed on two separate lines above the rest of the address.
+    maxLength: 40
+    nullable: true
+    example: HARRY ZHANG
+
+  company:
+    type: string
+    description: >
+      Either <code>name</code> or <code>company</code> is required,
+      you may also add both. Must be no longer than 40 characters.
+      If both <code>name</code> and <code>company</code> are provided,
+      they will be printed on two separate lines above the rest of the address.
+      This field can be used for any secondary recipient information which is
+      not part of the actual mailing address (Company Name, Department,
+      Attention Line, etc).
+    maxLength: 40
+    nullable: true
+    example: LOB
+
+  phone:
+    type: string
+    description: Must be no longer than 40 characters.
+    maxLength: 40
+    nullable: true
+    example: "5555555555"
+
+  email:
+    type: string
+    description: Must be no longer than 100 characters.
+    maxLength: 100
+    nullable: true
+    example: harry@lob.com
+
+  address_line1:
+    type: string
+    description: >
+      Must be no longer than 64 characters for US addresses or 200 characters
+      for international addresses.
+    maxLength: 200
+    example: 185 BERRY ST STE 6100
+
+  address_line2:
+    type: string
+    description: >
+      Must be no longer than 64 characters for US addresses or 200 characters
+      for international addresses.
+    maxLength: 200
+    nullable: true
+    example: null
+
+  address_city:
+    type: string
+    description: >
+      Required if address_country is US, otherwise optional.
+      Must be no longer than 200 characters.
+    maxLength: 200
+    nullable: true
+    example: SAN FRANCISCO
+
+  address_state:
+    type: string
+    description: >
+      Required as a 2 letter state short-name code if <code>address_country</code>
+      is <code>US</code>, otherwise optional and no longer than 200 characters.
+    maxLength: 200
+    nullable: true
+    example: CA
+
+  address_zip:
+    type: string
+    description: >
+      Required and must follow the ZIP format of <code>12345</code> or
+      ZIP+4 format of <code>12345-1234</code> if <code>address_country</code>
+      is <code>US</code>, otherwise optional and not any longer than 40 characters.
+    maxLength: 40
+    nullable: true
+    example: 94107-1741
+
+  address_country:
+    type: string
+    description: >
+      Must be a 2 letter country short-name code (ISO 3166). Defaults to <code>US</code>.
+    minLength: 2
+    example: US
+
+  send_date:
+    $ref: '../../../shared/attributes/send_date.yml'
+
+  metadata:
+    $ref: '../../../shared/models/metadata.yml'

--- a/resources/addresses/responses/address_writable.yml
+++ b/resources/addresses/responses/address_writable.yml
@@ -1,0 +1,14 @@
+description: Echos the writable fields of a newly created address object.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers/ratelimit.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers/ratelimit.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers/ratelimit.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/address_writable.yml'


### PR DESCRIPTION
Fixes https://lobsters.atlassian.net/browse/ENG-15332

To test:

- install httpie (couldn't cope with curl any more, sorry!) 
- in one terminal, run `prism proxy --errors Lob-API-public.yml https://api.lob.com/v1`
- in a second terminal, run each of the following tests. Watch the first terminal for errors.

```
> http -a test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: -v GET http://127.0.0.1:4010/addresses Accept-Encoding:
> http -a test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: -v GET http://127.0.0.1:4010/addresses/adr_43769b47aed248c2 Accept-Encoding:
> http -a test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: -v DELETE http://127.0.0.1:4010/addresses/adr_43769b47aed248c2 Accept-Encoding:
> http -a test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: -v POST http://127.0.0.1:4010/addresses description="Harry - Office" name="Harry Zhang" company=Lob email=harry@lob.com phone=5555555555 address_line1="185 Berry St" address_line2="# 6100" address_city="San Francisco" address_state=CA address_zip=94107 address_country=US Accept-Encoding:
```