### PR TITLE
run contract tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,8 @@ jobs:
           file_glob: "./Lob-API-public.yml"
           repo_token: ${{ github.token }}
           event_name: ${{ github.event_name }}
+
+      - name: run contract tests
+        uses: ./actions/contract_tests
+        env:
+          LOB_API_TEST_TOKEN: ${{ secrets.LOB_API_TEST_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,6 +23,12 @@ jobs:
           repo_token: ${{ github.token }}
           event_name: ${{ github.event_name }}
 
+      - name: run contract tests
+        uses: ./actions/contract_tests
+        continue-on-error: true
+        env:
+          LOB_API_TEST_TOKEN: ${{ secrets.LOB_API_TEST_TOKEN }}
+
       - name: invoke build
         uses: benc-uk/workflow-dispatch@v1.1.0
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lob [OpenAPI v3](https://github.com/OAI/OpenAPI-Specification) Specification
+# ![CI](https://github.com/lob/lob-openapi/workflows/CI/badge.svg) ![CD](https://github.com/lob/lob-openapi/workflows/CD/badge.svg) Lob [OpenAPI v3](https://github.com/OAI/OpenAPI-Specification) Specification
 
 - [How the spec is organized](#how-the-spec-is-organized)
   - [Bundled spec](#bundled-spec)
@@ -118,7 +118,7 @@ We use [Prism](https://meta.stoplight.io/docs/prism/README.md) for contract test
 To add a test, look in the `tests/` directory for a file named for the resource with
 the endpoint in question.
 
-The contract tests are not yet in CI, so be sure to run the contract tests when reviewing PRs!
+The contract tests run on github whenever you push to github and/or open a pull request.
 
 During development of the spec for existing endpoints, you can run Prism as a [validation proxy](https://meta.stoplight.io/docs/prism/docs/getting-started/03-cli.md#proxy) by running `npm run proxy`.
 

--- a/actions/contract_tests/Dockerfile
+++ b/actions/contract_tests/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:14.15.4-alpine
+
+# Copy code file from action repository to "/" in the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Set code file to execute when container starts up.
+# Use a shell form of ENTRYPOINT to support variable
+# substitution of the args from action.yml.
+ENTRYPOINT ["/entrypoint.sh"]

--- a/actions/contract_tests/README.md
+++ b/actions/contract_tests/README.md
@@ -1,0 +1,39 @@
+# Contract Tests in CI
+
+This version of our contract tests in CI works as a private github action rather than as a public
+github action. Extracting it out of the spec repo into a public github action repo is a planned
+future task.
+
+## How to use
+
+1. Create a valid Lob API test token
+2. Add the test token as a repository secret in the repository in which you
+   intend to run this action.
+3. Include this action (the directory and all its files):
+
+    - action.yml
+    - Dockerfile_
+    - entrypoint.sh
+    - and the README.md
+
+   in a directory in your repo, e.g., `/actions/contract_tests`
+4. In your workflow, include a step that
+   uses the action. If you use `npm` and
+   `npm test` to run your tests, you can
+   use the defaults, like so:
+
+   ```yml
+   test:
+     runs-on: ubuntu-latest
+
+     steps:
+       - name: checkout
+         uses: actions/checkout@v2
+
+       - name: contract tests
+         uses: ./actions/contract_tests
+         env:
+           LOB_API_TEST_TOKEN: ${{ secrets.TEST_TOKEN_FROM_STEP_2 }}
+    ```
+
+You can configure the installation and/or test commands used. Look in `action.yml` for details.

--- a/actions/contract_tests/action.yml
+++ b/actions/contract_tests/action.yml
@@ -1,0 +1,21 @@
+name: Run contract tests in CI
+
+description: run contract tests using tape and Prism as a github action
+
+inputs:
+  installCommand:
+    description: npm or yarn command to use to install node modules
+    required: false
+    default: "NODE_ENV=development npm install --no-package-lock --ignore-scripts"
+
+  testCommand:
+    description: npm or yarn command to use to run tests
+    required: false
+    default: "npm test"
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.installCommand }}
+    - ${{ inputs.testCommand }}

--- a/actions/contract_tests/entrypoint.sh
+++ b/actions/contract_tests/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# fail with failing exit code (and therefore a failing check)
+# if any subcommand fails
+set -e
+
+sh -c "$1 && $2"


### PR DESCRIPTION
Run our contract tests in CI: https://lobsters.atlassian.net/browse/ENG-15379

I built this out as a private github action for now (it will live in each repo - see the `README.md` in `/actions/contract_tests` for more info). We can extract it out into a public github action at a later time.