### PR TITLE
check response.status in tests, fix sPeLling of BaSIC

### DIFF
--- a/tests/addresses_test.js
+++ b/tests/addresses_test.js
@@ -10,14 +10,13 @@ const adr_id = 'adr_43769b47aed248c2';
 
 // contract tests
 test('list addresses', async function(t) {
-  const client = await setup();
+  const response = await setup()
+    .then(client => client.get(resource_endpoint, { headers: authHeader }));
 
-  t.ok(client.get(resource_endpoint, { headers: authHeader }));
+  t.equal(response.status, 200);
 });
 
 test('create an address', async function(t) {
-  const client = await setup();
-
   const params = {
     description:     'Harry - Office',
     name:            'Harry Zhang',
@@ -31,18 +30,22 @@ test('create an address', async function(t) {
     address_zip:     '94107',
     address_country: 'US',
   }
+  const response = await setup()
+    .then(client => client.post(resource_endpoint, params, { headers: authHeader }));
 
-  t.ok(client.post(resource_endpoint, params, { headers: authHeader }));
+  t.equal(response.status, 200);
 });
 
 test('retrieve an address', async function(t) {
-  const client = await setup();
+  const response = await setup().
+    then(client => client.get(`${resource_endpoint}/${adr_id}`, { headers: authHeader }));
 
-  t.ok(client.get(`${resource_endpoint}/${adr_id}`, { headers: authHeader }));
+  t.equal(response.status, 200);
 });
 
 test('delete an address', async function(t) {
-  const client = await setup();
+  const response = await setup()
+    .then(client => client.delete(`${resource_endpoint}/${adr_id}`, { headers: authHeader }));
 
-  t.ok(client.delete(`${resource_endpoint}/${adr_id}`, { headers: authHeader }));
+  t.equal(response.status, 200);
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -22,5 +22,5 @@ module.exports.setup = async () => {
   return createClientFromOperations(operations, clientOptions);
 }
 
-const testSecret = 'BASIC dGVzdF8wZGM4ZDUxZTBhY2ZmY2IxODgwZTBmMTljNzliMmY1YjBjYzo='
+const testSecret = 'Basic dGVzdF8wZGM4ZDUxZTBhY2ZmY2IxODgwZTBmMTljNzliMmY1YjBjYzo='
 module.exports.authHeader = { Authorization: testSecret };


### PR DESCRIPTION
promises are tricksy

* We have to resolve the promise in order to determine whether the response was actually ok. Tests updated to check response.status. Leaving aside that these shouldn't be returning 200...
* Fix for @tlhunter's #25 