### PR TITLE
fix(per-goalie): runs tests for all command-line args

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -16,3 +16,5 @@ jobs:
         uses: ./actions/contract_tests
         env:
           LOB_API_TEST_TOKEN: ${{ secrets.LOB_API_TEST_TOKEN }}
+        with:
+          testCommand: "npm run pergoalie av pmapi billing"

--- a/actions/contract_tests/goalieruns.js
+++ b/actions/contract_tests/goalieruns.js
@@ -2,18 +2,19 @@ const pkg = require("../../package.json");
 const util = require("util");
 const exec = util.promisify(require("child_process").exec);
 
-// grab the tests to be run
-test_set = pkg.config.goaliemappings[process.argv[2]].resources;
-for (resource_name in test_set) {
-  test = test_set[resource_name];
-  test_command = 'multi-tape "' + test + '" | tap-spec';
-  exec(test_command, function (err, stdout, stderr) {
-    if (err) {
-      // actually: send this to the right slack channel
-      console.error(err);
-      console.log(err.code);
-      return;
-    }
-    console.log(stdout);
-  });
+for (let arg of process.argv.slice(2)) {
+  test_set = pkg.config.goaliemappings[arg].resources;
+  for (resource_name in test_set) {
+    test = test_set[resource_name];
+    test_command = 'multi-tape "' + test + '" | tap-spec';
+    exec(test_command, function (err, stdout, stderr) {
+      if (err) {
+        // actually: send this to the right slack channel
+        console.error(err);
+        console.log(err.code);
+        return;
+      }
+      console.log(stdout);
+    });
+  }
 }

--- a/dist/Lob-API-postman.json
+++ b/dist/Lob-API-postman.json
@@ -1,11 +1,11 @@
 {
     "item": [
         {
-            "id": "8068aa89-0c38-45e3-a46e-42ebda04423c",
+            "id": "bde15c9b-3d54-4f5f-8c80-ce4aa6016509",
             "name": "addresses",
             "item": [
                 {
-                    "id": "884d0b62-915a-427b-b202-301e92b66b4d",
+                    "id": "6f424746-f725-4200-a3e8-de6c4db09139",
                     "name": "List all addresses",
                     "request": {
                         "name": "List all addresses",
@@ -53,7 +53,7 @@
                     },
                     "response": [
                         {
-                            "id": "6f982492-7354-428d-96fd-b5cbe4681b9b",
+                            "id": "0ef71300-a171-4313-9318-b51f2fd0c3af",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -135,7 +135,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "29026440-344a-45b4-88ef-f13e27b9dfe5",
+                            "id": "ed4952d1-7916-4533-89d9-a84c0619b435",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -194,7 +194,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -202,7 +202,7 @@
                     "event": []
                 },
                 {
-                    "id": "38f8e79a-1c14-46d4-bb73-88aea7fff4ff",
+                    "id": "95477f17-78b5-40c1-8e9a-2201f4474c06",
                     "name": "Creates a new address object",
                     "request": {
                         "name": "Creates a new address object",
@@ -277,7 +277,7 @@
                     },
                     "response": [
                         {
-                            "id": "73e968c2-7a1a-448b-b33f-ea3e982a6aa1",
+                            "id": "ba8c5067-5de0-49d3-85e6-7d56f50f0a2e",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -389,7 +389,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "036ae9b0-8c99-47ad-aab3-bd235a079528",
+                            "id": "0d8bc658-bbbe-4bd1-99d0-cafc24f71794",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -478,7 +478,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -486,11 +486,11 @@
                     "event": []
                 },
                 {
-                    "id": "50704b95-880f-45e3-a22a-539705e6936d",
+                    "id": "bd700722-621c-4357-b965-a6c54f9e9d99",
                     "name": "{adr id}",
                     "item": [
                         {
-                            "id": "5f5e0af2-e9c0-4b8b-9bc6-ae85145e69fe",
+                            "id": "02362f94-8c91-4d08-a98e-8ecfd940ab4a",
                             "name": "Retrieve address with given id",
                             "request": {
                                 "name": "Retrieve address with given id",
@@ -522,7 +522,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "8238b02c-8eb2-451a-8bb2-a82b7b9dc5a0",
+                                    "id": "d95b61e3-72ca-4b50-b894-c422bdcc772a",
                                     "name": "Returns an address object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -580,12 +580,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"date_created\": \"2000-06-11T18:16:33.415Z\",\n \"date_modified\": \"1998-10-16T01:22:22.921Z\",\n \"object\": \"ut qui\",\n \"description\": \"<string>\",\n \"name\": \"<string>\",\n \"company\": \"<string>\",\n \"phone\": \"<string>\",\n \"email\": \"<string>\",\n \"address_country\": \"US\",\n \"send_date\": \"<dateTime>\",\n \"metadata\": {\n  \"type\": \"object\",\n  \"properties\": {\n   \"customer_id\": {\n    \"type\": \"string\",\n    \"example\": \"987654\"\n   },\n   \"campaign\": {\n    \"type\": \"string\",\n    \"example\": \"NEWYORK2015\"\n   }\n  }\n },\n \"recipient_moved\": false,\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"date_created\": \"1955-02-27T08:15:09.125Z\",\n \"date_modified\": \"1953-06-30T20:08:02.745Z\",\n \"object\": \"magna et amet aliqua\",\n \"description\": \"<string>\",\n \"name\": \"<string>\",\n \"company\": \"<string>\",\n \"phone\": \"<string>\",\n \"email\": \"<string>\",\n \"address_country\": \"US\",\n \"send_date\": \"<dateTime>\",\n \"metadata\": {\n  \"type\": \"object\",\n  \"properties\": {\n   \"customer_id\": {\n    \"type\": \"string\",\n    \"example\": \"987654\"\n   },\n   \"campaign\": {\n    \"type\": \"string\",\n    \"example\": \"NEWYORK2015\"\n   }\n  }\n },\n \"recipient_moved\": true,\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "b7948fe5-09d6-4333-af9a-cf7f15bfd392",
+                                    "id": "f66222f9-473f-4143-a575-ce6cec71f964",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -625,7 +625,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -633,7 +633,7 @@
                             "event": []
                         },
                         {
-                            "id": "03742f0f-8478-480b-9961-a577aad16a5b",
+                            "id": "a4528be3-dde6-4071-b729-b7aa9ee232ad",
                             "name": "Deletes address with given id",
                             "request": {
                                 "name": "Deletes address with given id",
@@ -665,7 +665,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b653f0d3-2652-44b8-b14d-639f52d7123e",
+                                    "id": "1405d2c6-b3ae-4c84-8849-1a230620491b",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -705,12 +705,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "8b66d496-49ec-4843-b01a-f3456afcb297",
+                                    "id": "490eb57a-be76-45b2-9f23-4d3f64e1ef80",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -750,7 +750,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -764,11 +764,11 @@
             "event": []
         },
         {
-            "id": "a174a2a0-5d0f-41b8-9b9f-51017dbd4021",
+            "id": "4c4de72a-f726-4d28-820f-d48e0bb07eb0",
             "name": "certificates",
             "item": [
                 {
-                    "id": "97154655-89e0-42a9-ac2e-0dae708f1b47",
+                    "id": "e27704d9-3d21-410c-a546-ad0edbbf3c3b",
                     "name": "List all certificates",
                     "request": {
                         "name": "List all certificates",
@@ -791,7 +791,7 @@
                     },
                     "response": [
                         {
-                            "id": "e08782c1-19e1-479f-a911-4a639d70c29a",
+                            "id": "5cc19916-1fd6-4a35-adad-5659d5bb707a",
                             "name": "List of all certificates. Will to add wording about plans for the future.",
                             "originalRequest": {
                                 "url": {
@@ -825,12 +825,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"mollit ut enim\",\n   \"date_created\": \"2013-02-28T02:01:12.753Z\",\n   \"date_modified\": \"2010-09-21T00:29:29.769Z\",\n   \"id\": \"cert_f09oHcVJDrJ\",\n   \"name\": \"non deserunt\",\n   \"object\": \"aliquip nulla adipisicing\",\n   \"description\": \"veniam ullamco\",\n   \"account_id\": \"iw523h38\",\n   \"deleted\": false,\n   \"date_deleted\": \"1984-09-01T17:45:33.562Z\"\n  },\n  {\n   \"cert\": \"veniam occaecat et\",\n   \"date_created\": \"2008-05-09T06:20:01.455Z\",\n   \"date_modified\": \"1964-06-25T11:03:13.947Z\",\n   \"id\": \"cert_gruK\",\n   \"name\": \"voluptate eiusmod aliquip officia laborum\",\n   \"object\": \"sint voluptate\",\n   \"description\": \"in\",\n   \"account_id\": \"o\",\n   \"deleted\": false,\n   \"date_deleted\": \"2010-12-11T15:41:41.427Z\"\n  }\n ],\n \"count\": 90105126,\n \"object\": \"aute reprehenderit laborum\"\n}",
+                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"sit occaecat esse do eiusmod\",\n   \"date_created\": \"1999-03-11T23:18:48.936Z\",\n   \"date_modified\": \"1954-02-23T10:21:23.805Z\",\n   \"id\": \"cert_G\",\n   \"name\": \"velit do esse\",\n   \"object\": \"Excepteur aliquip\",\n   \"description\": \"nisi et veniam\",\n   \"account_id\": \"8nEbTw\",\n   \"deleted\": true,\n   \"date_deleted\": \"1946-11-28T11:50:32.015Z\"\n  },\n  {\n   \"cert\": \"proident sed nulla dolor\",\n   \"date_created\": \"1956-03-25T10:21:09.537Z\",\n   \"date_modified\": \"1952-10-10T20:35:57.054Z\",\n   \"id\": \"cert_iV8brnuJ2\",\n   \"name\": \"qui\",\n   \"object\": \"sunt ut\",\n   \"description\": \"ad proident adipisicing non\",\n   \"account_id\": \"P22Dmz\",\n   \"deleted\": false,\n   \"date_deleted\": \"1961-05-06T09:52:32.359Z\"\n  }\n ],\n \"count\": 70604947,\n \"object\": \"deserunt dolore qui culpa\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "04f679d6-3b4f-4f5e-9121-81f30ce6a405",
+                            "id": "5d244156-9176-4cdb-90f0-f5501660e0dd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -864,7 +864,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -872,7 +872,7 @@
                     "event": []
                 },
                 {
-                    "id": "17f1c344-385e-48f1-92df-d6f1af3a5ec7",
+                    "id": "e005a6d6-342b-4f2f-9740-08e44bf6ca49",
                     "name": "Creates a new certificate object",
                     "request": {
                         "name": "Creates a new certificate object",
@@ -930,7 +930,7 @@
                     },
                     "response": [
                         {
-                            "id": "05a4353a-84b6-4feb-9bfe-613c9bb55c3f",
+                            "id": "be791352-cad5-4201-961e-0e129a27e4fa",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -1001,12 +1001,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"2011-09-06T11:51:07.593Z\",\n \"date_modified\": \"1993-08-24T09:35:38.791Z\",\n \"id\": \"cert_DRfrz\",\n \"name\": \"<string>\",\n \"object\": \"occaecat consequat ad deserunt\",\n \"description\": \"<string>\",\n \"account_id\": \"LI5bqFCV\",\n \"deleted\": true,\n \"date_deleted\": \"1972-04-08T23:54:15.946Z\"\n}",
+                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1947-03-26T03:25:32.130Z\",\n \"date_modified\": \"1991-03-25T19:32:46.644Z\",\n \"id\": \"cert_vJ1r5d6tCrY\",\n \"name\": \"<string>\",\n \"object\": \"deserunt Lorem ea dolor\",\n \"description\": \"<string>\",\n \"account_id\": \"ZgXhf5q8\",\n \"deleted\": true,\n \"date_deleted\": \"1979-12-23T02:37:45.149Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b544a417-c774-4761-aec2-88c3c5ad81a8",
+                            "id": "d196d549-82d0-4f81-a7a9-4760939c8168",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1077,7 +1077,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1085,11 +1085,11 @@
                     "event": []
                 },
                 {
-                    "id": "1395834d-199d-458c-8936-5594e324b6c3",
+                    "id": "73832fd9-fc4b-4abf-9b09-5ea882a2de55",
                     "name": "{id}",
                     "item": [
                         {
-                            "id": "44c125b7-f18f-483b-a72b-f6b352d60cc3",
+                            "id": "d563e780-f342-48ad-afde-ed1a18a1e519",
                             "name": "Retrieve certificate with given id",
                             "request": {
                                 "name": "Retrieve certificate with given id",
@@ -1110,7 +1110,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_nmDo3NkM",
+                                            "value": "cert_m1o6",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -1121,7 +1121,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c6cc8528-5115-4102-8548-f909d1b42cc7",
+                                    "id": "a761951a-2735-4fab-bae3-26c0a55fd189",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -1161,12 +1161,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"2011-09-06T11:51:07.593Z\",\n \"date_modified\": \"1993-08-24T09:35:38.791Z\",\n \"id\": \"cert_DRfrz\",\n \"name\": \"<string>\",\n \"object\": \"occaecat consequat ad deserunt\",\n \"description\": \"<string>\",\n \"account_id\": \"LI5bqFCV\",\n \"deleted\": true,\n \"date_deleted\": \"1972-04-08T23:54:15.946Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1947-03-26T03:25:32.130Z\",\n \"date_modified\": \"1991-03-25T19:32:46.644Z\",\n \"id\": \"cert_vJ1r5d6tCrY\",\n \"name\": \"<string>\",\n \"object\": \"deserunt Lorem ea dolor\",\n \"description\": \"<string>\",\n \"account_id\": \"ZgXhf5q8\",\n \"deleted\": true,\n \"date_deleted\": \"1979-12-23T02:37:45.149Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "2e2b6065-e4f0-4c83-98e6-74d2b1d19909",
+                                    "id": "f690b8ca-449e-4aab-a611-7deee9d1ba3e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1206,7 +1206,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -1214,7 +1214,7 @@
                             "event": []
                         },
                         {
-                            "id": "d8ecb136-f0b7-403e-bc70-bafdbe5b7174",
+                            "id": "87b061c4-a879-4d7a-840d-2843cd0730ee",
                             "name": "Update name and/or description of a certificate.",
                             "request": {
                                 "name": "Update name and/or description of a certificate.",
@@ -1235,7 +1235,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_nmDo3NkM",
+                                            "value": "cert_m1o6",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -1267,7 +1267,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "2302d7e9-40c1-4219-b658-6ae46934b703",
+                                    "id": "c1eedbe4-57f9-45f7-8169-bc7bccaa0fd1",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -1321,12 +1321,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"2011-09-06T11:51:07.593Z\",\n \"date_modified\": \"1993-08-24T09:35:38.791Z\",\n \"id\": \"cert_DRfrz\",\n \"name\": \"<string>\",\n \"object\": \"occaecat consequat ad deserunt\",\n \"description\": \"<string>\",\n \"account_id\": \"LI5bqFCV\",\n \"deleted\": true,\n \"date_deleted\": \"1972-04-08T23:54:15.946Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1947-03-26T03:25:32.130Z\",\n \"date_modified\": \"1991-03-25T19:32:46.644Z\",\n \"id\": \"cert_vJ1r5d6tCrY\",\n \"name\": \"<string>\",\n \"object\": \"deserunt Lorem ea dolor\",\n \"description\": \"<string>\",\n \"account_id\": \"ZgXhf5q8\",\n \"deleted\": true,\n \"date_deleted\": \"1979-12-23T02:37:45.149Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "485a5425-16e7-4108-8712-ee96b8381cd4",
+                                    "id": "e01b32d6-c3fb-47fc-8ce6-4610ef288ca4",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1380,7 +1380,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -1388,7 +1388,7 @@
                             "event": []
                         },
                         {
-                            "id": "56b66f39-d827-497c-8058-e5ce1fd7fc45",
+                            "id": "a667458f-51ad-4d37-9a2b-cd5b53e9bbc6",
                             "name": "Deletes certificate with given id",
                             "request": {
                                 "name": "Deletes certificate with given id",
@@ -1409,7 +1409,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_nmDo3NkM",
+                                            "value": "cert_m1o6",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -1420,7 +1420,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "cd307e85-558f-4819-b24c-8fb2c6d380c9",
+                                    "id": "b3123b00-3959-486a-a1eb-4a6ccdf66bca",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -1460,12 +1460,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f27402eb-a189-447f-9242-b4fa6ed89e94",
+                                    "id": "6dd1b1e6-5d01-43a6-8858-d3957e0f3612",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1505,7 +1505,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -1519,11 +1519,11 @@
             "event": []
         },
         {
-            "id": "8f3cd8c0-7df7-4d12-8f05-885627ec1960",
+            "id": "23f44e0a-8ea0-4874-b705-6b2580e500c8",
             "name": "letters",
             "item": [
                 {
-                    "id": "bfd1180c-7a4c-4809-8eb2-a926f67f1fc6",
+                    "id": "2e29d365-95b7-402e-8a75-76be6e4e85a8",
                     "name": "List all letters",
                     "request": {
                         "name": "List all letters",
@@ -1571,7 +1571,7 @@
                     },
                     "response": [
                         {
-                            "id": "a20e45ce-6497-400d-a6c7-08a122299769",
+                            "id": "74b2119b-1aac-45c1-ba81-399c2a9b2389",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -1653,7 +1653,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "70414a21-0c6a-4d15-8160-0f9c61ba20a1",
+                            "id": "10f46f1e-6f45-4126-a386-a02ad0707148",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1712,7 +1712,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1720,7 +1720,7 @@
                     "event": []
                 },
                 {
-                    "id": "66900a50-68ad-4c37-8f43-dc8d3a418ab9",
+                    "id": "c899ef44-8806-4919-9ef6-86a9e9939718",
                     "name": "Creates a new letter object",
                     "request": {
                         "name": "Creates a new letter object",
@@ -1815,7 +1815,7 @@
                     },
                     "response": [
                         {
-                            "id": "bf868671-6b21-470a-9d21-e952141bbf47",
+                            "id": "3640eec1-f4ac-48f2-92e7-9196bc6cea87",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -1947,7 +1947,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0b053c0c-9deb-4a16-9c0d-834943116a6f",
+                            "id": "ddfdf049-fdbd-4a7b-a337-5ce774712da0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2056,7 +2056,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2064,11 +2064,11 @@
                     "event": []
                 },
                 {
-                    "id": "2abe45cd-60c2-4dc0-bf2f-218b30b26714",
+                    "id": "279918c6-2c7d-485e-b530-d1d4e863dc41",
                     "name": "{ltr id}",
                     "item": [
                         {
-                            "id": "a066f375-5a48-4636-9ca2-c292525f420c",
+                            "id": "cc2e2c17-fcf6-4063-983e-f4ffb5d98347",
                             "name": "Retrieve letter with given id",
                             "request": {
                                 "name": "Retrieve letter with given id",
@@ -2100,7 +2100,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "14956fe5-0046-4bfe-b9c6-355774cb6c24",
+                                    "id": "df915f32-5ac9-4c51-a73d-46b9945e5abf",
                                     "name": "Returns a letter object",
                                     "originalRequest": {
                                         "url": {
@@ -2163,7 +2163,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "7c03d554-9b4d-4975-9357-b27eed213622",
+                                    "id": "941b2693-18be-49d6-9a7d-1b00781edb2a",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2203,7 +2203,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -2211,7 +2211,7 @@
                             "event": []
                         },
                         {
-                            "id": "d09548f5-712d-47d4-8e85-bed81c598e57",
+                            "id": "ecc65eff-e60c-4a7e-90ee-9517149fe34a",
                             "name": "Cancel a letter",
                             "request": {
                                 "name": "Cancel a letter",
@@ -2243,7 +2243,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d60a98c4-a0ab-491b-af4c-ba8b4e05c90c",
+                                    "id": "ac6639ac-d9ef-43e7-88dd-8789506b0e58",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -2283,12 +2283,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "85a0ea58-a397-41b7-909d-5f67e9b58c9f",
+                                    "id": "b14e0d07-42c9-4474-852a-29b07bc82d95",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2328,7 +2328,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -2342,11 +2342,11 @@
             "event": []
         },
         {
-            "id": "eb797e0a-450f-4640-a491-60cdde070f5f",
+            "id": "eafe9719-80b6-41fe-a458-d0b24e23623a",
             "name": "postcards",
             "item": [
                 {
-                    "id": "85dd07a4-da31-4bfa-9981-8f2228771c71",
+                    "id": "0d6a1ad8-eca5-4ea7-af5d-5e607fee4f6f",
                     "name": "List all postcards",
                     "request": {
                         "name": "List all postcards",
@@ -2394,7 +2394,7 @@
                     },
                     "response": [
                         {
-                            "id": "a34dfccc-6893-497e-9687-89fc8886018d",
+                            "id": "2d29513a-4186-467c-bb38-1e9ca47c9c33",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -2476,7 +2476,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "009ae833-752e-4776-8579-cde7d22ba213",
+                            "id": "6571e5f9-e7d8-4ae3-92ad-df3be8b14c32",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2535,7 +2535,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2543,7 +2543,7 @@
                     "event": []
                 },
                 {
-                    "id": "d0e31cc8-91c5-48f3-885b-6545e0c931a9",
+                    "id": "348c9494-cf25-4a6f-a6c7-89c2f11de843",
                     "name": "Creates a new postcard object",
                     "request": {
                         "name": "Creates a new postcard object",
@@ -2613,7 +2613,7 @@
                     },
                     "response": [
                         {
-                            "id": "6ac14f61-c253-4140-8f1c-2d02fc73cb24",
+                            "id": "a56f88b5-8398-4cfb-b9e8-1f3133f2c147",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -2720,7 +2720,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6ce1353f-f5bc-4105-8c5e-b5a03de0834e",
+                            "id": "e6188e93-4bf9-48fa-8f64-a8e6ed925f06",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2804,7 +2804,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2812,11 +2812,11 @@
                     "event": []
                 },
                 {
-                    "id": "8fef4ea4-3b21-4b67-8e35-0d575e6f4f1e",
+                    "id": "d11a9d1f-062b-492d-aa07-79d4a576585b",
                     "name": "{psc id}",
                     "item": [
                         {
-                            "id": "a7b687f3-7c71-4524-8d27-967a6441dc30",
+                            "id": "4ba4ff6e-e37b-46b1-b682-768f4da57fc4",
                             "name": "Retrieve postcard with given id",
                             "request": {
                                 "name": "Retrieve postcard with given id",
@@ -2848,7 +2848,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "437e93e7-96e2-4747-b4fa-778ca05fb1cd",
+                                    "id": "5baa7246-8742-485d-9e87-b1c5950a5fff",
                                     "name": "Returns a postcard object",
                                     "originalRequest": {
                                         "url": {
@@ -2911,7 +2911,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "9835cd77-1e6c-4a79-8121-56d68ec0d199",
+                                    "id": "6354c17c-a410-4c86-9981-fd61022fdd19",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2951,7 +2951,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -2959,7 +2959,7 @@
                             "event": []
                         },
                         {
-                            "id": "b11c08aa-154f-4f8a-8c4b-5b2a673fbbee",
+                            "id": "dc0fa42a-a34a-4491-b77b-85e9365110f8",
                             "name": "Cancels postcard with given id",
                             "request": {
                                 "name": "Cancels postcard with given id",
@@ -2991,7 +2991,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "f5640691-f1a8-4aba-9dd2-172aea7e8855",
+                                    "id": "605f7c85-ec4e-4aa7-bc1e-518e83bd2a8e",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -3031,12 +3031,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "70f82036-b58c-40d4-a859-c57fccbc50c9",
+                                    "id": "d9003019-fb08-4b3d-b004-d69ffcd48ece",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3076,7 +3076,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -3090,11 +3090,11 @@
             "event": []
         },
         {
-            "id": "43afffaa-f9e3-4e0d-9cd5-89a4210e190b",
+            "id": "eb6ae857-ebb8-40e4-8ab6-198618740394",
             "name": "templates",
             "item": [
                 {
-                    "id": "ee75a340-88e9-4d5c-96a8-8a0ba77d3abc",
+                    "id": "6f88de18-2194-42aa-a24f-cabf180c7a5a",
                     "name": "List all templates",
                     "request": {
                         "name": "List all templates",
@@ -3142,7 +3142,7 @@
                     },
                     "response": [
                         {
-                            "id": "d124bbf0-4623-4b45-ac02-9f7acf3a9f4d",
+                            "id": "3963d798-3603-449e-bd38-09f1190461bd",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3224,7 +3224,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "20bbdc1d-4df1-4776-be4a-860d02e9be31",
+                            "id": "705e3615-afec-4608-94de-c8bf533f2a88",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3283,7 +3283,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3291,7 +3291,7 @@
                     "event": []
                 },
                 {
-                    "id": "21005687-6dac-4a00-87c3-f41501bdc21a",
+                    "id": "ba84ab9c-19f3-46cb-9d6f-f723fcb6909d",
                     "name": "Creates a new template object",
                     "request": {
                         "name": "Creates a new template object",
@@ -3342,7 +3342,7 @@
                     },
                     "response": [
                         {
-                            "id": "4337443e-fa0b-4ae0-add2-428f1d68ef49",
+                            "id": "ba79e6d0-11c2-4e09-a575-ee1c869e25bb",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -3433,7 +3433,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ac7077c2-a6a9-4c49-8635-9cf1510d304d",
+                            "id": "09509c5c-048b-4aa8-aca9-f60468105178",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3501,7 +3501,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3509,11 +3509,11 @@
                     "event": []
                 },
                 {
-                    "id": "b6f465f5-208d-4bb6-96c8-3295948481d5",
+                    "id": "8682ea0b-2fb2-496f-a438-0f116febd800",
                     "name": "{tmpl id}",
                     "item": [
                         {
-                            "id": "94bab387-7ad9-4c5a-9b91-1f3127429665",
+                            "id": "7b7ed1ad-97c6-464a-9312-92bed73d44e5",
                             "name": "Retrieve template with given id",
                             "request": {
                                 "name": "Retrieve template with given id",
@@ -3545,7 +3545,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "a1ca54cf-7ab7-448b-b413-67e6ef680935",
+                                    "id": "e51ec2d9-5ef0-4a1d-ad7e-f8e0e0a0689b",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -3608,7 +3608,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c9901e5a-11e2-47eb-b74d-be8935d2d1ab",
+                                    "id": "b11283e2-8241-4bb5-8054-54c65b6efe66",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3648,7 +3648,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -3656,7 +3656,7 @@
                             "event": []
                         },
                         {
-                            "id": "a9a29960-5551-46e8-8b44-70e1e3e2677f",
+                            "id": "6e0fd31d-951a-4b6e-9f2f-ea927c47acef",
                             "name": "Update description and/or published version of a template.",
                             "request": {
                                 "name": "Update description and/or published version of a template.",
@@ -3715,7 +3715,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "18625264-a4e1-4ecc-b67a-f020cebfffb7",
+                                    "id": "43418e74-973b-47ae-ba29-9cae56da9595",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -3798,7 +3798,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "0df004e6-c519-447c-ad7d-f4eccca2d8ee",
+                                    "id": "ddc225a5-e8ff-4915-8fe8-6c0f0ab55218",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3858,7 +3858,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -3866,7 +3866,7 @@
                             "event": []
                         },
                         {
-                            "id": "fe481d85-3d8e-47e0-bd31-bccd23ea9ec7",
+                            "id": "7b83d733-ebe3-4af6-bcdd-86577c51b96f",
                             "name": "Deletes template with given id",
                             "request": {
                                 "name": "Deletes template with given id",
@@ -3898,7 +3898,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c1ec79f1-12e4-46f7-9d89-c75999b42edc",
+                                    "id": "d360057c-71b1-4b48-b755-dbc914aaaf73",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -3938,12 +3938,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "dedc01cd-08ee-40e0-9d21-3964013c465b",
+                                    "id": "7e7fc34e-17e9-4d0c-87a0-a946627b5b46",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3983,7 +3983,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -3991,11 +3991,11 @@
                             "event": []
                         },
                         {
-                            "id": "9b3c2207-e992-4343-9dbf-577ee916c4c1",
+                            "id": "ff85cec4-0619-44a3-a823-e9eb0dea9f57",
                             "name": "versions",
                             "item": [
                                 {
-                                    "id": "8009baec-e03a-4002-9cd2-dabb6008f77a",
+                                    "id": "b73b56a7-8456-4263-abd8-fc8f49c9ba28",
                                     "name": "List all template_versions",
                                     "request": {
                                         "name": "List all template_versions",
@@ -4053,7 +4053,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "45232aec-a622-424b-bddd-71100392d806",
+                                            "id": "80d40654-b44d-4a47-b993-45736dc033b4",
                                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                                             "originalRequest": {
                                                 "url": {
@@ -4134,7 +4134,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "69f6072f-0d5f-4d2d-8c6a-4d1605905f57",
+                                            "id": "52be3901-242f-4791-9206-7fa3eef70ac6",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -4192,7 +4192,7 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         }
@@ -4200,7 +4200,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "fc69e603-aa86-4252-871d-98b7b360d224",
+                                    "id": "b4166490-87ce-4031-8c14-77074befc17f",
                                     "name": "Creates a new template_version object",
                                     "request": {
                                         "name": "Creates a new template_version object",
@@ -4261,7 +4261,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "4ef8f155-eb6b-4fb5-b138-1e786aa3d514",
+                                            "id": "5ec55f76-9066-4271-a247-488b0cfbf0c7",
                                             "name": "Returns the template version with the given template and version ids.",
                                             "originalRequest": {
                                                 "url": {
@@ -4349,7 +4349,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "ba94a9e7-8757-4c85-b0d8-8a513df926bb",
+                                            "id": "9cb7824b-3063-4146-a3a1-ba32b68e2dbf",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -4414,7 +4414,7 @@
                                                     "value": "application/json"
                                                 }
                                             ],
-                                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                            "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         }
@@ -4422,11 +4422,11 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "2449e3a1-062b-437b-a498-da42f326b9cf",
+                                    "id": "808797b6-d40e-4b7a-8866-11289ff700e3",
                                     "name": "{vrsn id}",
                                     "item": [
                                         {
-                                            "id": "a2c1f445-090d-4a49-a386-200163796ee8",
+                                            "id": "e4d94724-3b06-4f71-890d-aa0aab3a88f6",
                                             "name": "Retrieve template version with given template and version ids.",
                                             "request": {
                                                 "name": "Retrieve template version with given template and version ids.",
@@ -4467,7 +4467,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "99a30809-f49f-4568-9ea8-5930f9f7431d",
+                                                    "id": "d24e65c3-b63e-4af1-bc55-b08dcf9b30c2",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -4536,7 +4536,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "ac211adb-53e1-4fb0-8089-ec94e94e6545",
+                                                    "id": "19d1cf81-2c18-4b6a-9efd-c8858cba5064",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -4582,7 +4582,7 @@
                                                             "value": "application/json"
                                                         }
                                                     ],
-                                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                                     "cookie": [],
                                                     "_postman_previewlanguage": "json"
                                                 }
@@ -4590,7 +4590,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "e1da80e2-57ff-4ea3-b4fa-4c0d8e4f9231",
+                                            "id": "3eb5413d-addc-427c-a030-9652e97f7361",
                                             "name": "Updates the template version with given template and version ids.",
                                             "request": {
                                                 "name": "Updates the template version with given template and version ids.",
@@ -4653,7 +4653,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "1d0a785b-752d-4d1c-8db2-e9d1406054cd",
+                                                    "id": "37c6a9c5-0ad3-428e-a528-228e903d7bf6",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -4737,7 +4737,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "17d56ebc-403c-4f33-9383-e4f859fc9891",
+                                                    "id": "8e06ea82-7210-4bf8-aad6-2020dc2dcfcd",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -4798,7 +4798,7 @@
                                                             "value": "application/json"
                                                         }
                                                     ],
-                                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                                     "cookie": [],
                                                     "_postman_previewlanguage": "json"
                                                 }
@@ -4806,7 +4806,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "1f11a2e7-72fa-4caf-a459-6d48313a8f0f",
+                                            "id": "48b84d2e-3b14-4d27-9cc5-769c14e16f93",
                                             "name": "Deletes the template version with given template and version ids if possible.",
                                             "request": {
                                                 "name": "Deletes the template version with given template and version ids if possible.",
@@ -4847,7 +4847,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "3b864d17-9a24-49e2-862c-2f7c99c090ed",
+                                                    "id": "d797cdbd-f7c4-41aa-8513-4b4934dc9851",
                                                     "name": "Returns true if the delete was successful",
                                                     "originalRequest": {
                                                         "url": {
@@ -4893,12 +4893,12 @@
                                                             "value": "application/json"
                                                         }
                                                     ],
-                                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                                     "cookie": [],
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "c9a58d47-4791-4442-b106-8ee958fd1592",
+                                                    "id": "72945e26-9f19-4d3a-a817-a5904ca2e198",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -4944,7 +4944,7 @@
                                                             "value": "application/json"
                                                         }
                                                     ],
-                                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                                     "cookie": [],
                                                     "_postman_previewlanguage": "json"
                                                 }
@@ -4958,7 +4958,7 @@
                             "event": []
                         },
                         {
-                            "id": "fbfbc533-dbe3-478d-8217-6cc38b6dcd46",
+                            "id": "3c183f3c-2153-4229-9e92-d89e5739f4ac",
                             "name": "Compile the template into html",
                             "request": {
                                 "name": "Compile the template into html",
@@ -5004,7 +5004,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "67b0215d-9ab4-4e42-9388-bd36709430d1",
+                                    "id": "41a868ef-e579-4279-8626-716145b86ea4",
                                     "name": "Returns the compiled html",
                                     "originalRequest": {
                                         "url": {
@@ -5059,7 +5059,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "2bbef669-2a0c-47a0-9da9-607084e7d77a",
+                                    "id": "f9599628-62ac-45d4-aca1-f4a1f336ec13",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5109,7 +5109,7 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 }
@@ -5123,7 +5123,7 @@
             "event": []
         },
         {
-            "id": "7f20a77a-d6a6-4042-9282-678224734ae1",
+            "id": "8b08dc9e-5f42-450f-8e4a-6e0376b69e8d",
             "name": "Verify a US or US territory address with a live API key.",
             "request": {
                 "name": "Verify a US or US territory address with a live API key.",
@@ -5156,7 +5156,7 @@
             },
             "response": [
                 {
-                    "id": "9b574265-17cf-412e-917c-f61f2df51164",
+                    "id": "9bdcf107-0d12-497e-81d4-ac894c4776d7",
                     "name": "Returns a US verification object.",
                     "originalRequest": {
                         "url": {
@@ -5211,12 +5211,12 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"recipient\": \"Excepteur non ut proident\",\n \"primary_line\": \"aute tempor dolor nostrud nisi\",\n \"secondary_line\": \"dolore\",\n \"urbanization\": \"velit dolore fugiat est\",\n \"last_line\": \"SAN FRANCISCO CA 94107\",\n \"deliverability\": \"deliverable\",\n \"components\": {\n  \"primary_number\": \"185\",\n  \"street_predirection\": \"N\",\n  \"street_name\": \"BERRY\",\n  \"street_suffix\": \"ST\",\n  \"street_postdirection\": \"N\",\n  \"secondary_designator\": \"STE\",\n  \"secondary_number\": \"6100\",\n  \"pmb_designator\": \"\",\n  \"pmb_number\": \"\",\n  \"extra_secondary_designator\": \"\",\n  \"extra_secondary_number\": \"\",\n  \"city\": \"ea est quis\",\n  \"state\": \"es\",\n  \"zip_code\": \"in aliquip consequat\",\n  \"zip_code_plus_4\": \"1728\",\n  \"zip_code_type\": \"po_box\",\n  \"delivery_point_barcode\": \"941071728506\",\n  \"address_type\": \"commercial\",\n  \"record_type\": \"highrise\",\n  \"default_building_address\": false,\n  \"county\": \"nulla pa\",\n  \"county_fips\": \"77377\",\n  \"carrier_route\": \"C001\",\n  \"carrier_route_type\": \"city_delivery\",\n  \"latitude\": \"37.77597542841264\",\n  \"longitude\": \"-122.3929557343685\",\n  \"object\": \"cupidatat in reprehenderit exercitation\"\n },\n \"deliverability_analysis\": {\n  \"dpv_confirmation\": \"Y\",\n  \"dpv_cmra\": \"N\",\n  \"dpv_vacant\": \"N\",\n  \"dpv_active\": \"Y\",\n  \"dpv_footnotes\": [\n   \"AA\",\n   \"BB\"\n  ],\n  \"ews_match\": false,\n  \"lacs_indicator\": \"\",\n  \"lacs_return_code\": \"\",\n  \"suite_return_code\": \"\",\n  \"object\": \"commodo aliquip in\"\n },\n \"lob_confidence_score\": {\n  \"score\": null,\n  \"level\": \"high\",\n  \"object\": \"velit commodo la\"\n },\n \"object\": \"voluptate\"\n}",
+                    "body": "{\n \"recipient\": \"i\",\n \"primary_line\": \"Lorem dolor ea\",\n \"secondary_line\": \"dolore dolor nisi\",\n \"urbanization\": \"labore id cillu\",\n \"last_line\": \"SAN FRANCISCO CA 94107\",\n \"deliverability\": \"deliverable\",\n \"components\": {\n  \"primary_number\": \"185\",\n  \"street_predirection\": \"N\",\n  \"street_name\": \"BERRY\",\n  \"street_suffix\": \"ST\",\n  \"street_postdirection\": \"N\",\n  \"secondary_designator\": \"STE\",\n  \"secondary_number\": \"6100\",\n  \"pmb_designator\": \"\",\n  \"pmb_number\": \"\",\n  \"extra_secondary_designator\": \"\",\n  \"extra_secondary_number\": \"\",\n  \"city\": \"do irure consequat est anim\",\n  \"state\": \"\",\n  \"zip_code\": \"irure aliquip amet anim\",\n  \"zip_code_plus_4\": \"1728\",\n  \"zip_code_type\": \"standard\",\n  \"delivery_point_barcode\": \"941071728506\",\n  \"address_type\": \"commercial\",\n  \"record_type\": \"highrise\",\n  \"default_building_address\": false,\n  \"county\": \"irure sed\",\n  \"county_fips\": \"61339\",\n  \"carrier_route\": \"C001\",\n  \"carrier_route_type\": \"city_delivery\",\n  \"latitude\": \"37.77597542841264\",\n  \"longitude\": \"-122.3929557343685\",\n  \"object\": \"m\"\n },\n \"deliverability_analysis\": {\n  \"dpv_confirmation\": \"Y\",\n  \"dpv_cmra\": \"N\",\n  \"dpv_vacant\": \"N\",\n  \"dpv_active\": \"Y\",\n  \"dpv_footnotes\": [\n   \"AA\",\n   \"BB\"\n  ],\n  \"ews_match\": false,\n  \"lacs_indicator\": \"\",\n  \"lacs_return_code\": \"\",\n  \"suite_return_code\": \"\",\n  \"object\": \"minim ullamco\"\n },\n \"lob_confidence_score\": {\n  \"score\": null,\n  \"level\": \"high\",\n  \"object\": \"qui in voluptate\"\n },\n \"object\": \"conse\"\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "49cfa2c9-a218-4feb-83a6-6b657944c9e2",
+                    "id": "96252d01-174f-430f-a74f-8d3e058b80fc",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -5253,7 +5253,7 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 }
@@ -5261,7 +5261,7 @@
             "event": []
         },
         {
-            "id": "b61f5aad-dadc-4747-bbc2-e31f6ebc241f",
+            "id": "bb946d34-8c1c-4182-b221-c366e64406a2",
             "name": "Looks up information pertaining to a given ZIP code",
             "request": {
                 "name": "Looks up information pertaining to a given ZIP code",
@@ -5301,7 +5301,7 @@
             },
             "response": [
                 {
-                    "id": "c4d0f8db-42b4-46c3-aa4b-4da320f30bf6",
+                    "id": "03b3a62f-fd9a-4d63-a1d4-1e953f65bde8",
                     "name": "Returns a zip lookup object if a valid zip was provided.",
                     "originalRequest": {
                         "url": {
@@ -5366,12 +5366,12 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"et consectetur\",\n   \"state\": \"d\",\n   \"county\": \"sed nulla\",\n   \"county_fips\": \"75948\",\n   \"preferred\": true,\n   \"object\": \"culpa id\"\n  },\n  {\n   \"city\": \"nulla ipsum id\",\n   \"state\": \"d\",\n   \"county\": \"pariatur do\",\n   \"county_fips\": \"28638\",\n   \"preferred\": true,\n   \"object\": \"esse non\"\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"ad amet eiusmod\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"\"\n}",
+                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"c\",\n   \"state\": \"\",\n   \"county\": \"Excepteur sunt ullamco sed ipsum\",\n   \"county_fips\": \"42135\",\n   \"preferred\": true,\n   \"object\": \"id Lorem dolor\"\n  },\n  {\n   \"city\": \"proident ut enim nisi ut\",\n   \"state\": \"i\",\n   \"county\": \"dolor deserunt\",\n   \"county_fips\": \"40618\",\n   \"preferred\": true,\n   \"object\": \"pariatur voluptate\"\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"dolore sint Ut sunt aute\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"po_box\"\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "1e8f3d4a-e5a8-46ab-b327-2a92e8d2ffe3",
+                    "id": "1567f4c8-2b88-47e1-adfa-b1a5b0f8df84",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -5418,7 +5418,7 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 429\n}",
+                    "body": "{\n \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n \"status_code\": 500\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 }
@@ -5448,7 +5448,7 @@
         ]
     },
     "info": {
-        "_postman_id": "18be6b9c-964a-4f64-8db6-349f8f7e15b5",
+        "_postman_id": "bc08bd11-da72-41c2-8041-3be9aaec5739",
         "name": "Lob API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
## What

Allows you to input more than one team when running the tests with the `pergoalie` script.

Previous: `npm run pergoalie -- av`
Now: `npm run pergoalie -- av pmapi billing`

## Why

Innit cool?