### PR TITLE
add monitor job to gh actions

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,0 +1,18 @@
+name: Monitor API contracts
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: run contract tests
+        uses: ./actions/contract_tests
+        env:
+          LOB_API_TEST_TOKEN: ${{ secrets.LOB_API_TEST_TOKEN }}


### PR DESCRIPTION
https://lobsters.atlassian.net/browse/ENG-15426

Monitoring runs using the [latest commit on the default branch (in our case `main`).](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule) The documentation is profoundly unclear on the subject, but the workflow file has to be in the default branch for it to be triggered as well. See, for example: https://github.community/t/on-schedule-per-branch/17525. Even in that answer, the info is only implied.

Bottom line, gotta merge this to find out whether it works. :woman_facepalming: 