### PR TITLE
push changes only when there are changes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout
@@ -19,9 +19,14 @@ jobs:
           bundled-spec: 'dist/Lob-API-bundled.yml'
 
       - name: commit & push bundle to branch
+        shell: bash
         run: |
-          git config user.name lobot
-          git config user.email lobot@lob.com
-          git add --force dist/Lob-API-bundled.yml
-          git commit -m "update bundled spec"
-          git push
+          git update-index -q --refresh
+          changes=$(git status --porcelain)
+          if [ ! -z ${changes} ]; then
+            git config user.name lobot
+            git config user.email lobot@lob.com
+            git add --force dist/Lob-API-bundled.yml
+            git commit -m "update bundled spec"
+            git push
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,11 +1,11 @@
-name: CD check
+name: CD_check
 
 on: push
 
 jobs:
   check:
     if: github.actor != 'lobot'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [How the spec is organized](#how-the-spec-is-organized)
   - [Bundled spec](#bundled-spec)
+- [Contributing / Workflow](#contributing--workflow)
 - [Style Guide and linting](#style-guide-and-linting)
 - [Future proofing](#future-proofing)
 - [Previewing the spec as docs (aka QAing your work)](#previewing-the-spec-as-docs-aka-qaing-your-work)
@@ -51,6 +52,19 @@ You can also generate a bundled version locally at any time using `make bundle`.
 The CLI tool used by `make bundle` can do much more than bundle a multiple file spec
 into a single file. It can convert specs between `YAML` and `JSON`, fully
 dereference a spec, and more.
+
+## Contributing / Workflow
+
+To contribute, whether adding / modifying an endpoint or working on the tooling, start by making
+a branch. (As we build out the full tooling in the roadmap, everything will key off of the branch
+name, although that is not currently relevant.)
+
+This project uses CI/CD; as you push your branch to github, github actions will run tests and, if
+those tests pass, build release artifacts (bundled spec, postman collection, ...) and push them
+to your branch on github under the `dist/` directory. Because the CI/CD cycle on github pushes
+additional commits to your branch, you will either need to pull those commits or force push (`git push -f`)
+when pushing additional work to the branch. Don't be afraid to force push: the actions build each
+artifact anew on each push.
 
 ## Style Guide and linting
 


### PR DESCRIPTION
Fix a problem with #31 
- when merging to main, the branch already has the bundled spec: the subsequent push fails because there are no changes
- in any case, no need to push when the bundled spec hasn't changed! Now checking to see if it has actually changed before staging, committing and pushing
- using `git status --porcelain` instead of plumbing commands because the check reports as a failure if any step does something which returns a non-zero exit code. Note: it might be possible to redirect the exit code to the void and survive, but that defeats the purpose of using a git plumbing command. Anyhoo... 