### PR TITLE
Update npm postman pkg name to openapi-to-postmanv2

### DIFF
--- a/scripts/postman.sh
+++ b/scripts/postman.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 make bundle
 
-npx openapi2postmanv2 --pretty --spec dist/Lob-API-public-bundled.yml --output dist/Lob-API-postman.txt
+npx openapi-to-postmanv2 --pretty --spec dist/Lob-API-public-bundled.yml --output dist/Lob-API-postman.txt


### PR DESCRIPTION
The old `make postman` command gave an error of:
```
...
npm ERR! 404  'openapi2postmanv2@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
...
make: *** [postman] Error 1
```

I think this is the package we want: https://www.npmjs.com/package/openapi-to-postmanv2