### PR TITLE
add zip_lookups

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -20,4 +20,4 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^resources\/[a-zA-Z]+\/[a-zA-Z-_]+.yml"
+        match: "^resources\/[a-zA-Z-_]+\/[a-zA-Z-_]+.yml"

--- a/Lob-API-public.yml
+++ b/Lob-API-public.yml
@@ -22,6 +22,8 @@ servers:
 tags:
   - name: Addresses
     description: Content relevant to addresses
+  - name: Zip Lookups
+    description: Content relevant to US ZIP lookups
 
 components:
   securitySchemes:
@@ -38,3 +40,6 @@ paths:
 
   /addresses:
     $ref: resources/addresses/addresses.yml
+
+  /us_zip_lookups:
+    $ref: resources/zip_lookups/zip_lookups.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "tap-spec": "^5.0.0",
-        "tape": "^5.1.1"
+        "tape": "^5.1.1",
+        "tape-catch": "^1.0.6"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -1167,6 +1168,12 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "node_modules/domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
@@ -1766,6 +1773,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "dev": true,
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "node_modules/graceful-fs": {
@@ -2615,6 +2632,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3158,6 +3184,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -4052,6 +4087,18 @@
       },
       "bin": {
         "tape": "bin/tape"
+      }
+    },
+    "node_modules/tape-catch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tape-catch/-/tape-catch-1.0.6.tgz",
+      "integrity": "sha1-EpMdXqYKA6l9m9GdDX2M/D9s7PE=",
+      "dev": true,
+      "dependencies": {
+        "global": "~4.3.0"
+      },
+      "peerDependencies": {
+        "tape": "*"
       }
     },
     "node_modules/text-table": {
@@ -5347,6 +5394,12 @@
         }
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
@@ -5838,6 +5891,16 @@
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "requires": {
         "is-glob": "^4.0.1"
+      }
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "graceful-fs": {
@@ -6479,6 +6542,15 @@
         "mime-db": "1.45.0"
       }
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -6907,6 +6979,12 @@
         "parse-ms": "^1.0.0",
         "plur": "^1.0.0"
       }
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -7610,6 +7688,15 @@
         "resumer": "^0.0.0",
         "string.prototype.trim": "^1.2.3",
         "through": "^2.3.8"
+      }
+    },
+    "tape-catch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tape-catch/-/tape-catch-1.0.6.tgz",
+      "integrity": "sha1-EpMdXqYKA6l9m9GdDX2M/D9s7PE=",
+      "dev": true,
+      "requires": {
+        "global": "~4.3.0"
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
   },
   "homepage": "https://github.com/lob/lob-openapi#readme",
   "dependencies": {
+    "@stoplight/prism-cli": "^4.1.2",
+    "@stoplight/spectral": "^5.8.0"
   },
   "devDependencies": {
-    "@stoplight/prism-cli": "^4.1.2",
-    "@stoplight/spectral": "^5.8.0",
     "tap-spec": "^5.0.0",
-    "tape": "^5.1.1"
+    "tape": "^5.1.1",
+    "tape-catch": "^1.0.6"
   }
 }

--- a/resources/zip_lookups/attributes/zip_id.yml
+++ b/resources/zip_lookups/attributes/zip_id.yml
@@ -1,0 +1,5 @@
+type: string
+description: Unique identifier prefixed with <code>us_zip_</code>.
+readOnly: true
+pattern: '^us_zip_[a-zA-Z0-9]+$'
+example: us_zip_c7cb63d68f8d6

--- a/resources/zip_lookups/models/city.yml
+++ b/resources/zip_lookups/models/city.yml
@@ -1,0 +1,56 @@
+type: object
+
+required:
+  - city
+  - state
+  - county
+  - county_fips
+  - preferred
+
+properties:
+  city:
+    type: string
+    description: >
+      The name of the city.
+    example: SAN FRANCISCO
+    readOnly: true
+
+  state:
+    type: string
+    description: >
+      The state as a two-letter abbreviation.
+    maxLength: 2
+    example: CA
+    readOnly: true
+
+  county:
+    type: string
+    description: >
+      The name of the county that contains this city.
+    example: US
+    readOnly: true
+
+  county_fips:
+    type: string
+    description: >
+      A 5-digit [FIPS county code](https://en.wikipedia.org/wiki/FIPS_county_code)
+      which uniquely identifies components[county]. It consists of a 2-digit state
+      code and a 3-digit county code.
+    maxLength: 5
+    minLength: 5
+    example: '06075'
+    readOnly: true
+    
+  preferred:
+    type: boolean
+    description: >
+      Indicates whether or not the city is the [USPS default city](https://en.wikipedia.org/wiki/ZIP_Code#ZIP_Codes_and_previous_zoning_lines)
+      (preferred city) of a ZIP code. There is only one preferred city per ZIP code,
+      which will always be in position 0 in the array of cities.
+    maxLength: 1
+    minLength: 1
+    example: true
+    readOnly: true
+
+  object:
+    $ref: '../../../shared/attributes/object.yml'

--- a/resources/zip_lookups/models/zip.yml
+++ b/resources/zip_lookups/models/zip.yml
@@ -1,0 +1,45 @@
+allOf:
+  - $ref: '../../../shared/models/zip5.yml'
+
+  - type: object
+
+    required:
+      - id
+      - cities
+      - zip_code_type
+      - object
+
+    properties:
+      id:
+        $ref: '../attributes/zip_id.yml'
+
+      cities:
+        type: array
+        items:
+          $ref: 'city.yml'
+        description: >
+          An array of city objects containing valid cities for the <code>zip_code</code>.
+          Multiple cities will be returned if more than one city is associated with the
+          input ZIP code.
+        readOnly: true
+
+      zip_code_type:
+        type: string
+        enum:
+          - standard
+          - po_box
+          - unique
+          - military
+          - ''
+        description: >
+          A description of the ZIP code type.
+          * `standard` – The default ZIP code type. Used when none of the other types apply.
+          * `po_box` – The ZIP code contains only PO Boxes.
+          * `unique` – The ZIP code is uniquely assigned to a single organization (such as a government agency) that receives a large volume of mail.
+          * `military` – The ZIP code contains military addresses.
+          * `''` – A match could not be made with the provided inputs.
+        readOnly: true
+        example: 'standard'
+
+      object:
+        $ref: '../../../shared/attributes/object.yml'

--- a/resources/zip_lookups/responses/zip_lookups.yml
+++ b/resources/zip_lookups/responses/zip_lookups.yml
@@ -1,0 +1,14 @@
+description: Returns a zip lookup object if a valid zip was provided.
+
+headers:
+  ratelimit-limit:
+    $ref: '../../../shared/headers/ratelimit.yml#/ratelimit-limit'
+  ratelimit-remaining:
+    $ref: '../../../shared/headers/ratelimit.yml#/ratelimit-remaining'
+  ratelimit-reset:
+    $ref: '../../../shared/headers/ratelimit.yml#/ratelimit-reset'
+
+content:
+  application/json:
+    schema:
+      $ref: '../models/zip.yml'

--- a/resources/zip_lookups/zip_lookups.yml
+++ b/resources/zip_lookups/zip_lookups.yml
@@ -1,0 +1,33 @@
+
+post:
+  operationId: zip_lookup
+
+  summary: Looks up information pertaining to a given ZIP code
+
+  description: >-
+    Returns information about a ZIP code
+
+  tags:
+    - Zip Lookups
+
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../shared/models/zip5.yml'
+
+      application/x-www-form-urlencoded:
+        schema:
+          $ref: '../../shared/models/zip5.yml'
+
+      multipart/form-data:
+        schema:
+          $ref: '../../shared/models/zip5.yml'
+
+  responses:
+    '200':
+      $ref: responses/zip_lookups.yml
+
+    default:
+      $ref: '../../shared/responses/error.yml'

--- a/shared/models/zip5.yml
+++ b/shared/models/zip5.yml
@@ -1,0 +1,11 @@
+type: object
+
+required:
+  - zip_code
+
+properties:
+  zip_code:
+    type: string
+    description: A 5-digit ZIP code.
+    pattern: '^\d{5}$'
+    example: '94107'

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -17,9 +17,9 @@ const clientOptions = {
 
 const specFile = './Lob-API-public.yml';
 
-module.exports.setup = async () => {
+module.exports.setup = async (override = {}) => {
   const operations = await getHttpOperationsFromSpec(specFile);
-  return createClientFromOperations(operations, clientOptions);
+  return createClientFromOperations(operations, { ...clientOptions, ...override });
 }
 
 const testSecret = 'Basic dGVzdF8wZGM4ZDUxZTBhY2ZmY2IxODgwZTBmMTljNzliMmY1YjBjYzo='

--- a/tests/zip_lookups_test.js
+++ b/tests/zip_lookups_test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const test                  = require('tape');
+const { setup, authHeader } = require('./setup.js');
+
+const resource_endpoint = '/us_zip_lookups';
+const zip = '94107';
+
+test('lookup a US zip code', async function(t) {
+  const response = await setup()
+    .then(client => client.post(resource_endpoint, { zip_code: zip }, { headers: authHeader }));
+
+    t.equal(response.status, 200);
+  });
+
+// I could not figure out how to get t.throws to take an async function
+test('use an incorrectly formatted zip code', async function(t) {
+  const response = await setup({errors: false})
+    .then(client => client.post(resource_endpoint, { zip_code: '123456' }, { headers: authHeader }));
+
+  t.equal(response.status, 422);
+  t.match(response.data.error.message, /zip_code/);
+  t.end();
+});


### PR DESCRIPTION
* adds endpoints for zip_lookups (https://lobsters.atlassian.net/browse/ENG-15317)
* includes a couple of refinements to the contract testing framework:
  * we now have `tape-catch` in our devDependencies; I found it invaluable in debugging the test issue I was chasing down, even though I didn't keep it in the final version of the test
  * `setup` now accepts an `override` object for per test client settings (used here to set `errors: false`)

I ran into the errors + promises + testing maze with one of these tests. I ended up rewriting the test to check the returned error message rather than checking the thrown error. I couldn't get `t.throws` to accept an async function for its first parameter regardless of how I wrote it (async/await, promise, etc., etc.). The documentation for `t.throws` refers you to the documentation to Node.js [`assert.throws`](https://nodejs.org/api/assert.html#assert_assert_throws_fn_error_message) for examples; based on Node's docs, I'm not sure that it can take a function that returns a promise. The current pattern should work fine for our needs.