### PR TITLE
Add slack alerts

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           LOB_API_TEST_TOKEN: ${{ secrets.LOB_API_TEST_TOKEN }}
           LOB_API_LIVE_TOKEN: ${{ secrets.LOB_API_LIVE_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         with:
           testCommand: "npm run pergoalie av"
 
@@ -31,6 +32,7 @@ jobs:
         uses: ./actions/contract_tests
         env:
           LOB_API_TEST_TOKEN: ${{ secrets.LOB_API_TEST_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         with:
           testCommand: "npm run pergoalie pmApi"
 
@@ -45,5 +47,6 @@ jobs:
         uses: ./actions/contract_tests
         env:
           LOB_API_TEST_TOKEN: ${{ secrets.LOB_API_TEST_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         with:
           testCommand: "npm run pergoalie billing"

--- a/actions/contract_tests/goalieruns.js
+++ b/actions/contract_tests/goalieruns.js
@@ -42,7 +42,7 @@ module.exports.runTests = async function runTests() {
                 stdout.indexOf("      at:")
               );
               const block = [
-                `_FAILED TEST_:      ${testMessage}`,
+                `_FAILED CONTRACT TEST_:      ${testMessage}`,
                 `_EXPECTED_:  ${expectedCode}`,
                 `_ACTUAL_:      ${actualCode}`,
               ];

--- a/actions/contract_tests/goalieruns.js
+++ b/actions/contract_tests/goalieruns.js
@@ -1,19 +1,68 @@
+const Joi = require("joi");
 const pkg = require("../../package.json");
 const util = require("util");
 const exec = util.promisify(require("child_process").exec);
+const { WebClient } = require("@slack/web-api");
 
-for (let arg of process.argv.slice(2)) {
-  test_set = pkg.config.goalieMappings[arg].resources;
-  for (resource_name in test_set) {
-    test = test_set[resource_name];
-    test_command = 'multi-tape "' + test + '" | tap-spec';
-    exec(test_command, function (err, stdout, stderr) {
-      if (err) {
-        // actually: send this to the right slack channel
-        console.error(err);
-        return err.code;
+web = new WebClient(process.env.SLACK_TOKEN);
+
+module.exports.runTests = async function runTests() {
+  const validator = Joi.string()
+    .regex(/^[a-zA-Z]*$/)
+    .required();
+
+  for (let arg of process.argv.slice(2)) {
+    try {
+      validated_arg = await Joi.compile(validator).validateAsync(arg);
+      test_set = pkg.config.goalieMappings[validated_arg].resources;
+      for (resource_name in test_set) {
+        test = test_set[resource_name];
+        test_command = 'multi-tape "' + test + '" | tap-spec';
+        exec(test_command, async function (err, stdout, stderr) {
+          if (err) {
+            try {
+              // send this to the right slack channel
+              // the start and end indices, as well as the length, are constant because the stacktrace always
+              // includes the same spots in the tape module (only the failing test itself may change)
+              const startIndex = stdout.indexOf(
+                "at Test.bound [as equal] (/github/workspace/node_modules/tape/lib/test.js:91:32)"
+              );
+              const endIndex = stdout.indexOf(
+                "at processTicksAndRejections (internal/process/task_queues.js:93:5)"
+              );
+              const len = "at Test.bound [as equal] (/github/workspace/node_modules/tape/lib/test.js:91:32)"
+                .length;
+              const testMessage = stdout.slice(startIndex + len, endIndex);
+              const expectedCode = stdout.slice(
+                stdout.indexOf("expected: ") + 10,
+                stdout.indexOf("      actual:")
+              );
+              const actualCode = stdout.slice(
+                stdout.indexOf("actual:   ") + 10,
+                stdout.indexOf("      at:")
+              );
+              const block = [
+                `_FAILED TEST_:      ${testMessage}`,
+                `_EXPECTED_:  ${expectedCode}`,
+                `_ACTUAL_:      ${actualCode}`,
+              ];
+              const result = await web.chat.postMessage({
+                channel: pkg.config.goalieMappings[validated_arg].slackChannel,
+                text: `:sadpanda: ${block.join("\n")}`,
+              });
+            } catch (error) {
+              console.error(error);
+              return error.code;
+            }
+          }
+          console.log(stdout);
+        });
       }
-      console.log(stdout);
-    });
+    } catch (joiError) {
+      console.error(JSON.stringify(joiError, null, 2));
+      return joiError.code;
+    }
   }
-}
+};
+
+this.runTests();

--- a/dist/Lob-API-postman.json
+++ b/dist/Lob-API-postman.json
@@ -1,11 +1,11 @@
 {
     "item": [
         {
-            "id": "a97bcd50-f4ff-4c97-a35c-9d854c9b96a8",
+            "id": "f575f092-a7ac-4b19-9f41-2f6c50900b5f",
             "name": "addresses",
             "item": [
                 {
-                    "id": "9db340af-f12a-45ad-97b4-eb4d452ec42e",
+                    "id": "e8f75b6f-4790-459c-a187-17af510f74ca",
                     "name": "List all addresses",
                     "request": {
                         "name": "List all addresses",
@@ -53,7 +53,7 @@
                     },
                     "response": [
                         {
-                            "id": "ac586621-005c-467d-80a1-20711577f589",
+                            "id": "449c5974-e1ea-4957-ac3a-9aa30c7c9a39",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -117,7 +117,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "66d3fe43-7dc7-4a0a-ab4a-8cfe811375b5",
+                            "id": "c9105749-2bdf-47bb-ad74-b4a4d2385d7f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -184,7 +184,7 @@
                     "event": []
                 },
                 {
-                    "id": "983266f5-91ac-40d0-b324-b22eadd2dc16",
+                    "id": "9db4f9ca-d37e-4a47-933f-3861a6f71358",
                     "name": "Creates a new address object",
                     "request": {
                         "name": "Creates a new address object",
@@ -254,7 +254,7 @@
                     },
                     "response": [
                         {
-                            "id": "491cf6b6-0e01-4c69-be1d-dbea2960206a",
+                            "id": "e3b20e2d-7ea5-4a0c-b4b2-1f236c33e4c1",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -351,7 +351,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a3daf16f-61ec-4ccd-aca4-aa99a0349e60",
+                            "id": "42f25ccf-6ef2-4765-991a-4d4a81ca14ad",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -433,11 +433,11 @@
                     "event": []
                 },
                 {
-                    "id": "fcdb092a-644d-43ae-9e5c-a5493b7875b4",
+                    "id": "2442bd5b-7d4f-4bdd-95a1-68aeb82ec641",
                     "name": "{adr id}",
                     "item": [
                         {
-                            "id": "ddc10242-011d-487e-8603-db72bacf5ff7",
+                            "id": "91daa8d3-0b04-408b-9127-03e0d114da81",
                             "name": "Retrieve address with given id",
                             "request": {
                                 "name": "Retrieve address with given id",
@@ -469,7 +469,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "e32c9f88-eb79-4c20-83d8-c634f03fa00b",
+                                    "id": "dac0543e-e5ec-4f00-b90f-257396454bc1",
                                     "name": "Returns an address object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -527,12 +527,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"2017-02-06T09:21:36.907Z\",\n \"date_modified\": \"1957-10-19T11:34:55.092Z\",\n \"id\": \"<string>\",\n \"object\": \"dolor laboris ex id\",\n \"address_line2\": \"<string>\",\n \"deleted\": true,\n \"recipient_moved\": false,\n \"address_country\": \"UNITED STATES\"\n}",
+                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"1986-12-09T22:53:39.564Z\",\n \"date_modified\": \"1982-02-23T02:07:03.000Z\",\n \"id\": \"<string>\",\n \"object\": \"laboris aliquip culpa anim dolore\",\n \"address_line2\": \"<string>\",\n \"deleted\": false,\n \"recipient_moved\": true,\n \"address_country\": \"UNITED STATES\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c5834bac-cecf-4ae7-8cff-94680aa80f73",
+                                    "id": "26f0aff6-a5e1-49c5-978f-8a4318f95731",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -580,7 +580,7 @@
                             "event": []
                         },
                         {
-                            "id": "2c8fe084-b0c8-49ef-8f7c-f20c94adbdb6",
+                            "id": "f2f05801-3e5d-4e8d-af23-9cef827773e8",
                             "name": "Deletes address with given id",
                             "request": {
                                 "name": "Deletes address with given id",
@@ -612,7 +612,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "540af8cc-2923-4b41-90e7-2c092f330466",
+                                    "id": "74426b92-4f7d-4811-8530-0cdabf65fceb",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -657,7 +657,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "e1f4c769-a785-4e2e-a0dd-5331839a3372",
+                                    "id": "d5f974d9-8e57-4355-b9d3-505e3df74bc0",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -711,11 +711,11 @@
             "event": []
         },
         {
-            "id": "1e755efa-b539-43cd-bbe5-6435fc0400c1",
+            "id": "659ea6d3-2f6b-4869-829d-5b6f2684b986",
             "name": "bank accounts",
             "item": [
                 {
-                    "id": "dacd1257-1ae1-4c7b-9575-6903fb0ecf6c",
+                    "id": "a16106f5-1e6c-4ea0-9ba9-4c8ddf86b7b8",
                     "name": "List all bank_accounts",
                     "request": {
                         "name": "List all bank_accounts",
@@ -763,7 +763,7 @@
                     },
                     "response": [
                         {
-                            "id": "019e8ee7-7c53-4b32-8856-5fc1646ad07c",
+                            "id": "359214c5-3579-4e1e-bb7c-4a4f89a62d8e",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -827,7 +827,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ee2451e8-93a9-4e45-98cc-ce458665a0da",
+                            "id": "939dd86a-0e4c-4acc-a906-26b7a1d85b2a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -894,7 +894,7 @@
                     "event": []
                 },
                 {
-                    "id": "de5ab71b-875a-449f-8c7b-00b7059fe7e8",
+                    "id": "dc4298ef-5d7e-433c-8f51-efc8261293ba",
                     "name": "Creates a new bank_account",
                     "request": {
                         "name": "Creates a new bank_account",
@@ -969,7 +969,7 @@
                     },
                     "response": [
                         {
-                            "id": "53909500-0688-4f89-83e3-dec13cc8818b",
+                            "id": "4bbc311c-dae4-4aad-882d-ce250d4dc7e3",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1081,7 +1081,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a0bf05b3-83da-4648-b3bf-ea13750e809f",
+                            "id": "964ecff2-f536-45a8-b6c3-287be91aed18",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1178,11 +1178,11 @@
                     "event": []
                 },
                 {
-                    "id": "80eb9729-7f92-4d1f-92b7-5fd492e066ca",
+                    "id": "3eba1581-26e9-40c4-ab94-7908b7cc9d6d",
                     "name": "{bank id}",
                     "item": [
                         {
-                            "id": "660b32d4-8239-40a8-a78e-bca010739693",
+                            "id": "98affbf1-1dde-4c33-814f-dab671bf177a",
                             "name": "Retrieve bank_account with given id",
                             "request": {
                                 "name": "Retrieve bank_account with given id",
@@ -1214,7 +1214,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "896d7828-7dd3-4456-aa88-83a4c80f7ef4",
+                                    "id": "fdc963d6-2680-4f5b-ba91-80f8d640e5c1",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1277,7 +1277,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "bc82a0c6-a3f3-4078-9933-ffc1c13a12a4",
+                                    "id": "a3cda694-421e-4575-bc06-5f8c36272e73",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1325,7 +1325,7 @@
                             "event": []
                         },
                         {
-                            "id": "553e5366-9f4c-49b5-8d4d-64afad0be5fc",
+                            "id": "2a63667b-5a7e-44b7-ab90-ccbd0b74ec56",
                             "name": "Delete a bank_account",
                             "request": {
                                 "name": "Delete a bank_account",
@@ -1357,7 +1357,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "ed9661ea-bf0d-4721-b1bd-f794b3b9063c",
+                                    "id": "ed4c30e2-a603-41cc-a256-307620e04437",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -1402,7 +1402,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "68f053a3-ad10-4ee2-bef1-ee828ca6300e",
+                                    "id": "74008b08-1f74-41bf-aea4-a85dda48acf7",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1450,7 +1450,7 @@
                             "event": []
                         },
                         {
-                            "id": "d07340d8-b606-4c25-b350-d1afe65a2761",
+                            "id": "24146b73-b08f-46f0-b288-73d8a98d82af",
                             "name": "Verify a bank account",
                             "request": {
                                 "name": "Verify a bank account",
@@ -1512,7 +1512,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "469b9786-37de-4a71-b964-2787d3d9018c",
+                                    "id": "2ca9c6f1-a41e-496f-a813-e8b74a234d5c",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1604,7 +1604,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "3fe3b673-9a44-4259-b9b5-e5a5aadc730b",
+                                    "id": "e703be4c-240f-4f6b-a18d-e2cdf500e4ac",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1687,11 +1687,11 @@
             "event": []
         },
         {
-            "id": "dd5b250b-0c29-43c6-930b-c3acaaf5a002",
+            "id": "acdede9c-e595-44db-bb3a-4d80af96cef4",
             "name": "certificates",
             "item": [
                 {
-                    "id": "a72426c9-2a6a-477f-acd7-2dcbb01cbc93",
+                    "id": "af6dc3e2-7352-407d-9db8-1a71fa6dbd14",
                     "name": "List all certificates",
                     "request": {
                         "name": "List all certificates",
@@ -1714,7 +1714,7 @@
                     },
                     "response": [
                         {
-                            "id": "0ebe3c30-ffac-4c70-ae6f-e144d23cad23",
+                            "id": "d3b7ccf5-73ed-44ce-808c-a53f8ea20b4a",
                             "name": "List of all certificates. Will to add wording about plans for the future.",
                             "originalRequest": {
                                 "url": {
@@ -1748,12 +1748,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"in voluptate non\",\n   \"date_created\": \"1975-01-12T14:58:35.288Z\",\n   \"date_modified\": \"1984-07-25T08:55:48.984Z\",\n   \"id\": \"cert_jF5igAX\",\n   \"name\": \"laboris Ut ut\",\n   \"object\": \"proident dolore sunt irure\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"jsfAlXyxZUv\",\n   \"date_deleted\": \"1989-05-29T05:57:28.597Z\"\n  },\n  {\n   \"cert\": \"minim\",\n   \"date_created\": \"2011-12-19T02:57:55.502Z\",\n   \"date_modified\": \"1970-11-25T05:39:36.718Z\",\n   \"id\": \"cert_tH2\",\n   \"name\": \"sunt ipsum nulla mollit\",\n   \"object\": \"occaecat\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"pYGfC\",\n   \"date_deleted\": \"1970-04-07T01:45:45.527Z\"\n  }\n ],\n \"count\": -74080889,\n \"object\": \"ir\"\n}",
+                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"qui ad voluptate ut\",\n   \"date_created\": \"1966-01-21T03:23:36.576Z\",\n   \"date_modified\": \"1987-04-11T14:55:03.595Z\",\n   \"id\": \"cert_WivRmlPBYq\",\n   \"name\": \"sint irure\",\n   \"object\": \"eu proident nulla cupidatat in\",\n   \"description\": \"<string>\",\n   \"deleted\": true,\n   \"account_id\": \"LNDIg15O\",\n   \"date_deleted\": \"1943-11-08T22:17:21.906Z\"\n  },\n  {\n   \"cert\": \"reprehenderit\",\n   \"date_created\": \"1955-11-10T07:21:08.658Z\",\n   \"date_modified\": \"1986-02-21T05:29:40.647Z\",\n   \"id\": \"cert_inRp\",\n   \"name\": \"pariatur non anim ut culpa\",\n   \"object\": \"veniam id do\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"LU5HL3sNmF\",\n   \"date_deleted\": \"2016-04-25T23:05:22.045Z\"\n  }\n ],\n \"count\": -39523313,\n \"object\": \"aliqua sun\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "41c0419b-16f1-4937-8f47-36fb275e82b6",
+                            "id": "6b2e3ab8-4537-409f-95d5-7291bfe993f4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1795,7 +1795,7 @@
                     "event": []
                 },
                 {
-                    "id": "d772614f-ab39-4dec-a6aa-8c7802abb059",
+                    "id": "5f39271b-baa0-4e78-ace5-e3a5616a152d",
                     "name": "Creates a new certificate object",
                     "request": {
                         "name": "Creates a new certificate object",
@@ -1839,7 +1839,7 @@
                                 {
                                     "disabled": false,
                                     "key": "name",
-                                    "value": "non eu aliqua",
+                                    "value": "ut reprehenderit Lorem",
                                     "description": "(Required) "
                                 },
                                 {
@@ -1852,7 +1852,7 @@
                     },
                     "response": [
                         {
-                            "id": "02548d6c-6c82-448b-85b5-29ce39abbf50",
+                            "id": "71f2699f-f538-4aab-a611-837e493686c7",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -1901,7 +1901,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "ea dolor amet"
+                                            "value": "incididunt ea anim fugiat"
                                         },
                                         {
                                             "disabled": false,
@@ -1919,12 +1919,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"2015-09-14T07:43:50.547Z\",\n \"date_modified\": \"2007-09-05T14:00:05.816Z\",\n \"id\": \"cert_0xXyNqgQM\",\n \"name\": \"Duis mollit nulla dolor adipisicing\",\n \"object\": \"dolor\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"Yz7\",\n \"date_deleted\": \"2013-03-11T08:54:24.723Z\"\n}",
+                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1969-06-07T02:18:35.335Z\",\n \"date_modified\": \"1973-06-03T05:30:01.506Z\",\n \"id\": \"cert_uddYxw\",\n \"name\": \"veniam\",\n \"object\": \"exercitation aliqua sint incididunt\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"m7wsTJvja\",\n \"date_deleted\": \"1948-03-26T21:53:46.973Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9ae8fa2f-f97c-40ae-96b6-6d84bc67c6ee",
+                            "id": "ef1a64e1-a7b7-47f6-aa4e-7d8dd276a664",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1973,7 +1973,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "ea dolor amet"
+                                            "value": "incididunt ea anim fugiat"
                                         },
                                         {
                                             "disabled": false,
@@ -1999,11 +1999,11 @@
                     "event": []
                 },
                 {
-                    "id": "dc49545f-da30-4109-a2a5-53909efa4be3",
+                    "id": "62baccf0-2f9d-407b-ad99-cc8babf4a6cc",
                     "name": "{id}",
                     "item": [
                         {
-                            "id": "b6d3bf8c-cdb3-4178-ab57-37c8d4ab9b66",
+                            "id": "e1310759-b233-4235-9d1e-b6baaa6b9f65",
                             "name": "Retrieve certificate with given id",
                             "request": {
                                 "name": "Retrieve certificate with given id",
@@ -2024,7 +2024,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_JXLZQN3",
+                                            "value": "cert_zC0DFRKiIrR",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2035,7 +2035,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "258d7d1d-be3f-475b-8abe-f814838cf881",
+                                    "id": "8bb06d7d-4f3c-482f-82a7-b367267adb03",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2075,12 +2075,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"2015-09-14T07:43:50.547Z\",\n \"date_modified\": \"2007-09-05T14:00:05.816Z\",\n \"id\": \"cert_0xXyNqgQM\",\n \"name\": \"Duis mollit nulla dolor adipisicing\",\n \"object\": \"dolor\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"Yz7\",\n \"date_deleted\": \"2013-03-11T08:54:24.723Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1969-06-07T02:18:35.335Z\",\n \"date_modified\": \"1973-06-03T05:30:01.506Z\",\n \"id\": \"cert_uddYxw\",\n \"name\": \"veniam\",\n \"object\": \"exercitation aliqua sint incididunt\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"m7wsTJvja\",\n \"date_deleted\": \"1948-03-26T21:53:46.973Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c9d34d1f-7d32-4e6f-8753-83df474ff8c9",
+                                    "id": "4542d66f-aea0-4dcf-93f2-bdaffa6521d1",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2128,7 +2128,7 @@
                             "event": []
                         },
                         {
-                            "id": "8fa2f618-78c0-4f86-ac93-f4390b91549a",
+                            "id": "59b3af5e-429b-48c5-b7d4-6289ab76d6d0",
                             "name": "Update name and/or description of a certificate.",
                             "request": {
                                 "name": "Update name and/or description of a certificate.",
@@ -2149,7 +2149,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_JXLZQN3",
+                                            "value": "cert_zC0DFRKiIrR",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2169,7 +2169,7 @@
                                         {
                                             "disabled": false,
                                             "key": "name",
-                                            "value": "Duis sunt culpa"
+                                            "value": "minim dolor reprehenderit tempor laborum"
                                         },
                                         {
                                             "disabled": false,
@@ -2181,7 +2181,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "1765e800-c664-4300-a9c8-15839e419749",
+                                    "id": "185bc2e9-c43e-4865-a88f-1bf4120f3d34",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2217,7 +2217,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "dolor ullamco"
+                                                    "value": "occaecat magna"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2235,12 +2235,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"2015-09-14T07:43:50.547Z\",\n \"date_modified\": \"2007-09-05T14:00:05.816Z\",\n \"id\": \"cert_0xXyNqgQM\",\n \"name\": \"Duis mollit nulla dolor adipisicing\",\n \"object\": \"dolor\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"Yz7\",\n \"date_deleted\": \"2013-03-11T08:54:24.723Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1969-06-07T02:18:35.335Z\",\n \"date_modified\": \"1973-06-03T05:30:01.506Z\",\n \"id\": \"cert_uddYxw\",\n \"name\": \"veniam\",\n \"object\": \"exercitation aliqua sint incididunt\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"m7wsTJvja\",\n \"date_deleted\": \"1948-03-26T21:53:46.973Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "2d44cf60-7722-4886-b2ce-49882693a051",
+                                    "id": "6451ad9f-015b-41d2-905b-b30bbd5365fd",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2276,7 +2276,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "dolor ullamco"
+                                                    "value": "occaecat magna"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2302,7 +2302,7 @@
                             "event": []
                         },
                         {
-                            "id": "d200cf63-8d32-4d55-bb56-7ba61453adc3",
+                            "id": "786191b2-48e7-4688-85cc-75026a4fb4f0",
                             "name": "Deletes certificate with given id",
                             "request": {
                                 "name": "Deletes certificate with given id",
@@ -2323,7 +2323,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_JXLZQN3",
+                                            "value": "cert_zC0DFRKiIrR",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2334,7 +2334,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b299ef71-693c-4484-be1a-26ee97cf37eb",
+                                    "id": "2c62bc4f-4642-487e-9e78-e58628bf7a3c",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -2379,7 +2379,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "5a519d1d-c2e1-49b1-bd86-88d3db31af8a",
+                                    "id": "c7d02fb3-7e6e-42d4-b16b-eeeee89e54e9",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2433,11 +2433,11 @@
             "event": []
         },
         {
-            "id": "e8fe8a6f-3996-42f3-9735-e964329516e5",
+            "id": "639cd50e-d42b-483d-9307-d6dc09dd7c1a",
             "name": "checks",
             "item": [
                 {
-                    "id": "d999b320-b5d9-4cd6-a673-94ed67b0358a",
+                    "id": "f29554f4-0609-4c8b-843c-a179c1e78009",
                     "name": "List all checks",
                     "request": {
                         "name": "List all checks",
@@ -2485,7 +2485,7 @@
                     },
                     "response": [
                         {
-                            "id": "be910ca5-ec03-4390-9c18-99517895e9af",
+                            "id": "3286456f-7614-45ef-bc75-868e5305e95a",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -2549,7 +2549,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b5029ae4-be55-4358-883f-694f2765a233",
+                            "id": "298444f8-1975-40a2-aa1c-2978d1205324",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2616,7 +2616,7 @@
                     "event": []
                 },
                 {
-                    "id": "ef566bcb-8401-45ca-9923-c3c85ed66a84",
+                    "id": "cefe4f78-fef3-4e6a-872a-09642a6ad6e3",
                     "name": "Creates a new check",
                     "request": {
                         "name": "Creates a new check",
@@ -2686,7 +2686,7 @@
                     },
                     "response": [
                         {
-                            "id": "bbeb169d-09c1-4fe4-9e17-b85864763240",
+                            "id": "9bc1bd6d-a710-4f3e-b9bf-897dd937fc38",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -2788,7 +2788,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "53c22f91-58cd-4dae-ae29-0f3fc442ee0c",
+                            "id": "ddfbb1e0-0cf5-4943-8896-62977a8a9bb6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2875,11 +2875,11 @@
                     "event": []
                 },
                 {
-                    "id": "b4814dbb-7b6e-4c48-9f56-cab33df25428",
+                    "id": "a48e6622-e043-4a03-a176-076f729c10bb",
                     "name": "{chk id}",
                     "item": [
                         {
-                            "id": "a569d8be-8abb-456f-84fa-21a367436c55",
+                            "id": "6388441a-3613-4909-b0b4-d7f15e7102f6",
                             "name": "Retrieve check with given id",
                             "request": {
                                 "name": "Retrieve check with given id",
@@ -2911,7 +2911,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "377f0a76-39d2-44a8-b740-4bcf819cbaa4",
+                                    "id": "dc65fa8c-dcad-4ee6-b836-b8832d457f64",
                                     "name": "Returns a check object",
                                     "originalRequest": {
                                         "url": {
@@ -2974,7 +2974,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ffb2dc0d-0416-4720-bb6d-46fe0eb78f78",
+                                    "id": "66d6e223-2057-4751-b07d-6d32124a71e3",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3022,7 +3022,7 @@
                             "event": []
                         },
                         {
-                            "id": "cec0753b-9342-49e6-b538-094570923662",
+                            "id": "0d4eb463-5b2f-4f12-b505-d02a607b37ce",
                             "name": "Cancel a check",
                             "request": {
                                 "name": "Cancel a check",
@@ -3054,7 +3054,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "3ff2d16d-09ba-418b-8f55-ff188ba01014",
+                                    "id": "5d60b825-84cc-43e6-bf4d-763e43ac2b90",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -3099,7 +3099,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "5c0b3f00-8c57-494b-825c-edeaf66a827a",
+                                    "id": "e62b2806-cf07-4c1b-9942-3574347a2418",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3153,7 +3153,7 @@
             "event": []
         },
         {
-            "id": "ce3912c0-3ee8-4704-9b79-6c2908fdbc07",
+            "id": "e272ca97-9905-43ba-9ac8-a80aa1fb2aa0",
             "name": "Verify a US or US territory address with a live API key.",
             "request": {
                 "name": "Verify a US or US territory address with a live API key.",
@@ -3222,7 +3222,7 @@
             },
             "response": [
                 {
-                    "id": "6d9d55e3-cbcc-4a89-9934-eee5fd462462",
+                    "id": "c19c2e19-f5c7-47df-86f4-66164c7eaafc",
                     "name": "Returns an international verification object.",
                     "originalRequest": {
                         "url": {
@@ -3318,7 +3318,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "8aee90b4-72f6-42e2-99f4-f409fe2beb05",
+                    "id": "5f1dd6a6-00cc-4f8a-a823-19aa46099667",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -3399,11 +3399,11 @@
             "event": []
         },
         {
-            "id": "c86e8737-4e09-4b1c-b057-ac0c5c2d8220",
+            "id": "9c4d5d94-1ae9-4278-a278-74e408456530",
             "name": "letters",
             "item": [
                 {
-                    "id": "e02de979-7f16-4aa4-9e17-cc972e0ee7f2",
+                    "id": "818b1373-df4f-406a-aac0-885ef438eea0",
                     "name": "List all letters",
                     "request": {
                         "name": "List all letters",
@@ -3451,7 +3451,7 @@
                     },
                     "response": [
                         {
-                            "id": "e7752d4d-2b19-48ac-afe5-af323e38b392",
+                            "id": "4cc28248-239f-4cdd-a5f5-97770d0f4add",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3515,7 +3515,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ab84fb68-627c-42cd-bb38-a59696826b40",
+                            "id": "448d457f-0a90-46e6-a88a-b6fc28e850ab",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3582,7 +3582,7 @@
                     "event": []
                 },
                 {
-                    "id": "c0a04497-5c9c-4215-a4ca-af3dfd8270c2",
+                    "id": "b57618c4-67e5-4bd4-9490-f0076fb34452",
                     "name": "Creates a new letter object",
                     "request": {
                         "name": "Creates a new letter object",
@@ -3677,7 +3677,7 @@
                     },
                     "response": [
                         {
-                            "id": "f8a074f5-b604-44eb-b420-3f7a10e6ae76",
+                            "id": "6dccae3c-45fe-4373-8079-7facdc218173",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -3809,7 +3809,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "346e6dc0-dac1-4e81-bc9d-36399e96cb28",
+                            "id": "f6e90da2-7ebe-4d1a-9f1b-f03b59c9c871",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3926,11 +3926,11 @@
                     "event": []
                 },
                 {
-                    "id": "f2568c0d-f3d6-4592-b395-42f98c12c982",
+                    "id": "95890c91-10cf-46d4-9a7d-be4cecb30fcc",
                     "name": "{ltr id}",
                     "item": [
                         {
-                            "id": "deb9b1df-eb9f-4b01-8805-55f1ffe76f43",
+                            "id": "8f23c339-e074-4a53-b714-d4512902bfc0",
                             "name": "Retrieve letter with given id",
                             "request": {
                                 "name": "Retrieve letter with given id",
@@ -3962,7 +3962,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0b53fcb4-20cc-4ee5-9e53-c7999bfaa2a5",
+                                    "id": "c40b6593-42de-4126-8188-f9465703f9b1",
                                     "name": "Returns a letter object",
                                     "originalRequest": {
                                         "url": {
@@ -4025,7 +4025,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a57cba75-bf56-4e4b-97ea-12730a13aa55",
+                                    "id": "82b181af-2960-4d33-82cf-3f2e3b44dd52",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4073,7 +4073,7 @@
                             "event": []
                         },
                         {
-                            "id": "25e4b7e7-0012-41e4-b860-cd1008c02b55",
+                            "id": "0e266d1b-526f-45da-8a55-1595e2b3a62f",
                             "name": "Cancel a letter",
                             "request": {
                                 "name": "Cancel a letter",
@@ -4105,7 +4105,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d84a067c-4925-4718-a919-d7964f5bbb0c",
+                                    "id": "0f545840-abdf-40f3-a66f-ce1ad4b4eb8b",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -4150,7 +4150,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "baf6d3c8-46b7-400c-9f6d-d935ba328710",
+                                    "id": "3031b405-ed74-4f77-8631-ffe65a6c720c",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4204,11 +4204,11 @@
             "event": []
         },
         {
-            "id": "9c0e6bc8-f340-45c9-bfb6-bbfe3054314c",
+            "id": "2b1f2f98-3e28-476b-a9c5-c0119fa9d297",
             "name": "postcards",
             "item": [
                 {
-                    "id": "6a4517f8-abf5-4d92-bfaa-0ccf800eb856",
+                    "id": "5d7dcec0-e9da-4991-ac03-157d11aa7ef6",
                     "name": "List all postcards",
                     "request": {
                         "name": "List all postcards",
@@ -4256,7 +4256,7 @@
                     },
                     "response": [
                         {
-                            "id": "7047f345-e52e-4c83-90af-b1fac9df8a20",
+                            "id": "04597d1e-1024-4253-86bd-28e83537f210",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -4320,7 +4320,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2e09d135-e326-49e7-bb77-c0cbcaaeea35",
+                            "id": "7eca6824-a9c4-4138-8003-8a193b28f5fc",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4387,7 +4387,7 @@
                     "event": []
                 },
                 {
-                    "id": "8018c4d0-a992-463a-ba1f-7380a886b099",
+                    "id": "60500002-003e-4958-9642-eb0e1ba2127d",
                     "name": "Creates a new postcard object",
                     "request": {
                         "name": "Creates a new postcard object",
@@ -4457,7 +4457,7 @@
                     },
                     "response": [
                         {
-                            "id": "97844a46-0c0e-4eb3-8a44-23372a26750e",
+                            "id": "45cf07e1-3f3a-40f1-aa1b-b89d42d5f32b",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -4564,7 +4564,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "84cf823d-a326-4ff1-8980-b25fc8ae2c6a",
+                            "id": "4b6f34ea-d49c-497d-b420-d135a55dba6e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4656,11 +4656,11 @@
                     "event": []
                 },
                 {
-                    "id": "9576d3a0-371f-4435-9630-b488f6de577c",
+                    "id": "3de91127-c143-4e8e-9b2b-0e855db3c29e",
                     "name": "{psc id}",
                     "item": [
                         {
-                            "id": "ad96c182-4060-4725-9038-7164724c1373",
+                            "id": "9c7de447-2984-4d08-8e29-0d96c4e35151",
                             "name": "Retrieve postcard with given id",
                             "request": {
                                 "name": "Retrieve postcard with given id",
@@ -4692,7 +4692,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b4e93cb5-c7f0-4208-a4c7-f03519cac312",
+                                    "id": "a15cc98a-93ff-461c-8588-fbcc4479ba36",
                                     "name": "Returns a postcard object",
                                     "originalRequest": {
                                         "url": {
@@ -4755,7 +4755,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f891660e-f46e-41c3-8b2a-a4990a5f22af",
+                                    "id": "27f71305-6d06-4fc6-94b3-49733c17d2d6",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4803,7 +4803,7 @@
                             "event": []
                         },
                         {
-                            "id": "d22a80e3-cdbc-4da6-a9d8-9a3e1fab9745",
+                            "id": "eb98f864-87c8-4b60-b2d2-236bdd94a641",
                             "name": "Cancels postcard with given id",
                             "request": {
                                 "name": "Cancels postcard with given id",
@@ -4835,7 +4835,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "e0a58c71-da88-45a6-88f5-c9c0f192f834",
+                                    "id": "4bab2d63-068a-4bd0-99c4-3943f1784f5d",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -4880,7 +4880,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "541a0d15-7d5f-4a9e-9158-80aee3d0ca1c",
+                                    "id": "35fdea80-d7d5-4c6b-bccd-41c13cd0a6b2",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4934,11 +4934,11 @@
             "event": []
         },
         {
-            "id": "364de8bd-cad6-44bc-8d02-5a844d780eb0",
+            "id": "a73d1bc8-b96a-475e-b26c-0418912bf642",
             "name": "self mailers",
             "item": [
                 {
-                    "id": "dfe3cd3b-af92-4bc8-bdc8-f44f92558e06",
+                    "id": "d2ac3e90-0b1e-40e4-9aa3-6fa1e4ffa081",
                     "name": "List all self_mailers",
                     "request": {
                         "name": "List all self_mailers",
@@ -4986,7 +4986,7 @@
                     },
                     "response": [
                         {
-                            "id": "b55c742d-e79c-4df2-bdea-6b3f820f3dea",
+                            "id": "7c2206de-e3e0-4281-8aba-326b7832fca3",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -5068,7 +5068,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "99ca3f33-5a63-42d3-b9ce-c44eb4cc837e",
+                            "id": "42a82ee1-ef2a-4e23-b1ec-c30b8f5db046",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5135,7 +5135,7 @@
                     "event": []
                 },
                 {
-                    "id": "f86a353b-5c12-40fb-a506-c2d0900f13d7",
+                    "id": "fd56f1b0-6e91-4e7f-ae30-2de663c3512a",
                     "name": "Creates a new self_mailer object",
                     "request": {
                         "name": "Creates a new self_mailer object",
@@ -5205,7 +5205,7 @@
                     },
                     "response": [
                         {
-                            "id": "80d36a7a-74a4-441d-8fb7-c4fc029af768",
+                            "id": "2d458e16-749f-4d3c-ab4d-bdf5b372ba51",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -5312,7 +5312,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "354b1bee-288a-4c55-92f4-5d64a8aeb84c",
+                            "id": "4a457eb0-6e8b-4b2c-9fb6-a61dd47878dd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5404,11 +5404,11 @@
                     "event": []
                 },
                 {
-                    "id": "26deec3e-a06b-4a75-a7d5-8cc14daf3f1c",
+                    "id": "dba9ac2f-bbe7-4104-92bf-36241b8a45dc",
                     "name": "{sfm id}",
                     "item": [
                         {
-                            "id": "7a4d6798-6dfc-4211-910f-17090f1a065d",
+                            "id": "24fd845c-3aa5-4be9-8ebc-acb36f828ddb",
                             "name": "Retrieve self_mailer with given id",
                             "request": {
                                 "name": "Retrieve self_mailer with given id",
@@ -5440,7 +5440,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4b7a4e97-a6f0-40b5-8f97-579e99be7ea9",
+                                    "id": "2278aaed-c4db-4064-afd1-040a25a1a082",
                                     "name": "Returns a self_mailer object",
                                     "originalRequest": {
                                         "url": {
@@ -5503,7 +5503,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a534a210-83f5-4849-8fb0-e44d13163550",
+                                    "id": "c92d006d-f9c0-4688-9b5e-056c51f6ba63",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5551,7 +5551,7 @@
                             "event": []
                         },
                         {
-                            "id": "5c43a8d1-86ec-4ac8-945c-ded6ab343321",
+                            "id": "27670514-dc5f-487c-ad5f-54e03d9b0e3d",
                             "name": "Deletes self_mailer with given id",
                             "request": {
                                 "name": "Deletes self_mailer with given id",
@@ -5583,7 +5583,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c394514c-cb61-4e33-9dc9-537c3b541adf",
+                                    "id": "0c6654bf-7022-410d-88f2-693618653c43",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -5628,7 +5628,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "7969dfa0-9870-4289-8503-72ddd0b36fab",
+                                    "id": "a3e6909c-1a57-40ca-b1f3-8233d24b45be",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5682,11 +5682,11 @@
             "event": []
         },
         {
-            "id": "fc420cec-8442-4466-b70e-0b26af5739b5",
+            "id": "e413a663-90ac-4364-87cd-90a236108ae6",
             "name": "templates",
             "item": [
                 {
-                    "id": "542d98dd-edf5-4bd2-93b5-a1b7709efe33",
+                    "id": "3fffae56-04b2-44b5-8093-a37e15e5d7ea",
                     "name": "List all templates",
                     "request": {
                         "name": "List all templates",
@@ -5734,7 +5734,7 @@
                     },
                     "response": [
                         {
-                            "id": "9e6d2d55-54fc-4cc6-adc9-9d0e04fbe246",
+                            "id": "f93d4661-1e71-4647-9ddb-6933dccc03af",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -5816,7 +5816,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bb10d6b8-de75-4da4-8634-057aa0f5613e",
+                            "id": "f5b74e6d-7e29-410e-b9e2-6ec2f7a38782",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5883,7 +5883,7 @@
                     "event": []
                 },
                 {
-                    "id": "4cdc7d58-0142-4cc4-8516-2c3d83cbef40",
+                    "id": "02e3a712-cb2c-478b-a310-fd7e3f24e09e",
                     "name": "Creates a new template object",
                     "request": {
                         "name": "Creates a new template object",
@@ -5934,7 +5934,7 @@
                     },
                     "response": [
                         {
-                            "id": "17caf0f2-e370-4d12-8d4b-9af4e3b0110f",
+                            "id": "588561f7-62e9-4bf0-a619-22a8a0399aef",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -6025,7 +6025,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8a5f02bb-0fee-4814-baad-9dd9cc68e32f",
+                            "id": "9de019f1-3978-4f2b-a66e-34ce89bc5ee6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6101,11 +6101,11 @@
                     "event": []
                 },
                 {
-                    "id": "20fd0d60-ce9c-43ee-8d58-e2035bd95bdc",
+                    "id": "6cf54580-03c6-435a-bd1d-2644f7da3fd1",
                     "name": "{tmpl id}",
                     "item": [
                         {
-                            "id": "2b73f10f-91fe-4bf3-9925-4f458cd2e765",
+                            "id": "b077cb90-1e9e-4d7e-b3fe-4cee5a18ef2b",
                             "name": "Retrieve template with given id",
                             "request": {
                                 "name": "Retrieve template with given id",
@@ -6137,7 +6137,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b90f1f7c-367c-4444-aad1-1bd39d1f0ceb",
+                                    "id": "f697625c-7454-4375-915a-e6e162e74622",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6200,7 +6200,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "cd0329fc-3e59-4d1e-ae86-535b29127ae2",
+                                    "id": "82e4835e-cbe2-442b-be4e-46e79a5a5754",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6248,7 +6248,7 @@
                             "event": []
                         },
                         {
-                            "id": "b25bfc59-57a6-49aa-88db-55cdbaa773a2",
+                            "id": "7d395afd-c2a2-4848-8eb6-3fc156c2786a",
                             "name": "Update description and/or published version of a template.",
                             "request": {
                                 "name": "Update description and/or published version of a template.",
@@ -6307,7 +6307,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c77b5737-012f-4114-9b51-36586154d9e1",
+                                    "id": "152f685a-4f18-4a0d-866f-5e5f7bcad5c9",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6390,7 +6390,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f28c1924-2bf4-4c82-a908-f012f6297a01",
+                                    "id": "5d6b756f-4053-49b0-994a-f75582d6b987",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6458,7 +6458,7 @@
                             "event": []
                         },
                         {
-                            "id": "19e8bac4-765f-463a-85e3-fea9029c5d49",
+                            "id": "ae25ea80-cf97-43db-bce1-bb10f97217ec",
                             "name": "Deletes template with given id",
                             "request": {
                                 "name": "Deletes template with given id",
@@ -6490,7 +6490,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "95cf8253-2175-422b-b3d9-dd3219d6ce2d",
+                                    "id": "8171bf7b-0809-4bfc-84a3-a403b4b8e011",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -6535,7 +6535,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a0310e65-af5e-4b62-afb1-fc9b23dd7f27",
+                                    "id": "99de7765-65c4-4b67-9122-24c531a2eed3",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6583,11 +6583,11 @@
                             "event": []
                         },
                         {
-                            "id": "6ba32c9a-95e0-4c8c-b2b0-5ac3477b0c2f",
+                            "id": "fddcbd40-2b0b-44f8-8706-40f137f0b87e",
                             "name": "versions",
                             "item": [
                                 {
-                                    "id": "fc23c8ac-b1f5-4731-8db7-0c7d5c20732e",
+                                    "id": "40260662-c7c4-41a8-858d-6e91a6ceca21",
                                     "name": "List all template_versions",
                                     "request": {
                                         "name": "List all template_versions",
@@ -6645,7 +6645,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "9c821dba-90a8-4ae2-94e2-7cb5377393ec",
+                                            "id": "53168f5c-69f2-4295-856e-f57a55cbf22e",
                                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                                             "originalRequest": {
                                                 "url": {
@@ -6726,7 +6726,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "383b6079-a87b-474d-8011-602e9fc98023",
+                                            "id": "2c305857-88c5-441e-a395-e77ea6181dc5",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -6792,7 +6792,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "b0f8c449-1e2c-47ec-9c37-1a60eea5293b",
+                                    "id": "e7fd2dfd-911a-494a-a730-e74568cd070d",
                                     "name": "Creates a new template_version object",
                                     "request": {
                                         "name": "Creates a new template_version object",
@@ -6853,7 +6853,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "191536f9-18cd-479d-96a3-e34059d68295",
+                                            "id": "52c9b071-a309-4bd2-81b8-e5840856a944",
                                             "name": "Returns the template version with the given template and version ids.",
                                             "originalRequest": {
                                                 "url": {
@@ -6941,7 +6941,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c027147b-659b-4ae2-b19e-95fe5ef263b1",
+                                            "id": "d29cb00f-ba65-4e60-bf9f-950762e92c0e",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -7014,11 +7014,11 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "d0c1be04-9286-40f3-8286-f7ab58f211d7",
+                                    "id": "39c46581-0d4d-4824-a51a-c5f5b5f0cf99",
                                     "name": "{vrsn id}",
                                     "item": [
                                         {
-                                            "id": "931beaa6-778d-45aa-8432-790bfac8cb61",
+                                            "id": "c45709c1-06a0-457a-9b51-9da57fd16e91",
                                             "name": "Retrieve template version with given template and version ids.",
                                             "request": {
                                                 "name": "Retrieve template version with given template and version ids.",
@@ -7059,7 +7059,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "02de0a44-f180-4cc4-bc72-abac26e2b229",
+                                                    "id": "63435d57-c674-4d4a-af9d-5a0bccc37f95",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7128,7 +7128,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "a50dd022-18ea-443f-971f-232e5ecc0e12",
+                                                    "id": "5fc856b4-13fb-471b-8686-41b79780fe65",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7182,7 +7182,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "de0230d3-2da5-4e3c-b1b3-f5a3a7b1920b",
+                                            "id": "4e42afa2-bca1-4962-b3ca-224b3c0c0743",
                                             "name": "Updates the template version with given template and version ids.",
                                             "request": {
                                                 "name": "Updates the template version with given template and version ids.",
@@ -7245,7 +7245,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "ae94eeda-feb4-435e-88ee-dcde88b5aebd",
+                                                    "id": "53a42188-324e-4b56-a33c-ce9b0edc6a3f",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7329,7 +7329,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "8d66187c-34ed-4c9c-845d-39ac789e09cf",
+                                                    "id": "cf426eda-58c1-421b-b55b-aba77d0ad7e2",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7398,7 +7398,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "ca481f6e-53d5-4b2a-872a-d001434f2e10",
+                                            "id": "df765412-1cdc-47f4-9b94-94bd8a34e13d",
                                             "name": "Deletes the template version with given template and version ids if possible.",
                                             "request": {
                                                 "name": "Deletes the template version with given template and version ids if possible.",
@@ -7439,7 +7439,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "9de9a870-8b56-4747-a512-706dfd727ec3",
+                                                    "id": "e5c44e7e-3775-48a3-9775-e9b66cc56432",
                                                     "name": "Returns true if the delete was successful",
                                                     "originalRequest": {
                                                         "url": {
@@ -7490,7 +7490,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "a5c10d8e-f7b7-409a-812d-5e96d2599154",
+                                                    "id": "5c7bf5d7-b253-45e1-a141-d2fc09b6d51f",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7550,7 +7550,7 @@
                             "event": []
                         },
                         {
-                            "id": "458fa792-059d-434e-ac52-13a8f2bd8620",
+                            "id": "ea04e99f-b8ed-45e0-9ada-e25f1426c706",
                             "name": "Compile the template into html",
                             "request": {
                                 "name": "Compile the template into html",
@@ -7596,7 +7596,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "5074bcc5-a6b4-45c3-bee7-ebb7a7bf38c9",
+                                    "id": "334baa66-9a8d-4f76-af17-24b8f5590d91",
                                     "name": "Returns the compiled html",
                                     "originalRequest": {
                                         "url": {
@@ -7651,7 +7651,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "186c0959-1955-417a-8319-c3decd4fb9d3",
+                                    "id": "1f52fe34-31e5-4c0f-8e1d-ebadd4ad876d",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -7715,7 +7715,7 @@
             "event": []
         },
         {
-            "id": "62cea742-23b6-451d-a6bf-e0e4cdc9d06f",
+            "id": "193590a6-0035-4cfc-bd76-2b3eac604958",
             "name": "Autocomplete a partial US address.",
             "request": {
                 "name": "Autocomplete a partial US address.",
@@ -7779,7 +7779,7 @@
             },
             "response": [
                 {
-                    "id": "f9e84390-8a82-4623-8433-7f82de431fc9",
+                    "id": "42909a94-65bd-41cf-9213-5d73d9239fd3",
                     "name": "Returns a US autocompletion object.",
                     "originalRequest": {
                         "url": {
@@ -7885,7 +7885,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "138b399e-a2af-403c-9c50-af4c5862d8d3",
+                    "id": "b82e7a80-81a9-4fb4-ac3b-a01de4196fcb",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -7976,7 +7976,7 @@
             "event": []
         },
         {
-            "id": "dc93bbaa-dad0-4d91-9aad-48d341c6016c",
+            "id": "31633dbd-0394-4f0c-8af2-3cf9b50a46c5",
             "name": "Verify a US or US territory address with a live API key.",
             "request": {
                 "name": "Verify a US or US territory address with a live API key.",
@@ -8016,7 +8016,7 @@
             },
             "response": [
                 {
-                    "id": "41004e29-7a88-49ab-9a4b-0ecc0ce7442b",
+                    "id": "97c9590c-21b8-4626-8491-6a90428772fc",
                     "name": "Returns a US verification object.",
                     "originalRequest": {
                         "url": {
@@ -8081,7 +8081,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "6bbe6da9-15db-4113-8647-5fb01ec13dff",
+                    "id": "e0d87332-7190-408c-aee4-b9c8e2cc46e5",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8131,7 +8131,7 @@
             "event": []
         },
         {
-            "id": "2743d8d2-1566-42f5-8755-46b0d6dcc053",
+            "id": "af33c4e8-373a-410c-b920-6ee88592e255",
             "name": "Looks up information pertaining to a given ZIP code",
             "request": {
                 "name": "Looks up information pertaining to a given ZIP code",
@@ -8171,7 +8171,7 @@
             },
             "response": [
                 {
-                    "id": "ae2f50ff-b6ab-4321-8977-f9eb24b0aaff",
+                    "id": "0a520b33-d7ae-4c5a-a45e-30289566d831",
                     "name": "Returns a zip lookup object if a valid zip was provided.",
                     "originalRequest": {
                         "url": {
@@ -8236,12 +8236,12 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"c\",\n   \"county\": \"irure ut adipisi\",\n   \"county_fips\": \"04915\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"ci\",\n   \"county\": \"exercitation in magna culpa\",\n   \"county_fips\": \"76723\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"velit voluptate eu\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"\"\n}",
+                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"s\",\n   \"county\": \"adipisicing aute ut esse velit\",\n   \"county_fips\": \"38275\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"c\",\n   \"county\": \"nisi\",\n   \"county_fips\": \"29617\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"do anim\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"po_box\"\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "5e41752e-0404-4e60-b299-640a784b5bd0",
+                    "id": "f0d9208a-36f3-4f2b-8563-b6333d4120b1",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8318,7 +8318,7 @@
         ]
     },
     "info": {
-        "_postman_id": "1852a81c-b270-4e18-881f-abbf6f2cdc4e",
+        "_postman_id": "27f30083-b5f9-4e66-9326-46a44eeffebf",
         "name": "Lob API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "license": "MIT",
       "devDependencies": {
         "@redocly/openapi-cli": "^1.0.0-beta.44",
+        "@slack/web-api": "^6.2.3",
         "@stoplight/prism-cli": "^4.2.1",
         "@stoplight/spectral": "^5.9.1",
         "btoa": "^1.2.1",
         "husky": "^5.0.9",
+        "joi": "^17.4.0",
         "multi-tape": "^1.6.1",
         "openapi-to-postmanv2": "^2.6.0",
         "prettier": "^2.2.1",
@@ -46,6 +48,21 @@
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "dev": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@jsdevtools/ono": {
@@ -148,6 +165,87 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
+    "node_modules/@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=12.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-Nu4jWC39mDY5egAX4oElwOypdu8Cx9tmR7bo3ghaHYaC7mkKM1+b+soanW5s2ssu4yOLxMdFExMh6wlR34B6CA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.2.3.tgz",
+      "integrity": "sha512-Qt0JUSuT1RKFYRpMfbP0xKkqWoXGzmEa4N+7H5oB9eH228ABn1sM3LDNW7ZQiLs5jpDuzHAp7dSxAZpb+ZfO/w==",
+      "dev": true,
+      "dependencies": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.0.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.21.1",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "^2.2.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/@stoplight/better-ajv-errors": {
@@ -787,6 +885,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -803,6 +910,12 @@
       "version": "14.14.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
       "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
     "node_modules/@types/swagger-schema-official": {
@@ -1103,6 +1216,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1786,6 +1908,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
     "node_modules/events-to-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
@@ -1968,6 +2096,26 @@
       "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -2633,6 +2781,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==",
+      "dev": true
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2748,6 +2902,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
@@ -2829,6 +2992,19 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "node_modules/joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
@@ -3913,6 +4089,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -3935,6 +4120,53 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
+    "node_modules/p-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
+      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -4845,44 +5077,11 @@
       "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A==",
       "dev": true
     },
-    "node_modules/redoc-cli/node_modules/@types/chokidar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
-      "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
-      "extraneous": true,
-      "dependencies": {
-        "chokidar": "*"
-      }
-    },
     "node_modules/redoc-cli/node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
-    },
-    "node_modules/redoc-cli/node_modules/@types/handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-      "extraneous": true,
-      "dependencies": {
-        "handlebars": "*"
-      }
-    },
-    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
-      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
-      "extraneous": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/redoc-cli/node_modules/@types/node": {
-      "version": "14.0.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
-      "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==",
-      "extraneous": true
     },
     "node_modules/redoc-cli/node_modules/ajv": {
       "version": "5.5.2",
@@ -7073,6 +7272,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -8420,6 +8628,21 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@hapi/hoek": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
+      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -8498,6 +8721,74 @@
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.1",
         "yaml-ast-parser": "0.0.43"
+      }
+    },
+    "@sideway/address": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
+    "@slack/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "dev": true,
+      "requires": {
+        "@types/node": ">=12.0.0"
+      }
+    },
+    "@slack/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-Nu4jWC39mDY5egAX4oElwOypdu8Cx9tmR7bo3ghaHYaC7mkKM1+b+soanW5s2ssu4yOLxMdFExMh6wlR34B6CA==",
+      "dev": true
+    },
+    "@slack/web-api": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.2.3.tgz",
+      "integrity": "sha512-Qt0JUSuT1RKFYRpMfbP0xKkqWoXGzmEa4N+7H5oB9eH228ABn1sM3LDNW7ZQiLs5jpDuzHAp7dSxAZpb+ZfO/w==",
+      "dev": true,
+      "requires": {
+        "@slack/logger": "^3.0.0",
+        "@slack/types": "^2.0.0",
+        "@types/is-stream": "^1.1.0",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.21.1",
+        "eventemitter3": "^3.1.0",
+        "form-data": "^2.5.0",
+        "is-electron": "^2.2.0",
+        "is-stream": "^1.1.0",
+        "p-queue": "^6.6.1",
+        "p-retry": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@stoplight/better-ajv-errors": {
@@ -9027,6 +9318,15 @@
         "@types/node": "*"
       }
     },
+    "@types/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -9043,6 +9343,12 @@
       "version": "14.14.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
       "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
     "@types/swagger-schema-official": {
@@ -9151,9 +9457,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
       "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      }
+      "requires": {}
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -9279,6 +9583,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -9836,6 +10149,12 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "dev": true
+    },
     "events-to-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
@@ -9983,6 +10302,12 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
       "dev": true
     },
     "for-each": {
@@ -10487,6 +10812,12 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -10560,6 +10891,12 @@
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
       "dev": true
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
@@ -10617,6 +10954,19 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -11503,6 +11853,12 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -11519,6 +11875,43 @@
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+          "dev": true
+        }
+      }
+    },
+    "p-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
+      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -12301,41 +12694,11 @@
           "integrity": "sha512-rmuSC2JFFl4DkPDdGVrmffT9KcbG2AB5jvhxPIrOc1dO9mHRMUUftQY35KZlvWqqSSqVn+AM+J9dhiTo1ZqR8A==",
           "dev": true
         },
-        "@types/chokidar": {
-          "version": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
-          "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
-          "extraneous": true,
-          "requires": {
-            "chokidar": "*"
-          }
-        },
         "@types/color-name": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
           "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
           "dev": true
-        },
-        "@types/handlebars": {
-          "version": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-          "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-          "extraneous": true,
-          "requires": {
-            "handlebars": "*"
-          }
-        },
-        "@types/mkdirp": {
-          "version": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
-          "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
-          "extraneous": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "@types/node": {
-          "version": "14.0.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
-          "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==",
-          "extraneous": true
         },
         "ajv": {
           "version": "5.5.2",
@@ -14519,6 +14882,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
       "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "reusify": {

--- a/package.json
+++ b/package.json
@@ -75,10 +75,12 @@
   "homepage": "https://github.com/lob/lob-openapi#readme",
   "devDependencies": {
     "@redocly/openapi-cli": "^1.0.0-beta.44",
+    "@slack/web-api": "^6.2.3",
     "@stoplight/prism-cli": "^4.2.1",
     "@stoplight/spectral": "^5.9.1",
     "btoa": "^1.2.1",
     "husky": "^5.0.9",
+    "joi": "^17.4.0",
     "multi-tape": "^1.6.1",
     "openapi-to-postmanv2": "^2.6.0",
     "prettier": "^2.2.1",


### PR DESCRIPTION
Automatically messages the appropriate channels in the case of contract test failures.

This is a sample error which could be surfaced in one of the goalie channels, due to a contract test failure:

```
FAILED CONTRACT TEST:      
 at /github/workspace/tests/zip_lookups_test.js:43:5
 
EXPECTED:  200
ACTUAL:      422
```

The original message contained a stacktrace, but I removed that because most of the stacktrace (save for the failed test line included in the current message) shows the parts in the `tape` module which errored (and those will stay the same regardless of which test fails).

The particular error message, in case of a contract test failure triggered by a mistake in production on our end, will always be "should be strictly equal", because we'd be surfacing a status code that doesn't match the one we expect in the tests. The test summary (e.g. "use an incorrectly formatted zip code") doesn't change from run to run, so that too can be excluded. Therefore, so that this doesn't clutter up any goalie channels, only the most important information––which contract test failed, the received status code, and the expected status code––will be surfaced in the message.

Assigning @jekatlob as well as Hilary, because it'll be good to have feedback from somebody who may be using these Slack alerts.