### PR TITLE
feat(testing): fixed up template tests

### DIFF
--- a/dist/Lob-API-postman.json
+++ b/dist/Lob-API-postman.json
@@ -1,11 +1,11 @@
 {
     "item": [
         {
-            "id": "04e15dc9-9db4-4546-829f-103a11d76d89",
+            "id": "87d5aa0f-63bd-4484-a6ec-e4a37123bf01",
             "name": "addresses",
             "item": [
                 {
-                    "id": "b115b1d8-babd-4051-9878-3f7c71d0da11",
+                    "id": "3f62eb5c-5ea3-4679-9a9e-b5d37ecdb528",
                     "name": "List all addresses",
                     "request": {
                         "name": "List all addresses",
@@ -53,7 +53,7 @@
                     },
                     "response": [
                         {
-                            "id": "672571a5-cb4b-4892-904e-3afc4ca8a480",
+                            "id": "4b3d64e0-9707-441c-9001-401ebdf3ad1c",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -117,7 +117,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "28b42d9c-7a45-4fc8-b0eb-9ac63de0d463",
+                            "id": "5e6c55cb-296c-40a8-bbb1-cdfcf3d2f178",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -184,7 +184,7 @@
                     "event": []
                 },
                 {
-                    "id": "6cfb9710-00ab-474d-b766-b5c696f18747",
+                    "id": "1c624feb-ba97-4609-9aa0-2d77cb10744e",
                     "name": "Creates a new address object",
                     "request": {
                         "name": "Creates a new address object",
@@ -254,7 +254,7 @@
                     },
                     "response": [
                         {
-                            "id": "1846b228-61c1-44fa-8adc-dae6e73619f7",
+                            "id": "82899602-ea97-465e-810c-3f8ce7db1528",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -351,7 +351,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5e13804c-141e-4c70-9134-eec963bda7e4",
+                            "id": "5b14d2d3-2a7c-432a-9f1e-cb36a5046dc2",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -433,11 +433,11 @@
                     "event": []
                 },
                 {
-                    "id": "2c878caa-000a-4852-b925-2954d33845cc",
+                    "id": "c6684796-887c-47b2-a6b1-f06b09b99fbf",
                     "name": "{adr id}",
                     "item": [
                         {
-                            "id": "b57611fa-812c-4545-8e4b-135d155abc7b",
+                            "id": "45c39def-3723-4cdf-8d8f-f3776db537b0",
                             "name": "Retrieve address with given id",
                             "request": {
                                 "name": "Retrieve address with given id",
@@ -469,7 +469,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "dd11a403-261e-44c4-b6b9-ef3a71eb9289",
+                                    "id": "4700206c-911c-4791-8887-b6eda3bffa81",
                                     "name": "Returns an address object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -527,12 +527,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_country\": \"UNITED STATES\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"2010-03-17T01:37:27.969Z\",\n \"date_modified\": \"1941-10-15T19:57:43.675Z\",\n \"id\": \"<string>\",\n \"object\": \"address\",\n \"address_line2\": \"<string>\",\n \"deleted\": true,\n \"recipient_moved\": true\n}",
+                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_country\": \"UNITED STATES\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"1997-05-17T20:22:18.245Z\",\n \"date_modified\": \"1974-01-13T18:23:03.183Z\",\n \"id\": \"<string>\",\n \"object\": \"address\",\n \"address_line2\": \"<string>\",\n \"deleted\": false,\n \"recipient_moved\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "4aed7f47-5eb6-49dd-83d6-20bc9ab2b306",
+                                    "id": "a3314d85-53fa-4465-8d0a-bbc4b9d061ad",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -580,7 +580,7 @@
                             "event": []
                         },
                         {
-                            "id": "6b006789-9a89-4429-a086-6217846bf2f2",
+                            "id": "3025ee2d-f53e-4726-b0e9-68164dfa73ae",
                             "name": "Deletes address with given id",
                             "request": {
                                 "name": "Deletes address with given id",
@@ -612,7 +612,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "f186f871-3714-4220-b877-87090d36ac93",
+                                    "id": "4907a971-e255-49ba-88bd-172923177390",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -657,7 +657,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "27e82ad2-e243-4e3e-91b5-6a4c8ffcc86c",
+                                    "id": "01cd2b69-b4c8-4460-85dc-fd0732016d02",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -711,11 +711,11 @@
             "event": []
         },
         {
-            "id": "f74efc74-6b4d-46c7-b743-7dfd96d16378",
+            "id": "55eabf61-ea45-4f7f-99b7-d4df001f7cce",
             "name": "bank accounts",
             "item": [
                 {
-                    "id": "3a0bff2c-657d-4de9-9e7e-c5c739528216",
+                    "id": "1ac6d072-c178-4425-96bc-fa46f62f0e1e",
                     "name": "List all bank_accounts",
                     "request": {
                         "name": "List all bank_accounts",
@@ -763,7 +763,7 @@
                     },
                     "response": [
                         {
-                            "id": "b06791fa-abb3-4009-9b8a-e74118124bf1",
+                            "id": "ebabe5d1-0305-4158-99f9-460c638a93c7",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -827,7 +827,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "381c7e4a-daf9-4a6f-9a7d-19d0b1c986c2",
+                            "id": "02e966ae-7db9-477c-b18a-6d7ea00b6e09",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -894,7 +894,7 @@
                     "event": []
                 },
                 {
-                    "id": "12b4507c-8d6b-405a-847c-444adf161613",
+                    "id": "29f0e61b-e746-46a5-a139-8d1ced09d5a9",
                     "name": "Creates a new bank_account",
                     "request": {
                         "name": "Creates a new bank_account",
@@ -969,7 +969,7 @@
                     },
                     "response": [
                         {
-                            "id": "04a7212e-9285-436e-9fb8-e00bd4e8adb5",
+                            "id": "7b0dd5c0-2d32-40fb-8703-65f550dab428",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1081,7 +1081,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3ca5985c-5b71-4a4d-809c-20285b59d678",
+                            "id": "4296df05-478c-4f50-b0b4-426c101e51f4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1178,11 +1178,11 @@
                     "event": []
                 },
                 {
-                    "id": "d022a206-8644-4bf3-8034-44a46124f585",
+                    "id": "54ade743-fa0f-46df-9f1d-46386599a431",
                     "name": "{bank id}",
                     "item": [
                         {
-                            "id": "2ac1f24f-e6d8-457a-8670-6ef3c6ecacf6",
+                            "id": "42a7932c-fe7a-4705-a3fd-898113e47150",
                             "name": "Retrieve bank_account with given id",
                             "request": {
                                 "name": "Retrieve bank_account with given id",
@@ -1214,7 +1214,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d52205f2-9a0d-4585-96e5-de36ef84d119",
+                                    "id": "7f8601ce-15b8-424a-a6a8-36b79aa37f9e",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1277,7 +1277,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c9b7405c-3370-4949-aa64-78b48982e4fa",
+                                    "id": "0d830a36-09e0-4ffd-8f39-d454a158fd06",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1325,7 +1325,7 @@
                             "event": []
                         },
                         {
-                            "id": "4ac53d84-f61a-4a41-9fd8-3b3284b755c9",
+                            "id": "9ecabbd7-58ab-4b39-ac2b-30245007ad06",
                             "name": "Delete a bank_account",
                             "request": {
                                 "name": "Delete a bank_account",
@@ -1357,7 +1357,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "2384e841-ec63-40df-9fc4-2f976b2d94de",
+                                    "id": "0e218675-4955-4827-9ca4-7f250f768c6f",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -1402,7 +1402,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ef6adf63-1b90-431a-8931-bdb3472eda16",
+                                    "id": "01289139-531e-4118-a79f-a4bd0f8b6dc7",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1450,7 +1450,7 @@
                             "event": []
                         },
                         {
-                            "id": "8218a1be-5a74-4c7d-883b-0a2225e43acb",
+                            "id": "ab9ab952-e200-4b04-ae91-8c66b398b190",
                             "name": "Verify a bank account",
                             "request": {
                                 "name": "Verify a bank account",
@@ -1512,7 +1512,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4a1d043c-dc9c-4dab-abcb-7f53439b5dc2",
+                                    "id": "b68939fe-85ee-4058-91d9-39884517e8d8",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1604,7 +1604,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "e451e0d7-aaed-497c-9280-bcd6ea75de80",
+                                    "id": "4a42ea06-cb7f-40cc-8611-1fca17e846d8",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1687,11 +1687,11 @@
             "event": []
         },
         {
-            "id": "71c58369-7529-4eeb-8e64-fd8efaaad002",
+            "id": "d48738b2-2ebd-4bad-8102-c8a83af9c78a",
             "name": "bulk",
             "item": [
                 {
-                    "id": "aec1eaf9-0931-494d-81ab-d628d103dbd0",
+                    "id": "f71e4b7d-aa0b-4d28-a6d6-3cb08dda55bc",
                     "name": "Verify a list of US or US territory address with a live API key.",
                     "request": {
                         "name": "Verify a list of US or US territory address with a live API key.",
@@ -1732,7 +1732,7 @@
                     },
                     "response": [
                         {
-                            "id": "08457bdd-835a-4322-8d7b-e2addd3690ea",
+                            "id": "faa77b7a-3b63-4671-a220-43d404ab8415",
                             "name": "Returns an US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -1798,7 +1798,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4d0ea3e2-4646-4398-80cf-b25cf2113903",
+                            "id": "23a6566d-817d-4b67-94da-38de1e7fd9df",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1849,7 +1849,7 @@
                     "event": []
                 },
                 {
-                    "id": "4f5b7afa-9acf-43b9-a4ea-b2b7d6b10b75",
+                    "id": "093bca05-ba0f-40b3-8269-2cf940db3924",
                     "name": "Verify a list of international addresses with a live API key.",
                     "request": {
                         "name": "Verify a list of international addresses with a live API key.",
@@ -1883,7 +1883,7 @@
                     },
                     "response": [
                         {
-                            "id": "f67a886b-461d-4cde-8676-5bcb4f8bb120",
+                            "id": "cc55a3fd-df50-4bbf-af8b-9579cc3e46cc",
                             "name": "Returns an array of international verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -1944,7 +1944,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "17bb54db-7b01-4ee0-91f3-56c9bb813a85",
+                            "id": "4a55d0cb-0b8f-45a1-8b57-f88e6e402ae7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1993,11 +1993,11 @@
             "event": []
         },
         {
-            "id": "b16c068b-be3b-42a6-93db-d7a17a22715d",
+            "id": "b75bdfa7-5f4b-4089-adfe-948b137b3404",
             "name": "certificates",
             "item": [
                 {
-                    "id": "8d6553c9-be31-469d-9e54-f718c840fa52",
+                    "id": "c51adda8-0101-4865-8525-cfa629681f31",
                     "name": "List all certificates",
                     "request": {
                         "name": "List all certificates",
@@ -2020,7 +2020,7 @@
                     },
                     "response": [
                         {
-                            "id": "54e548bd-b630-4710-8399-600ed44f8a62",
+                            "id": "2d299576-9882-4bb8-881a-0efc2946f659",
                             "name": "List of all certificates. Will to add wording about plans for the future.",
                             "originalRequest": {
                                 "url": {
@@ -2054,12 +2054,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"veniam dolor sint\",\n   \"date_created\": \"1989-08-03T15:57:22.364Z\",\n   \"date_modified\": \"1987-08-30T13:55:16.906Z\",\n   \"id\": \"cert_bt1wGNzL1\",\n   \"name\": \"in aute Ut\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"Ii\",\n   \"date_deleted\": \"1968-11-28T00:58:18.670Z\"\n  },\n  {\n   \"cert\": \"dolore velit consectetur sit n\",\n   \"date_created\": \"2004-04-29T16:03:20.514Z\",\n   \"date_modified\": \"1962-02-14T16:49:29.892Z\",\n   \"id\": \"cert_Q3AD3XU6zq\",\n   \"name\": \"minim eu\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": true,\n   \"account_id\": \"zw6pwJJdN\",\n   \"date_deleted\": \"1984-06-17T10:40:56.241Z\"\n  }\n ],\n \"count\": -3152047,\n \"object\": \"conseq\"\n}",
+                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"ad tempor\",\n   \"date_created\": \"1983-12-01T01:16:20.260Z\",\n   \"date_modified\": \"2004-02-27T17:57:15.428Z\",\n   \"id\": \"cert_OAan5NDMllo\",\n   \"name\": \"quis aliqua aute dolor nisi\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"Wwdm4Qh\",\n   \"date_deleted\": \"1941-07-12T12:23:37.824Z\"\n  },\n  {\n   \"cert\": \"culpa consequat est dolore qui\",\n   \"date_created\": \"1958-12-10T15:36:16.407Z\",\n   \"date_modified\": \"1954-09-13T05:57:40.821Z\",\n   \"id\": \"cert_P\",\n   \"name\": \"minim nulla reprehenderit\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"lEWQOPhc\",\n   \"date_deleted\": \"1969-05-30T19:28:19.643Z\"\n  }\n ],\n \"count\": -25494438,\n \"object\": \"in pariatur irure sint\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b7724bce-a002-48a6-9896-9848cec153a4",
+                            "id": "2a1eabc5-292c-449c-84d6-b16ffc86461e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2101,7 +2101,7 @@
                     "event": []
                 },
                 {
-                    "id": "3b4fbfcb-06cd-4755-9e6c-0e6dc1154b19",
+                    "id": "e822b2dd-9869-43b0-bf61-ffa848292dd8",
                     "name": "Creates a new certificate object",
                     "request": {
                         "name": "Creates a new certificate object",
@@ -2145,7 +2145,7 @@
                                 {
                                     "disabled": false,
                                     "key": "name",
-                                    "value": "ut ipsum Duis",
+                                    "value": "ipsum ea dolor",
                                     "description": "(Required) "
                                 },
                                 {
@@ -2158,7 +2158,7 @@
                     },
                     "response": [
                         {
-                            "id": "f1199273-a73b-4539-ab16-70fffcfae17f",
+                            "id": "cf2a9cfe-1dc5-4b58-894c-ad9d260ae651",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -2207,7 +2207,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "minim dolore aliqua"
+                                            "value": "dolor adipisicing laboris Lorem deserunt"
                                         },
                                         {
                                             "disabled": false,
@@ -2225,12 +2225,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1994-06-03T20:50:58.559Z\",\n \"date_modified\": \"1941-07-16T07:41:27.753Z\",\n \"id\": \"cert_qFl2F70oRJ\",\n \"name\": \"voluptate qui\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"rCBgU1FsAU\",\n \"date_deleted\": \"1970-11-15T04:50:35.565Z\"\n}",
+                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1954-08-10T08:25:28.422Z\",\n \"date_modified\": \"1950-06-13T23:52:24.163Z\",\n \"id\": \"cert_BN\",\n \"name\": \"in fugiat\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"rbb6cmy6\",\n \"date_deleted\": \"2009-03-10T14:41:51.115Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e134e30f-46cd-4b7e-b350-00b82428af9a",
+                            "id": "9570ad9c-6131-45da-bcbc-d6c9d9b13b17",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2279,7 +2279,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "minim dolore aliqua"
+                                            "value": "dolor adipisicing laboris Lorem deserunt"
                                         },
                                         {
                                             "disabled": false,
@@ -2305,11 +2305,11 @@
                     "event": []
                 },
                 {
-                    "id": "818d2fe5-7bc0-48a6-af48-97f646750c66",
+                    "id": "56e277aa-0a1d-410b-8d8d-238f46ad2ffd",
                     "name": "{id}",
                     "item": [
                         {
-                            "id": "5bba291c-eab1-42de-ac90-250fd77126d7",
+                            "id": "b9e98fe2-702e-443a-81a0-14f7e797cc8a",
                             "name": "Retrieve certificate with given id",
                             "request": {
                                 "name": "Retrieve certificate with given id",
@@ -2330,7 +2330,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_dK",
+                                            "value": "cert_7Q",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2341,7 +2341,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "7515af24-866f-418e-bad9-3beb86abe28e",
+                                    "id": "c6fedd0a-8715-4123-8d2f-a7523769b49d",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2381,12 +2381,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1994-06-03T20:50:58.559Z\",\n \"date_modified\": \"1941-07-16T07:41:27.753Z\",\n \"id\": \"cert_qFl2F70oRJ\",\n \"name\": \"voluptate qui\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"rCBgU1FsAU\",\n \"date_deleted\": \"1970-11-15T04:50:35.565Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1954-08-10T08:25:28.422Z\",\n \"date_modified\": \"1950-06-13T23:52:24.163Z\",\n \"id\": \"cert_BN\",\n \"name\": \"in fugiat\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"rbb6cmy6\",\n \"date_deleted\": \"2009-03-10T14:41:51.115Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "bedb60bd-b2d4-483e-9675-2a5d93b5599b",
+                                    "id": "fdbc9e5b-08cd-4046-be81-50c33f676416",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2434,7 +2434,7 @@
                             "event": []
                         },
                         {
-                            "id": "2e9ded52-bd91-48d2-a92e-5eff9cfdd805",
+                            "id": "cc041ff5-967d-4cfa-a317-29111afc91e9",
                             "name": "Update name and/or description of a certificate.",
                             "request": {
                                 "name": "Update name and/or description of a certificate.",
@@ -2455,7 +2455,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_dK",
+                                            "value": "cert_7Q",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2475,7 +2475,7 @@
                                         {
                                             "disabled": false,
                                             "key": "name",
-                                            "value": "labore occaecat"
+                                            "value": "magna sunt"
                                         },
                                         {
                                             "disabled": false,
@@ -2487,7 +2487,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d7a680c9-c0a4-4787-98a0-dbd6cd5f907d",
+                                    "id": "f36a1e8e-81b9-43ce-be92-b77a6271c816",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2523,7 +2523,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "aliquip nisi eiusmod"
+                                                    "value": "dolor mollit pariatur"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2541,12 +2541,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1994-06-03T20:50:58.559Z\",\n \"date_modified\": \"1941-07-16T07:41:27.753Z\",\n \"id\": \"cert_qFl2F70oRJ\",\n \"name\": \"voluptate qui\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"rCBgU1FsAU\",\n \"date_deleted\": \"1970-11-15T04:50:35.565Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1954-08-10T08:25:28.422Z\",\n \"date_modified\": \"1950-06-13T23:52:24.163Z\",\n \"id\": \"cert_BN\",\n \"name\": \"in fugiat\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"rbb6cmy6\",\n \"date_deleted\": \"2009-03-10T14:41:51.115Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "6b0d4b04-5949-45a9-bc8f-48f40b111d18",
+                                    "id": "dc3f23c1-db1e-4103-ac57-3c35c8713a72",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2582,7 +2582,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "aliquip nisi eiusmod"
+                                                    "value": "dolor mollit pariatur"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2608,7 +2608,7 @@
                             "event": []
                         },
                         {
-                            "id": "202c23ff-16c8-400b-81df-435cccca22e0",
+                            "id": "f70106ae-83b6-42c8-a250-3b79e29fc814",
                             "name": "Deletes certificate with given id",
                             "request": {
                                 "name": "Deletes certificate with given id",
@@ -2629,7 +2629,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_dK",
+                                            "value": "cert_7Q",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2640,7 +2640,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4ac76e63-80d8-40b9-bc2c-3c6de55fcd19",
+                                    "id": "64dc5bd3-7c28-414a-b225-6c6f265dafda",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -2685,7 +2685,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "6428ae98-2506-4a58-b7b3-687e48b0dd25",
+                                    "id": "84bd4260-60f0-41d3-87fd-6cc67fcf7eab",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2739,11 +2739,11 @@
             "event": []
         },
         {
-            "id": "31d2a1af-1673-4349-993f-39cf40f6cb9f",
+            "id": "73a7c2ce-3335-4d2a-921b-2e94df5058d8",
             "name": "checks",
             "item": [
                 {
-                    "id": "38ef6e52-4e66-4a50-8a8c-6bfb63bfad07",
+                    "id": "a99d2d99-a922-4503-b92e-5dfc3d601394",
                     "name": "List all checks",
                     "request": {
                         "name": "List all checks",
@@ -2791,7 +2791,7 @@
                     },
                     "response": [
                         {
-                            "id": "853eda7e-f259-4370-9de0-832025467aee",
+                            "id": "32a26fb8-d7de-4922-a403-9899c1fb2434",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -2855,7 +2855,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b573a1e4-9350-40d6-9e45-018eb9305437",
+                            "id": "d01950d5-6458-4516-a127-026d4cc088fc",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2922,7 +2922,7 @@
                     "event": []
                 },
                 {
-                    "id": "7e7d7966-d5e5-4818-8024-d54e74774996",
+                    "id": "c2ae4d48-3817-495d-a82c-5b21e3f2e0ea",
                     "name": "Creates a new check",
                     "request": {
                         "name": "Creates a new check",
@@ -2992,7 +2992,7 @@
                     },
                     "response": [
                         {
-                            "id": "e0cab48a-d60d-414d-a65d-3cdc03b278ea",
+                            "id": "8979a92c-b346-47ce-a01b-be4b599d8cf0",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -3164,7 +3164,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "42e4b48c-3814-45bc-8cdb-eb846e8c9860",
+                            "id": "3bb20f53-7d25-4f4b-b146-051970af161c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3321,11 +3321,11 @@
                     "event": []
                 },
                 {
-                    "id": "2d3a9ae7-4a73-416a-8c99-0671f3227798",
+                    "id": "42919fa1-c65e-4a02-8e81-866aaa2c086b",
                     "name": "{chk id}",
                     "item": [
                         {
-                            "id": "cac90bd5-c230-4a5f-b86f-f0a792f0a99c",
+                            "id": "ad2fae24-7f9e-4036-b49d-caaaa7394e6d",
                             "name": "Retrieve check with given id",
                             "request": {
                                 "name": "Retrieve check with given id",
@@ -3357,7 +3357,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "a4ed7414-4c7e-46a4-a076-02a7f8f30454",
+                                    "id": "fc5b1732-cbf6-42cd-a6bd-c17381cbd459",
                                     "name": "Returns a check object",
                                     "originalRequest": {
                                         "url": {
@@ -3420,7 +3420,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ed2b33af-96c7-4278-be44-d0d09cd6044a",
+                                    "id": "bfc8214d-5f79-41fd-b797-051fcf8fded9",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3468,7 +3468,7 @@
                             "event": []
                         },
                         {
-                            "id": "cabcf970-2e8a-4880-8c2d-a2a4807a5741",
+                            "id": "12fbb471-5fa9-4d14-a03f-81611897e7d3",
                             "name": "Cancel a check",
                             "request": {
                                 "name": "Cancel a check",
@@ -3500,7 +3500,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "f0aa6ffe-83fb-4b6d-b62c-284988cc29e3",
+                                    "id": "98ecf960-6448-4b86-8e77-0961c508b503",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -3545,7 +3545,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "3a9b37d7-a262-429c-b7de-da76371579e2",
+                                    "id": "49190226-108a-4843-babb-7a6b06b4c299",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3599,7 +3599,7 @@
             "event": []
         },
         {
-            "id": "d50b4d3b-2739-4b64-a99d-66bb3b0cfb50",
+            "id": "7c32db25-a0c9-41f2-ac79-aa041c0c4b2a",
             "name": "Verify an international (except US or US territories) address with a live API key.",
             "request": {
                 "name": "Verify an international (except US or US territories) address with a live API key.",
@@ -3674,7 +3674,7 @@
             },
             "response": [
                 {
-                    "id": "cf109043-fdd9-46d9-99a3-97ff9629eb46",
+                    "id": "06f49cf7-02b1-4fd8-ac36-6703b4e4f407",
                     "name": "Returns an international verification object.",
                     "originalRequest": {
                         "url": {
@@ -3776,7 +3776,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "82c1eb0c-16f3-4689-9507-f68a92feff68",
+                    "id": "72329955-1e2b-42af-ae42-c768de17839c",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -3863,11 +3863,11 @@
             "event": []
         },
         {
-            "id": "fb0ff9e4-4e86-454b-95bc-a036479eef47",
+            "id": "719ced7b-dae9-4e14-bb6c-b0307677a1f2",
             "name": "letters",
             "item": [
                 {
-                    "id": "f1fd16a0-39e0-426f-a931-934cba37d1d3",
+                    "id": "553a54fd-c908-4713-818c-10c051cf11fc",
                     "name": "List all letters",
                     "request": {
                         "name": "List all letters",
@@ -3915,7 +3915,7 @@
                     },
                     "response": [
                         {
-                            "id": "8917b87f-2338-47ba-960a-3b8d32e4a513",
+                            "id": "f56f0860-1b91-4148-98fd-e6e45cb82f50",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3979,7 +3979,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e544b2a9-ab7e-4c42-8da0-e47cc7367038",
+                            "id": "f06166ee-621a-4310-97bc-7ff90e2e909b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4046,7 +4046,7 @@
                     "event": []
                 },
                 {
-                    "id": "79e67ada-dfbb-445b-8566-4897c62bd9e5",
+                    "id": "80899b0d-52bb-45b5-8bfe-6b9744954977",
                     "name": "Creates a new letter object",
                     "request": {
                         "name": "Creates a new letter object",
@@ -4141,7 +4141,7 @@
                     },
                     "response": [
                         {
-                            "id": "e90567ba-b2c4-432d-a23f-67c130af4e84",
+                            "id": "c89918f2-435f-40cf-9101-a6a6e7862f1d",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -4273,7 +4273,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "12107b33-80fd-498a-a0ad-eed386ff3850",
+                            "id": "03083467-fe49-4613-a692-63007a75c241",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4390,11 +4390,11 @@
                     "event": []
                 },
                 {
-                    "id": "70052906-8da6-4a0d-8bd2-26cb16bb3153",
+                    "id": "6c139df5-b063-4ece-a927-81dfce9c2044",
                     "name": "{ltr id}",
                     "item": [
                         {
-                            "id": "06726fa1-0d6e-44cb-953a-768ff985782f",
+                            "id": "22b250e1-1dcf-437c-ba4f-05f4b50faced",
                             "name": "Retrieve letter with given id",
                             "request": {
                                 "name": "Retrieve letter with given id",
@@ -4426,7 +4426,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "a13fd61f-a6fb-4374-94ab-f82a08fe5c47",
+                                    "id": "cf5c2b10-964c-4279-9caa-cec174763b45",
                                     "name": "Returns a letter object",
                                     "originalRequest": {
                                         "url": {
@@ -4489,7 +4489,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c8043bff-916d-4d5b-a848-7a220bffd908",
+                                    "id": "bb510ede-a1c2-4f35-9f41-69d761d04e1e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4537,7 +4537,7 @@
                             "event": []
                         },
                         {
-                            "id": "5380451a-fa5d-4c93-9dcd-7c87e2df39ff",
+                            "id": "ec777dfe-e431-4677-9170-183cd607a56c",
                             "name": "Cancel a letter",
                             "request": {
                                 "name": "Cancel a letter",
@@ -4569,7 +4569,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b6e4da88-dfa5-4dbd-a023-3eb7d841dbaf",
+                                    "id": "8163f85c-38b9-4a5f-abba-6d37c1d419f4",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -4614,7 +4614,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "344ea00e-cd24-4b5e-b94e-f65f2c55251d",
+                                    "id": "62ccc953-528a-4bfd-a647-1c704ec41437",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4668,11 +4668,11 @@
             "event": []
         },
         {
-            "id": "90908ad4-6274-4830-9d34-c430c534af0b",
+            "id": "d91a8356-e3fb-4bea-96c3-8532353d9bf9",
             "name": "postcards",
             "item": [
                 {
-                    "id": "6caf0e42-bf26-418a-8df7-2bde94c16831",
+                    "id": "c592605c-9be4-43f8-8cd3-18940fa289d6",
                     "name": "List all postcards",
                     "request": {
                         "name": "List all postcards",
@@ -4720,7 +4720,7 @@
                     },
                     "response": [
                         {
-                            "id": "014f452e-5a63-4a4c-9d31-1a5df91c696e",
+                            "id": "1540f326-d6fa-4bc5-80cd-1bcd6ee2588b",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -4784,7 +4784,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "35caf100-b7de-4297-b228-a430db171f76",
+                            "id": "304a06e9-21c1-4336-bf54-21a984779ebe",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4851,7 +4851,7 @@
                     "event": []
                 },
                 {
-                    "id": "75936cda-5d75-4d3c-8b6f-ce862fd41dd8",
+                    "id": "6c97df80-deb7-4fde-800a-94050d22a21c",
                     "name": "Creates a new postcard object",
                     "request": {
                         "name": "Creates a new postcard object",
@@ -4921,7 +4921,7 @@
                     },
                     "response": [
                         {
-                            "id": "eff4fe96-88ef-4abd-8bfd-12921b4aab2d",
+                            "id": "78c373d1-5a89-40e8-8a42-e605f7e31562",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -5028,7 +5028,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e2a2a981-45df-4a57-8b89-bac35069fee0",
+                            "id": "7eaf2098-8bd7-4f8d-bd99-1493b33a4c48",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5120,11 +5120,11 @@
                     "event": []
                 },
                 {
-                    "id": "73565c35-7490-4be9-8a1c-65f51fd84e08",
+                    "id": "04b49ed0-2331-4a82-9f1b-164370e4585c",
                     "name": "{psc id}",
                     "item": [
                         {
-                            "id": "f6c910d3-130d-4236-a75c-074c873e679e",
+                            "id": "804a81ac-0015-4e34-b718-57093c5fea5d",
                             "name": "Retrieve postcard with given id",
                             "request": {
                                 "name": "Retrieve postcard with given id",
@@ -5156,7 +5156,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "8b4adb97-35cd-4aa3-9b33-084705ca9594",
+                                    "id": "e98dc66c-a2fe-4928-bdfa-3f67c2a83063",
                                     "name": "Returns a postcard object",
                                     "originalRequest": {
                                         "url": {
@@ -5219,7 +5219,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "63147719-a067-4c85-8e1e-97cf81169d3b",
+                                    "id": "a56d4525-9de8-4626-9084-f8ba53821bf9",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5267,7 +5267,7 @@
                             "event": []
                         },
                         {
-                            "id": "12a411d8-320c-4d4a-8dba-692b643121a8",
+                            "id": "6be12614-c9d6-40e2-a05b-3e2525a2a455",
                             "name": "Cancels postcard with given id",
                             "request": {
                                 "name": "Cancels postcard with given id",
@@ -5299,7 +5299,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "bcfd17b5-ad34-44ae-b7e3-0f5d67804679",
+                                    "id": "ded206be-cd3b-4e7e-869a-30dec50508de",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -5344,7 +5344,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "2778d43c-51f5-4ddd-9336-6c7879cb8627",
+                                    "id": "3d4498a4-97fb-4446-b044-6c274f048f0e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5398,11 +5398,11 @@
             "event": []
         },
         {
-            "id": "ecb900e8-9ea0-4e4f-909c-4dec0804fd64",
+            "id": "a6630eec-119e-4c63-ac3e-4c9649fc9b16",
             "name": "self mailers",
             "item": [
                 {
-                    "id": "61a94014-a505-466d-9118-04ccccde98e6",
+                    "id": "759563ad-1232-4fc3-868e-eb4751349b60",
                     "name": "List all self_mailers",
                     "request": {
                         "name": "List all self_mailers",
@@ -5450,7 +5450,7 @@
                     },
                     "response": [
                         {
-                            "id": "dd0ba412-3f6e-478f-8aa8-c38c36357797",
+                            "id": "9e6c27b0-c796-477f-be54-d1b29f562f28",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -5532,7 +5532,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5fd62ab5-1c87-4ac2-bf38-4850f3c0f208",
+                            "id": "c6e76727-3393-43fe-90ab-a14a538a348b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5599,7 +5599,7 @@
                     "event": []
                 },
                 {
-                    "id": "444c62ce-cd74-4f05-be48-62b0406c1217",
+                    "id": "01d2c5cd-fdc2-4172-8190-b14f31130b5b",
                     "name": "Creates a new self_mailer object",
                     "request": {
                         "name": "Creates a new self_mailer object",
@@ -5669,7 +5669,7 @@
                     },
                     "response": [
                         {
-                            "id": "a60cab73-f424-42cf-b0ff-99010465bbc1",
+                            "id": "e750a0e1-12e2-421a-9843-b137cd13d5a7",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -5776,7 +5776,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cf6eae90-c54c-43cf-b2a7-e9ae6ede45cb",
+                            "id": "28b67039-f4ec-4c01-9861-6815c2e1a55e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5868,11 +5868,11 @@
                     "event": []
                 },
                 {
-                    "id": "a6392b39-109b-4f17-a76f-8938b697a243",
+                    "id": "e1a5c2e6-bb28-4963-a49b-b45a04dc3329",
                     "name": "{sfm id}",
                     "item": [
                         {
-                            "id": "0404e77d-9c1d-419e-b605-9a3e0c6201fc",
+                            "id": "d4e87698-c5ea-439d-8dee-9fb9b89b70da",
                             "name": "Retrieve self_mailer with given id",
                             "request": {
                                 "name": "Retrieve self_mailer with given id",
@@ -5904,7 +5904,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "5c029547-42e5-4ad3-a713-9b89b290ea06",
+                                    "id": "964eb2fa-39e1-4bb4-95ff-b2fed3df214b",
                                     "name": "Returns a self_mailer object",
                                     "originalRequest": {
                                         "url": {
@@ -5967,7 +5967,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "653a44cb-687c-411f-830b-e8815167cef0",
+                                    "id": "6271a23a-4667-49bf-80e6-acd1204f6c9e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6015,7 +6015,7 @@
                             "event": []
                         },
                         {
-                            "id": "af2f55e4-9570-49e0-93d3-8697968d621e",
+                            "id": "2878b2d9-9bb8-41ae-a37d-7e0d3f663191",
                             "name": "Deletes self_mailer with given id",
                             "request": {
                                 "name": "Deletes self_mailer with given id",
@@ -6047,7 +6047,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d2b5e207-db0e-41a9-b64b-929dd77d6a62",
+                                    "id": "27179717-148f-4629-bc77-a72860726701",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -6092,7 +6092,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a358788e-3258-4e26-b9fd-83b325ae3764",
+                                    "id": "1568bcc9-dc30-4c4c-8a5f-37569b06699e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6146,11 +6146,11 @@
             "event": []
         },
         {
-            "id": "fc5d6e00-60e1-46eb-b60d-45822331c9f2",
+            "id": "ca8d669a-8daf-4abe-874c-a367250448a2",
             "name": "templates",
             "item": [
                 {
-                    "id": "f4289b77-880f-49ee-ba76-4842c4560115",
+                    "id": "8aba7330-11dc-494f-8209-4dc1ec86aac9",
                     "name": "List all templates",
                     "request": {
                         "name": "List all templates",
@@ -6198,7 +6198,7 @@
                     },
                     "response": [
                         {
-                            "id": "675ded51-f4bb-4883-bdce-1a1d37482931",
+                            "id": "e9adfb22-2976-44c1-ab12-1a21dfdd966e",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -6280,7 +6280,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "292363c9-c9d9-4e19-8320-7aa94a247664",
+                            "id": "b7b6b14f-0ba3-49b5-b75c-59849fc522a0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6347,7 +6347,7 @@
                     "event": []
                 },
                 {
-                    "id": "6a9b71f9-3f22-41e3-8654-00f343251220",
+                    "id": "0abe5558-626b-4c81-91eb-322824a87aa2",
                     "name": "Creates a new template object",
                     "request": {
                         "name": "Creates a new template object",
@@ -6398,7 +6398,7 @@
                     },
                     "response": [
                         {
-                            "id": "04f131c1-87dc-41b3-8854-97d2ec664095",
+                            "id": "a7137ee3-29fd-4eca-9fe2-b54b28f3f51e",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -6489,7 +6489,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0a4e671e-e9c5-4d64-8489-93420498f855",
+                            "id": "f579abe8-6b83-432d-9fb5-2f8cbb42040c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6565,11 +6565,11 @@
                     "event": []
                 },
                 {
-                    "id": "7dc7cbe3-c0f8-4ab1-8d94-9c9d38d917d5",
+                    "id": "fe706776-bc52-4e73-ba1f-a653090a54e7",
                     "name": "{tmpl id}",
                     "item": [
                         {
-                            "id": "92bddb54-69d5-4f5a-9ec8-89c1c15143e5",
+                            "id": "b01a0ab6-fd05-41e1-8567-68653cf4b45c",
                             "name": "Retrieve template with given id",
                             "request": {
                                 "name": "Retrieve template with given id",
@@ -6601,7 +6601,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "61a8bd29-36c6-425d-97dc-89e899e178bc",
+                                    "id": "a4f44ec4-6849-4bcc-a58f-5aa2e1725ea7",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6664,7 +6664,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "369572a3-cd3c-400e-b98d-51feb4102090",
+                                    "id": "229a7f2a-1c40-4c8a-8eb3-96554e776a1f",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6712,7 +6712,7 @@
                             "event": []
                         },
                         {
-                            "id": "2870b23d-afbd-4e66-b73c-620e596e3c46",
+                            "id": "2371b6fb-8c11-4cf0-afda-1f6ae7bf24b8",
                             "name": "Update description and/or published version of a template.",
                             "request": {
                                 "name": "Update description and/or published version of a template.",
@@ -6771,7 +6771,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "3b3947b8-e196-49e8-9f64-78b388ba6123",
+                                    "id": "31ea02fe-1b47-426f-b7f0-b65eb7e6a610",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6854,7 +6854,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f6053ba0-35c5-4eae-9e83-f5510d51d4e8",
+                                    "id": "bd6b5368-46be-4c61-9d27-b0c1c594d7ae",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6922,7 +6922,7 @@
                             "event": []
                         },
                         {
-                            "id": "74806993-ec9c-41ed-a117-612c293ed504",
+                            "id": "72f36b9d-81ca-4b8d-b659-1b614b9110f6",
                             "name": "Deletes template with given id",
                             "request": {
                                 "name": "Deletes template with given id",
@@ -6954,7 +6954,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0604f472-75d0-4b03-ac6f-6913fd3606d4",
+                                    "id": "233a2dab-fb7f-44a8-8662-a769cee3b86c",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -6999,7 +6999,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "b0ab179f-18b4-4ea5-9a92-1c76f8c91b18",
+                                    "id": "b1fbb9d5-1832-4b04-8e32-227ab05b0ec2",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -7047,11 +7047,11 @@
                             "event": []
                         },
                         {
-                            "id": "d09e573b-67de-43b8-9694-a754dd727e7f",
+                            "id": "a7b16b3c-33a4-4960-9ca9-4d3801260c05",
                             "name": "versions",
                             "item": [
                                 {
-                                    "id": "7cd29964-6b30-458b-b901-0651b37f9d12",
+                                    "id": "e66c83ec-bcf2-48c7-b86d-4b138b20ee7c",
                                     "name": "List all template_versions",
                                     "request": {
                                         "name": "List all template_versions",
@@ -7109,7 +7109,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "a2d12c49-7a3f-46bf-b0f2-f4b6001e60e9",
+                                            "id": "93d4a8f0-8cb8-47dc-99eb-a647fc195505",
                                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                                             "originalRequest": {
                                                 "url": {
@@ -7190,7 +7190,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "160efb19-f6bf-4f7f-bff2-d90c740f83a8",
+                                            "id": "14ecf849-0615-4103-9f11-2e8c097e7f3a",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -7256,7 +7256,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "6a40a0f1-cac1-4325-ba30-43bdc914d7f1",
+                                    "id": "9cf972b6-d1b9-49cd-9837-e9588c67fd7b",
                                     "name": "Creates a new template_version object",
                                     "request": {
                                         "name": "Creates a new template_version object",
@@ -7317,7 +7317,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "e1c0eb61-80cf-4e09-b499-1033560cb320",
+                                            "id": "1150efe4-1564-4e0a-b499-a31ce48be45d",
                                             "name": "Returns the template version with the given template and version ids.",
                                             "originalRequest": {
                                                 "url": {
@@ -7405,7 +7405,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "ff148fd4-53a0-4c91-b5e7-3a0f98346530",
+                                            "id": "31c94b82-040e-44e6-aaef-329d3ff2819a",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -7478,11 +7478,11 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "e00dd96f-f182-4862-abf1-f750ef6021d1",
+                                    "id": "7d65f730-dd85-4428-8719-565992eaa2fc",
                                     "name": "{vrsn id}",
                                     "item": [
                                         {
-                                            "id": "c39cb07d-d465-4f0f-af8e-5dbc49e6ee07",
+                                            "id": "660b5627-6bfd-4a2b-a117-f4d999d3e763",
                                             "name": "Retrieve template version with given template and version ids.",
                                             "request": {
                                                 "name": "Retrieve template version with given template and version ids.",
@@ -7523,7 +7523,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "fec30fdc-c145-4712-bc29-b7bff9bee6c1",
+                                                    "id": "128dab66-7f0c-47d7-bf90-013aa6f640fe",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7592,7 +7592,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "7faee87b-e723-46c8-ba20-d384425ac277",
+                                                    "id": "0afddc90-7ec5-4d62-928d-8f39d4824901",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7646,7 +7646,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "b1370e8f-6be7-4f68-b565-17cfca6845ad",
+                                            "id": "1befa0ad-30d2-48dc-9624-3cad7cd62042",
                                             "name": "Updates the template version with given template and version ids.",
                                             "request": {
                                                 "name": "Updates the template version with given template and version ids.",
@@ -7709,7 +7709,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "a2404650-3cf4-4b38-b5e6-4cae16240a48",
+                                                    "id": "8d5f2c9b-1aaa-4738-ad94-e3acd58cac93",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7793,7 +7793,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "73b7cca1-c148-4f7f-b542-5886b45013d4",
+                                                    "id": "8c3164c1-d61a-4c53-b151-2976865117c9",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7862,7 +7862,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "d70bd87b-93be-406a-85fd-12c0327be371",
+                                            "id": "cc95d333-32ec-421a-9860-e5de72e807e1",
                                             "name": "Deletes the template version with given template and version ids if possible.",
                                             "request": {
                                                 "name": "Deletes the template version with given template and version ids if possible.",
@@ -7903,7 +7903,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "71f0477e-0ec1-4c2f-9a48-8626f75e8605",
+                                                    "id": "7063d976-f29e-4ae6-8e48-2961d65fcc0b",
                                                     "name": "Returns true if the delete was successful",
                                                     "originalRequest": {
                                                         "url": {
@@ -7954,7 +7954,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "b4ca689a-173a-4c40-9788-35b55d87d90f",
+                                                    "id": "2b302670-fdf1-45f3-a33f-498df3843cf8",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -8014,7 +8014,7 @@
                             "event": []
                         },
                         {
-                            "id": "a494842d-4137-4dd9-865f-ca3545a32f80",
+                            "id": "be3d5903-dc9d-438c-a058-d2c5ad7641e8",
                             "name": "Compile the template into html",
                             "request": {
                                 "name": "Compile the template into html",
@@ -8060,7 +8060,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "5790ef0f-e0a1-4511-956a-9d3c71fa48e4",
+                                    "id": "50e14a89-6d54-45f9-922b-f214ce8b88be",
                                     "name": "Returns the compiled html",
                                     "originalRequest": {
                                         "url": {
@@ -8115,7 +8115,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "96777342-7cb7-4c5b-ac9a-0a0487396e39",
+                                    "id": "666b7500-7a6d-49f0-ad3a-7ff684bd8e29",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -8179,7 +8179,7 @@
             "event": []
         },
         {
-            "id": "0b47c5b8-2d0a-44f2-b5e1-41f525737e8c",
+            "id": "ddc0f6f9-73d5-426c-89ba-2ab5ec47ecdf",
             "name": "Autocomplete a partial US address.",
             "request": {
                 "name": "Autocomplete a partial US address.",
@@ -8243,7 +8243,7 @@
             },
             "response": [
                 {
-                    "id": "8adaeab3-3870-4141-b53e-a58ee7d966bb",
+                    "id": "d685178f-2b85-48dd-bf8f-a39ddd6f765b",
                     "name": "Returns a US autocompletion object.",
                     "originalRequest": {
                         "url": {
@@ -8349,7 +8349,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "437fe853-7689-40fc-867f-17402a32bb6d",
+                    "id": "3cc323e7-2f8d-4b3f-8e27-585473b051a1",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8440,7 +8440,7 @@
             "event": []
         },
         {
-            "id": "64ae3678-ad68-4f18-a6bb-e473db1cfa61",
+            "id": "89dbdaa7-eeed-46b9-bbaf-fff6c82d6ef0",
             "name": "Verify a US or US territory address with a live API key.",
             "request": {
                 "name": "Verify a US or US territory address with a live API key.",
@@ -8480,7 +8480,7 @@
             },
             "response": [
                 {
-                    "id": "a67d9adc-2086-4dc0-9448-846a5febb15d",
+                    "id": "e33a361a-bcba-4aff-99cf-16f5cca0dcda",
                     "name": "Returns a US verification object.",
                     "originalRequest": {
                         "url": {
@@ -8545,7 +8545,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "7c615e0c-c30c-4a98-bd03-fb24eb63ed96",
+                    "id": "c5a3da3b-4fc0-4b3b-ad9f-dbda5b4b1dc9",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8595,7 +8595,7 @@
             "event": []
         },
         {
-            "id": "c11a73a0-5d4e-4661-ae11-f750a19599b9",
+            "id": "9fe9cda2-ad71-4524-ac6a-0b78004723da",
             "name": "Looks up information pertaining to a given ZIP code",
             "request": {
                 "name": "Looks up information pertaining to a given ZIP code",
@@ -8635,7 +8635,7 @@
             },
             "response": [
                 {
-                    "id": "5bf6f003-b488-4ca8-b815-37c7170b2e22",
+                    "id": "6230ba35-a541-4ee5-bcea-a6464d26ef84",
                     "name": "Returns a zip lookup object if a valid zip was provided.",
                     "originalRequest": {
                         "url": {
@@ -8700,12 +8700,12 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"e\",\n   \"county\": \"voluptate non consequat culpa\",\n   \"county_fips\": \"23285\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"fu\",\n   \"county\": \"irure tempor sed id\",\n   \"county_fips\": \"38681\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"military\"\n}",
+                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"e\",\n   \"county\": \"in officia nisi voluptate eiusmod\",\n   \"county_fips\": \"23445\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"\",\n   \"county\": \"in ut Ut ipsum anim\",\n   \"county_fips\": \"36335\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"\"\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "d8ee385b-880b-46e1-b909-abb55df8f41a",
+                    "id": "47779859-e95f-4010-b3b4-ed20833763e5",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8782,7 +8782,7 @@
         ]
     },
     "info": {
-        "_postman_id": "6fc15a42-24df-4224-9598-90acdeccd255",
+        "_postman_id": "a223a2ea-bac4-4f93-9e83-47dc057ad8d0",
         "name": "Lob API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/dist/Lob-API-postman.json
+++ b/dist/Lob-API-postman.json
@@ -1,11 +1,11 @@
 {
     "item": [
         {
-            "id": "87d5aa0f-63bd-4484-a6ec-e4a37123bf01",
+            "id": "5febad24-b752-40e7-815b-0cea9bd38f8e",
             "name": "addresses",
             "item": [
                 {
-                    "id": "3f62eb5c-5ea3-4679-9a9e-b5d37ecdb528",
+                    "id": "58dbdaac-7092-428c-a8eb-5425741c82f2",
                     "name": "List all addresses",
                     "request": {
                         "name": "List all addresses",
@@ -53,7 +53,7 @@
                     },
                     "response": [
                         {
-                            "id": "4b3d64e0-9707-441c-9001-401ebdf3ad1c",
+                            "id": "9c1a1273-bdac-4a23-ba7c-4a88100ac997",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -117,7 +117,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5e6c55cb-296c-40a8-bbb1-cdfcf3d2f178",
+                            "id": "2e158f80-c640-4288-b3fb-d260def2d462",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -184,7 +184,7 @@
                     "event": []
                 },
                 {
-                    "id": "1c624feb-ba97-4609-9aa0-2d77cb10744e",
+                    "id": "59b9c474-8b6e-41ef-bbf3-18cf5c478f6f",
                     "name": "Creates a new address object",
                     "request": {
                         "name": "Creates a new address object",
@@ -254,7 +254,7 @@
                     },
                     "response": [
                         {
-                            "id": "82899602-ea97-465e-810c-3f8ce7db1528",
+                            "id": "86530447-2954-41ec-91e3-a99e6b1fee8b",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -351,7 +351,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5b14d2d3-2a7c-432a-9f1e-cb36a5046dc2",
+                            "id": "42f43ae2-e030-4f9d-b18c-a14411470852",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -433,11 +433,11 @@
                     "event": []
                 },
                 {
-                    "id": "c6684796-887c-47b2-a6b1-f06b09b99fbf",
+                    "id": "ed68da01-e818-4083-9ee7-e29ef32c13b5",
                     "name": "{adr id}",
                     "item": [
                         {
-                            "id": "45c39def-3723-4cdf-8d8f-f3776db537b0",
+                            "id": "cebabcb7-be29-4127-b1c2-f41e13719bb3",
                             "name": "Retrieve address with given id",
                             "request": {
                                 "name": "Retrieve address with given id",
@@ -469,7 +469,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4700206c-911c-4791-8887-b6eda3bffa81",
+                                    "id": "e04c34b5-7f56-4542-8a17-1dca48787b99",
                                     "name": "Returns an address object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -527,12 +527,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_country\": \"UNITED STATES\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"1997-05-17T20:22:18.245Z\",\n \"date_modified\": \"1974-01-13T18:23:03.183Z\",\n \"id\": \"<string>\",\n \"object\": \"address\",\n \"address_line2\": \"<string>\",\n \"deleted\": false,\n \"recipient_moved\": true\n}",
+                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_country\": \"UNITED STATES\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"1984-07-03T05:39:34.261Z\",\n \"date_modified\": \"2010-12-25T01:15:30.424Z\",\n \"id\": \"<string>\",\n \"object\": \"address\",\n \"address_line2\": \"<string>\",\n \"deleted\": true,\n \"recipient_moved\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a3314d85-53fa-4465-8d0a-bbc4b9d061ad",
+                                    "id": "512fcaa0-5239-43ad-aedf-8c182d4bdfa0",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -580,7 +580,7 @@
                             "event": []
                         },
                         {
-                            "id": "3025ee2d-f53e-4726-b0e9-68164dfa73ae",
+                            "id": "7f9dbd09-5956-4a52-a8a8-8d8cc8609d01",
                             "name": "Deletes address with given id",
                             "request": {
                                 "name": "Deletes address with given id",
@@ -612,7 +612,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4907a971-e255-49ba-88bd-172923177390",
+                                    "id": "efab51f2-724b-4c72-ae97-7619910a5027",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -652,12 +652,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "01cd2b69-b4c8-4460-85dc-fd0732016d02",
+                                    "id": "028df7df-2511-4930-8cd0-27f37633b8ca",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -711,11 +711,11 @@
             "event": []
         },
         {
-            "id": "55eabf61-ea45-4f7f-99b7-d4df001f7cce",
+            "id": "529ade02-f000-4a54-8104-063ffb107665",
             "name": "bank accounts",
             "item": [
                 {
-                    "id": "1ac6d072-c178-4425-96bc-fa46f62f0e1e",
+                    "id": "df0cae11-3620-4f99-a68a-ccb3a7b53f6e",
                     "name": "List all bank_accounts",
                     "request": {
                         "name": "List all bank_accounts",
@@ -763,7 +763,7 @@
                     },
                     "response": [
                         {
-                            "id": "ebabe5d1-0305-4158-99f9-460c638a93c7",
+                            "id": "03aa5886-cade-47a7-959d-54c4f918056d",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -827,7 +827,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "02e966ae-7db9-477c-b18a-6d7ea00b6e09",
+                            "id": "741d4773-35bd-4551-ab3b-1470e2a3e981",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -894,7 +894,7 @@
                     "event": []
                 },
                 {
-                    "id": "29f0e61b-e746-46a5-a139-8d1ced09d5a9",
+                    "id": "e44d707a-b583-4344-a8e8-3a45afd388b5",
                     "name": "Creates a new bank_account",
                     "request": {
                         "name": "Creates a new bank_account",
@@ -969,7 +969,7 @@
                     },
                     "response": [
                         {
-                            "id": "7b0dd5c0-2d32-40fb-8703-65f550dab428",
+                            "id": "7f7a99f6-fda0-40d5-a912-fee780dfcf8b",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1081,7 +1081,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4296df05-478c-4f50-b0b4-426c101e51f4",
+                            "id": "f49a92a8-c84e-4a5c-b209-f8080de62e7b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1178,11 +1178,11 @@
                     "event": []
                 },
                 {
-                    "id": "54ade743-fa0f-46df-9f1d-46386599a431",
+                    "id": "88d15741-8422-447c-a462-dd0875756f6f",
                     "name": "{bank id}",
                     "item": [
                         {
-                            "id": "42a7932c-fe7a-4705-a3fd-898113e47150",
+                            "id": "6cafb6f4-4f49-4672-a91a-7f353d18f19d",
                             "name": "Retrieve bank_account with given id",
                             "request": {
                                 "name": "Retrieve bank_account with given id",
@@ -1214,7 +1214,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "7f8601ce-15b8-424a-a6a8-36b79aa37f9e",
+                                    "id": "45c1b476-d454-41a4-b201-34507e958f25",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1277,7 +1277,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "0d830a36-09e0-4ffd-8f39-d454a158fd06",
+                                    "id": "c56633d3-cd77-4c59-84b4-0d4a058c6dd4",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1325,7 +1325,7 @@
                             "event": []
                         },
                         {
-                            "id": "9ecabbd7-58ab-4b39-ac2b-30245007ad06",
+                            "id": "15108ba1-ef0b-4a8f-9f46-ada9596bc06c",
                             "name": "Delete a bank_account",
                             "request": {
                                 "name": "Delete a bank_account",
@@ -1357,7 +1357,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0e218675-4955-4827-9ca4-7f250f768c6f",
+                                    "id": "0ab0fa48-94d3-4798-a4cc-76f70bf5d283",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -1397,12 +1397,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "01289139-531e-4118-a79f-a4bd0f8b6dc7",
+                                    "id": "5e9893f1-f94c-41fb-bdc6-0f70c2e75046",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1450,7 +1450,7 @@
                             "event": []
                         },
                         {
-                            "id": "ab9ab952-e200-4b04-ae91-8c66b398b190",
+                            "id": "eb3c9685-4bc7-46bc-ae5f-cc4e5b6ca0cf",
                             "name": "Verify a bank account",
                             "request": {
                                 "name": "Verify a bank account",
@@ -1512,7 +1512,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b68939fe-85ee-4058-91d9-39884517e8d8",
+                                    "id": "d0da975b-6a27-4fd8-937c-1d47e6f5cbd1",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1604,7 +1604,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "4a42ea06-cb7f-40cc-8611-1fca17e846d8",
+                                    "id": "ba5bdcbb-e437-46b3-8118-bf71f1dae5a4",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1687,11 +1687,11 @@
             "event": []
         },
         {
-            "id": "d48738b2-2ebd-4bad-8102-c8a83af9c78a",
+            "id": "afcf586b-1422-41c7-9a39-bfab7ef378f9",
             "name": "bulk",
             "item": [
                 {
-                    "id": "f71e4b7d-aa0b-4d28-a6d6-3cb08dda55bc",
+                    "id": "f335dd87-3113-4aab-9831-b74092f2ae0f",
                     "name": "Verify a list of US or US territory address with a live API key.",
                     "request": {
                         "name": "Verify a list of US or US territory address with a live API key.",
@@ -1732,7 +1732,7 @@
                     },
                     "response": [
                         {
-                            "id": "faa77b7a-3b63-4671-a220-43d404ab8415",
+                            "id": "e6e06ae9-dcdf-4f3d-a17f-0ba40c464d68",
                             "name": "Returns an US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -1798,7 +1798,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "23a6566d-817d-4b67-94da-38de1e7fd9df",
+                            "id": "49bf2664-ab32-4d0a-8c29-e732bc3f730a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1849,7 +1849,7 @@
                     "event": []
                 },
                 {
-                    "id": "093bca05-ba0f-40b3-8269-2cf940db3924",
+                    "id": "cf40620e-8c3a-4575-82c2-b793af743dd6",
                     "name": "Verify a list of international addresses with a live API key.",
                     "request": {
                         "name": "Verify a list of international addresses with a live API key.",
@@ -1883,7 +1883,7 @@
                     },
                     "response": [
                         {
-                            "id": "cc55a3fd-df50-4bbf-af8b-9579cc3e46cc",
+                            "id": "b8758637-e99b-47a1-83a9-e843d452698b",
                             "name": "Returns an array of international verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -1944,7 +1944,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4a55d0cb-0b8f-45a1-8b57-f88e6e402ae7",
+                            "id": "1166a631-e1e4-4179-a211-c2a5757d3e22",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1993,11 +1993,11 @@
             "event": []
         },
         {
-            "id": "b75bdfa7-5f4b-4089-adfe-948b137b3404",
+            "id": "b5407042-671d-4fc2-80ba-a85f38a1e4ea",
             "name": "certificates",
             "item": [
                 {
-                    "id": "c51adda8-0101-4865-8525-cfa629681f31",
+                    "id": "bf46d915-e250-429c-946c-d3c2e2f5cbf7",
                     "name": "List all certificates",
                     "request": {
                         "name": "List all certificates",
@@ -2020,7 +2020,7 @@
                     },
                     "response": [
                         {
-                            "id": "2d299576-9882-4bb8-881a-0efc2946f659",
+                            "id": "1f4596f3-71a3-4bc4-9f40-4d9a259a55a0",
                             "name": "List of all certificates. Will to add wording about plans for the future.",
                             "originalRequest": {
                                 "url": {
@@ -2054,12 +2054,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"ad tempor\",\n   \"date_created\": \"1983-12-01T01:16:20.260Z\",\n   \"date_modified\": \"2004-02-27T17:57:15.428Z\",\n   \"id\": \"cert_OAan5NDMllo\",\n   \"name\": \"quis aliqua aute dolor nisi\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"Wwdm4Qh\",\n   \"date_deleted\": \"1941-07-12T12:23:37.824Z\"\n  },\n  {\n   \"cert\": \"culpa consequat est dolore qui\",\n   \"date_created\": \"1958-12-10T15:36:16.407Z\",\n   \"date_modified\": \"1954-09-13T05:57:40.821Z\",\n   \"id\": \"cert_P\",\n   \"name\": \"minim nulla reprehenderit\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"lEWQOPhc\",\n   \"date_deleted\": \"1969-05-30T19:28:19.643Z\"\n  }\n ],\n \"count\": -25494438,\n \"object\": \"in pariatur irure sint\"\n}",
+                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"id dolor\",\n   \"date_created\": \"1982-10-15T22:22:05.257Z\",\n   \"date_modified\": \"1952-09-23T04:57:36.872Z\",\n   \"id\": \"cert_284B\",\n   \"name\": \"in\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": true,\n   \"account_id\": \"rYngeHjrQF\",\n   \"date_deleted\": \"1975-07-04T21:42:26.215Z\"\n  },\n  {\n   \"cert\": \"dolore velit\",\n   \"date_created\": \"2018-06-23T23:18:03.773Z\",\n   \"date_modified\": \"1954-07-23T09:12:00.857Z\",\n   \"id\": \"cert_M0BDsZO21oT\",\n   \"name\": \"Duis officia magna sunt occaecat\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"bnyxPz\",\n   \"date_deleted\": \"1972-05-20T19:58:31.841Z\"\n  }\n ],\n \"count\": -37845818,\n \"object\": \"exercitation Ut fugiat nisi\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2a1eabc5-292c-449c-84d6-b16ffc86461e",
+                            "id": "71208477-5fff-4dc7-9f97-9b0861d89cb4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2101,7 +2101,7 @@
                     "event": []
                 },
                 {
-                    "id": "e822b2dd-9869-43b0-bf61-ffa848292dd8",
+                    "id": "aff6e5d2-50d5-467d-a809-b74e17ab57c9",
                     "name": "Creates a new certificate object",
                     "request": {
                         "name": "Creates a new certificate object",
@@ -2145,7 +2145,7 @@
                                 {
                                     "disabled": false,
                                     "key": "name",
-                                    "value": "ipsum ea dolor",
+                                    "value": "Excepteur officia laborum",
                                     "description": "(Required) "
                                 },
                                 {
@@ -2158,7 +2158,7 @@
                     },
                     "response": [
                         {
-                            "id": "cf2a9cfe-1dc5-4b58-894c-ad9d260ae651",
+                            "id": "b84ad794-bbff-4b5f-a31b-d737d9dd7f17",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -2207,7 +2207,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "dolor adipisicing laboris Lorem deserunt"
+                                            "value": "mollit sunt"
                                         },
                                         {
                                             "disabled": false,
@@ -2225,12 +2225,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1954-08-10T08:25:28.422Z\",\n \"date_modified\": \"1950-06-13T23:52:24.163Z\",\n \"id\": \"cert_BN\",\n \"name\": \"in fugiat\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"rbb6cmy6\",\n \"date_deleted\": \"2009-03-10T14:41:51.115Z\"\n}",
+                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1957-04-03T08:48:08.900Z\",\n \"date_modified\": \"1963-01-29T23:04:05.752Z\",\n \"id\": \"cert_oGOj1ZacjV\",\n \"name\": \"officia in laborum\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"z\",\n \"date_deleted\": \"2008-03-10T15:10:24.938Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9570ad9c-6131-45da-bcbc-d6c9d9b13b17",
+                            "id": "e375508a-7acb-4f54-977d-0b69e25d6938",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2279,7 +2279,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "dolor adipisicing laboris Lorem deserunt"
+                                            "value": "mollit sunt"
                                         },
                                         {
                                             "disabled": false,
@@ -2305,11 +2305,11 @@
                     "event": []
                 },
                 {
-                    "id": "56e277aa-0a1d-410b-8d8d-238f46ad2ffd",
+                    "id": "33a4cd60-5f23-4bb0-9e49-f129a1eb74e6",
                     "name": "{id}",
                     "item": [
                         {
-                            "id": "b9e98fe2-702e-443a-81a0-14f7e797cc8a",
+                            "id": "4ded8691-b1c2-41bc-80cb-e08bf91201a5",
                             "name": "Retrieve certificate with given id",
                             "request": {
                                 "name": "Retrieve certificate with given id",
@@ -2330,7 +2330,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_7Q",
+                                            "value": "cert_Bk7tzM6BTz",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2341,7 +2341,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c6fedd0a-8715-4123-8d2f-a7523769b49d",
+                                    "id": "2a5a5529-2f97-4fea-832c-9cee73d3b552",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2381,12 +2381,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1954-08-10T08:25:28.422Z\",\n \"date_modified\": \"1950-06-13T23:52:24.163Z\",\n \"id\": \"cert_BN\",\n \"name\": \"in fugiat\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"rbb6cmy6\",\n \"date_deleted\": \"2009-03-10T14:41:51.115Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1957-04-03T08:48:08.900Z\",\n \"date_modified\": \"1963-01-29T23:04:05.752Z\",\n \"id\": \"cert_oGOj1ZacjV\",\n \"name\": \"officia in laborum\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"z\",\n \"date_deleted\": \"2008-03-10T15:10:24.938Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "fdbc9e5b-08cd-4046-be81-50c33f676416",
+                                    "id": "fa84c9b2-ea09-4b28-8573-d31afb158e4e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2434,7 +2434,7 @@
                             "event": []
                         },
                         {
-                            "id": "cc041ff5-967d-4cfa-a317-29111afc91e9",
+                            "id": "61189cea-ba5f-43cc-8f59-9a9612455397",
                             "name": "Update name and/or description of a certificate.",
                             "request": {
                                 "name": "Update name and/or description of a certificate.",
@@ -2455,7 +2455,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_7Q",
+                                            "value": "cert_Bk7tzM6BTz",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2475,7 +2475,7 @@
                                         {
                                             "disabled": false,
                                             "key": "name",
-                                            "value": "magna sunt"
+                                            "value": "quis ipsum enim"
                                         },
                                         {
                                             "disabled": false,
@@ -2487,7 +2487,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "f36a1e8e-81b9-43ce-be92-b77a6271c816",
+                                    "id": "4057e7ce-97fc-4fe0-ba37-9a3a0cd2dbbd",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2523,7 +2523,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "dolor mollit pariatur"
+                                                    "value": "elit ut"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2541,12 +2541,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1954-08-10T08:25:28.422Z\",\n \"date_modified\": \"1950-06-13T23:52:24.163Z\",\n \"id\": \"cert_BN\",\n \"name\": \"in fugiat\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"rbb6cmy6\",\n \"date_deleted\": \"2009-03-10T14:41:51.115Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1957-04-03T08:48:08.900Z\",\n \"date_modified\": \"1963-01-29T23:04:05.752Z\",\n \"id\": \"cert_oGOj1ZacjV\",\n \"name\": \"officia in laborum\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"z\",\n \"date_deleted\": \"2008-03-10T15:10:24.938Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "dc3f23c1-db1e-4103-ac57-3c35c8713a72",
+                                    "id": "03c272ec-c69d-4980-84ee-00bb5fdd385f",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2582,7 +2582,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "dolor mollit pariatur"
+                                                    "value": "elit ut"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2608,7 +2608,7 @@
                             "event": []
                         },
                         {
-                            "id": "f70106ae-83b6-42c8-a250-3b79e29fc814",
+                            "id": "d83a0f8e-a65f-43c5-a4cc-01ee9fd8d7fb",
                             "name": "Deletes certificate with given id",
                             "request": {
                                 "name": "Deletes certificate with given id",
@@ -2629,7 +2629,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_7Q",
+                                            "value": "cert_Bk7tzM6BTz",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2640,7 +2640,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "64dc5bd3-7c28-414a-b225-6c6f265dafda",
+                                    "id": "5ee9f336-b017-4171-b17a-24359baa4eb4",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -2680,12 +2680,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "84bd4260-60f0-41d3-87fd-6cc67fcf7eab",
+                                    "id": "2bd840d8-45a9-4d94-8972-f3a58000bc09",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2739,11 +2739,11 @@
             "event": []
         },
         {
-            "id": "73a7c2ce-3335-4d2a-921b-2e94df5058d8",
+            "id": "fd5997ee-5611-4a89-a0f3-7dded5567621",
             "name": "checks",
             "item": [
                 {
-                    "id": "a99d2d99-a922-4503-b92e-5dfc3d601394",
+                    "id": "fd6958ac-cfc4-48d6-8583-ff05be58b0c1",
                     "name": "List all checks",
                     "request": {
                         "name": "List all checks",
@@ -2791,7 +2791,7 @@
                     },
                     "response": [
                         {
-                            "id": "32a26fb8-d7de-4922-a403-9899c1fb2434",
+                            "id": "c57cf595-64c1-4884-97b1-6339f99756f0",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -2855,7 +2855,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d01950d5-6458-4516-a127-026d4cc088fc",
+                            "id": "89837f98-31f5-45a4-bd0f-1ce8eca459c5",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2922,7 +2922,7 @@
                     "event": []
                 },
                 {
-                    "id": "c2ae4d48-3817-495d-a82c-5b21e3f2e0ea",
+                    "id": "fbc2abcc-297b-46ac-a5d1-cd3edb8df31a",
                     "name": "Creates a new check",
                     "request": {
                         "name": "Creates a new check",
@@ -2992,7 +2992,7 @@
                     },
                     "response": [
                         {
-                            "id": "8979a92c-b346-47ce-a01b-be4b599d8cf0",
+                            "id": "777549f5-900e-4c45-8b27-a2c3ea003118",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -3164,7 +3164,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3bb20f53-7d25-4f4b-b146-051970af161c",
+                            "id": "71c1cb32-da9d-4031-9a5b-4fff82df08b7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3321,11 +3321,11 @@
                     "event": []
                 },
                 {
-                    "id": "42919fa1-c65e-4a02-8e81-866aaa2c086b",
+                    "id": "417bb5eb-e0cb-467a-a89b-d3a18f8aa05b",
                     "name": "{chk id}",
                     "item": [
                         {
-                            "id": "ad2fae24-7f9e-4036-b49d-caaaa7394e6d",
+                            "id": "aeb4e85e-c398-4841-9978-32267bdec4d9",
                             "name": "Retrieve check with given id",
                             "request": {
                                 "name": "Retrieve check with given id",
@@ -3357,7 +3357,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "fc5b1732-cbf6-42cd-a6bd-c17381cbd459",
+                                    "id": "1c9c35e2-cb49-4989-8ac1-fb8c1eebeb5d",
                                     "name": "Returns a check object",
                                     "originalRequest": {
                                         "url": {
@@ -3420,7 +3420,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "bfc8214d-5f79-41fd-b797-051fcf8fded9",
+                                    "id": "25f70c1b-dcd2-40d5-a572-9425780ef563",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3468,7 +3468,7 @@
                             "event": []
                         },
                         {
-                            "id": "12fbb471-5fa9-4d14-a03f-81611897e7d3",
+                            "id": "a0e6848f-9187-4835-8abf-f96459d3a3e9",
                             "name": "Cancel a check",
                             "request": {
                                 "name": "Cancel a check",
@@ -3500,7 +3500,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "98ecf960-6448-4b86-8e77-0961c508b503",
+                                    "id": "c4028952-1a72-48d4-b780-443e41e02b89",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -3540,12 +3540,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "49190226-108a-4843-babb-7a6b06b4c299",
+                                    "id": "6102791f-4d0f-4fef-afb6-4163a53dd185",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3599,7 +3599,7 @@
             "event": []
         },
         {
-            "id": "7c32db25-a0c9-41f2-ac79-aa041c0c4b2a",
+            "id": "e216a77e-aebd-427e-a449-c88df150fe82",
             "name": "Verify an international (except US or US territories) address with a live API key.",
             "request": {
                 "name": "Verify an international (except US or US territories) address with a live API key.",
@@ -3674,7 +3674,7 @@
             },
             "response": [
                 {
-                    "id": "06f49cf7-02b1-4fd8-ac36-6703b4e4f407",
+                    "id": "8ac7188e-df56-4c48-af76-94dfdaac7a9f",
                     "name": "Returns an international verification object.",
                     "originalRequest": {
                         "url": {
@@ -3776,7 +3776,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "72329955-1e2b-42af-ae42-c768de17839c",
+                    "id": "aacf5532-c931-4aec-b75f-d22a3e952567",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -3863,11 +3863,11 @@
             "event": []
         },
         {
-            "id": "719ced7b-dae9-4e14-bb6c-b0307677a1f2",
+            "id": "28500711-9f38-4a74-ab68-9eb16e53d7d9",
             "name": "letters",
             "item": [
                 {
-                    "id": "553a54fd-c908-4713-818c-10c051cf11fc",
+                    "id": "bc40b941-5ef1-471c-8929-57cfea2a47e4",
                     "name": "List all letters",
                     "request": {
                         "name": "List all letters",
@@ -3915,7 +3915,7 @@
                     },
                     "response": [
                         {
-                            "id": "f56f0860-1b91-4148-98fd-e6e45cb82f50",
+                            "id": "d7fca385-0f69-476f-9b1f-5251bd8afb1a",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3979,7 +3979,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f06166ee-621a-4310-97bc-7ff90e2e909b",
+                            "id": "2a5e0541-01a4-46af-bd68-ba31336614bd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4046,7 +4046,7 @@
                     "event": []
                 },
                 {
-                    "id": "80899b0d-52bb-45b5-8bfe-6b9744954977",
+                    "id": "16471df4-aea9-48c0-aa7f-f99a8c22e9aa",
                     "name": "Creates a new letter object",
                     "request": {
                         "name": "Creates a new letter object",
@@ -4141,7 +4141,7 @@
                     },
                     "response": [
                         {
-                            "id": "c89918f2-435f-40cf-9101-a6a6e7862f1d",
+                            "id": "fdc9204c-7883-4b59-b692-bc179b17a044",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -4273,7 +4273,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "03083467-fe49-4613-a692-63007a75c241",
+                            "id": "f9251ee4-c1cc-490f-ba1a-87be1b4135dd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4390,11 +4390,11 @@
                     "event": []
                 },
                 {
-                    "id": "6c139df5-b063-4ece-a927-81dfce9c2044",
+                    "id": "2658f26c-68aa-4dff-a192-24f4bd257f2e",
                     "name": "{ltr id}",
                     "item": [
                         {
-                            "id": "22b250e1-1dcf-437c-ba4f-05f4b50faced",
+                            "id": "70d7dc10-8d6b-4aaf-9850-5c1df2930d15",
                             "name": "Retrieve letter with given id",
                             "request": {
                                 "name": "Retrieve letter with given id",
@@ -4426,7 +4426,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "cf5c2b10-964c-4279-9caa-cec174763b45",
+                                    "id": "c41ee4e9-0d7c-40b1-9a6f-4526b0c0e419",
                                     "name": "Returns a letter object",
                                     "originalRequest": {
                                         "url": {
@@ -4489,7 +4489,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "bb510ede-a1c2-4f35-9f41-69d761d04e1e",
+                                    "id": "ec11be3c-f045-478a-bbbf-c70186ff20cc",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4537,7 +4537,7 @@
                             "event": []
                         },
                         {
-                            "id": "ec777dfe-e431-4677-9170-183cd607a56c",
+                            "id": "1cc24f8d-24d9-4e76-819f-6905dbe635f2",
                             "name": "Cancel a letter",
                             "request": {
                                 "name": "Cancel a letter",
@@ -4569,7 +4569,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "8163f85c-38b9-4a5f-abba-6d37c1d419f4",
+                                    "id": "77ab5d72-3e1a-45ab-9daf-4a6680fb63a9",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -4609,12 +4609,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "62ccc953-528a-4bfd-a647-1c704ec41437",
+                                    "id": "cb4b4d0d-66df-4dc7-a1fc-6d4551ba0482",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4668,11 +4668,11 @@
             "event": []
         },
         {
-            "id": "d91a8356-e3fb-4bea-96c3-8532353d9bf9",
+            "id": "d3ed31c0-d6ea-4b52-994a-f2ac5fe85aac",
             "name": "postcards",
             "item": [
                 {
-                    "id": "c592605c-9be4-43f8-8cd3-18940fa289d6",
+                    "id": "3ceff6c9-2fc5-4d7d-8a5a-a51ba09e8b45",
                     "name": "List all postcards",
                     "request": {
                         "name": "List all postcards",
@@ -4720,7 +4720,7 @@
                     },
                     "response": [
                         {
-                            "id": "1540f326-d6fa-4bc5-80cd-1bcd6ee2588b",
+                            "id": "40565e83-6871-4156-81ab-9de9c9cca28d",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -4784,7 +4784,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "304a06e9-21c1-4336-bf54-21a984779ebe",
+                            "id": "3f598633-02d6-4e96-8a2d-bcd5f0ac42a4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4851,7 +4851,7 @@
                     "event": []
                 },
                 {
-                    "id": "6c97df80-deb7-4fde-800a-94050d22a21c",
+                    "id": "5f314af5-ce20-4934-8d8d-1a7a600d9fae",
                     "name": "Creates a new postcard object",
                     "request": {
                         "name": "Creates a new postcard object",
@@ -4921,7 +4921,7 @@
                     },
                     "response": [
                         {
-                            "id": "78c373d1-5a89-40e8-8a42-e605f7e31562",
+                            "id": "b632b444-6d82-49dc-8ba8-ab51520ff1fb",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -5028,7 +5028,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7eaf2098-8bd7-4f8d-bd99-1493b33a4c48",
+                            "id": "92b0bc0c-0529-4358-8251-4e4345c15945",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5120,11 +5120,11 @@
                     "event": []
                 },
                 {
-                    "id": "04b49ed0-2331-4a82-9f1b-164370e4585c",
+                    "id": "9029d254-cd75-46af-b6ec-419159f09acc",
                     "name": "{psc id}",
                     "item": [
                         {
-                            "id": "804a81ac-0015-4e34-b718-57093c5fea5d",
+                            "id": "fae1402a-f444-4175-af12-c21c4bf352bf",
                             "name": "Retrieve postcard with given id",
                             "request": {
                                 "name": "Retrieve postcard with given id",
@@ -5156,7 +5156,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "e98dc66c-a2fe-4928-bdfa-3f67c2a83063",
+                                    "id": "b95a01b8-b982-436c-96ab-5cc0b4bfc799",
                                     "name": "Returns a postcard object",
                                     "originalRequest": {
                                         "url": {
@@ -5219,7 +5219,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a56d4525-9de8-4626-9084-f8ba53821bf9",
+                                    "id": "dee4f6df-2b9d-452f-98e1-b22b6ea68c71",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5267,7 +5267,7 @@
                             "event": []
                         },
                         {
-                            "id": "6be12614-c9d6-40e2-a05b-3e2525a2a455",
+                            "id": "dd11d000-569c-42cb-98cb-22d9006b8f8f",
                             "name": "Cancels postcard with given id",
                             "request": {
                                 "name": "Cancels postcard with given id",
@@ -5299,7 +5299,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "ded206be-cd3b-4e7e-869a-30dec50508de",
+                                    "id": "ba2d3e58-f091-4dec-a04a-428ff008ce5c",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -5339,12 +5339,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "3d4498a4-97fb-4446-b044-6c274f048f0e",
+                                    "id": "d9ef9519-9dc4-40f8-bb92-66adef8f1b79",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5398,11 +5398,11 @@
             "event": []
         },
         {
-            "id": "a6630eec-119e-4c63-ac3e-4c9649fc9b16",
+            "id": "001f6178-926d-4605-8443-ad5faee5e251",
             "name": "self mailers",
             "item": [
                 {
-                    "id": "759563ad-1232-4fc3-868e-eb4751349b60",
+                    "id": "cffc8755-0f83-4c5a-9da6-584831bcb454",
                     "name": "List all self_mailers",
                     "request": {
                         "name": "List all self_mailers",
@@ -5450,7 +5450,7 @@
                     },
                     "response": [
                         {
-                            "id": "9e6c27b0-c796-477f-be54-d1b29f562f28",
+                            "id": "db83be8e-41c6-4977-9b5b-7d69d84f8d34",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -5532,7 +5532,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c6e76727-3393-43fe-90ab-a14a538a348b",
+                            "id": "89f546d9-9ab5-4901-89f8-acda739045cf",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5599,7 +5599,7 @@
                     "event": []
                 },
                 {
-                    "id": "01d2c5cd-fdc2-4172-8190-b14f31130b5b",
+                    "id": "fc965ccf-24e7-42c7-bf1b-10c1037cfd1c",
                     "name": "Creates a new self_mailer object",
                     "request": {
                         "name": "Creates a new self_mailer object",
@@ -5669,7 +5669,7 @@
                     },
                     "response": [
                         {
-                            "id": "e750a0e1-12e2-421a-9843-b137cd13d5a7",
+                            "id": "1054f48c-0042-49ac-a6c0-dd90ba31bdb5",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -5776,7 +5776,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "28b67039-f4ec-4c01-9861-6815c2e1a55e",
+                            "id": "2d3db289-e936-414c-8474-60e24b4a33ac",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5868,11 +5868,11 @@
                     "event": []
                 },
                 {
-                    "id": "e1a5c2e6-bb28-4963-a49b-b45a04dc3329",
+                    "id": "98c8dbb4-35af-466a-80d8-e501c14da722",
                     "name": "{sfm id}",
                     "item": [
                         {
-                            "id": "d4e87698-c5ea-439d-8dee-9fb9b89b70da",
+                            "id": "71f2f921-0b30-4577-a35e-102b9c4b5d70",
                             "name": "Retrieve self_mailer with given id",
                             "request": {
                                 "name": "Retrieve self_mailer with given id",
@@ -5904,7 +5904,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "964eb2fa-39e1-4bb4-95ff-b2fed3df214b",
+                                    "id": "131d1401-26ed-4955-b198-0151834500c6",
                                     "name": "Returns a self_mailer object",
                                     "originalRequest": {
                                         "url": {
@@ -5967,7 +5967,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "6271a23a-4667-49bf-80e6-acd1204f6c9e",
+                                    "id": "4b2b83cd-b855-48a9-8fb1-ce7253a597f7",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6015,7 +6015,7 @@
                             "event": []
                         },
                         {
-                            "id": "2878b2d9-9bb8-41ae-a37d-7e0d3f663191",
+                            "id": "6fe3f52b-73b0-42ce-9427-077038774bd4",
                             "name": "Deletes self_mailer with given id",
                             "request": {
                                 "name": "Deletes self_mailer with given id",
@@ -6047,7 +6047,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "27179717-148f-4629-bc77-a72860726701",
+                                    "id": "6d535d88-3be8-4150-bc2b-960850bbd76e",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -6087,12 +6087,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "1568bcc9-dc30-4c4c-8a5f-37569b06699e",
+                                    "id": "80467e84-187b-44b7-9d83-b076e4ec29cb",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6146,11 +6146,11 @@
             "event": []
         },
         {
-            "id": "ca8d669a-8daf-4abe-874c-a367250448a2",
+            "id": "db576008-041b-4952-8651-3c6b819ef4cb",
             "name": "templates",
             "item": [
                 {
-                    "id": "8aba7330-11dc-494f-8209-4dc1ec86aac9",
+                    "id": "3f7efa3f-1dbf-47d0-a3a6-d9c0554d4447",
                     "name": "List all templates",
                     "request": {
                         "name": "List all templates",
@@ -6198,7 +6198,7 @@
                     },
                     "response": [
                         {
-                            "id": "e9adfb22-2976-44c1-ab12-1a21dfdd966e",
+                            "id": "f3398aec-ffe1-4477-967d-1c523ef56252",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -6280,7 +6280,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b7b6b14f-0ba3-49b5-b75c-59849fc522a0",
+                            "id": "0c849186-189c-4a53-8943-987cd0b4912b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6347,7 +6347,7 @@
                     "event": []
                 },
                 {
-                    "id": "0abe5558-626b-4c81-91eb-322824a87aa2",
+                    "id": "0118f4e1-3d64-4a47-902b-2d7840eb1bda",
                     "name": "Creates a new template object",
                     "request": {
                         "name": "Creates a new template object",
@@ -6398,7 +6398,7 @@
                     },
                     "response": [
                         {
-                            "id": "a7137ee3-29fd-4eca-9fe2-b54b28f3f51e",
+                            "id": "b38b4a63-6753-4b0b-976b-c7ab211b088c",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -6489,7 +6489,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f579abe8-6b83-432d-9fb5-2f8cbb42040c",
+                            "id": "3fade44e-7f5f-4b15-85d1-fff5fb903a62",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6565,11 +6565,11 @@
                     "event": []
                 },
                 {
-                    "id": "fe706776-bc52-4e73-ba1f-a653090a54e7",
+                    "id": "76c227d3-4464-459c-96b6-5b0776044475",
                     "name": "{tmpl id}",
                     "item": [
                         {
-                            "id": "b01a0ab6-fd05-41e1-8567-68653cf4b45c",
+                            "id": "e7d53bc1-1124-44b3-a7c9-f3d7945364b1",
                             "name": "Retrieve template with given id",
                             "request": {
                                 "name": "Retrieve template with given id",
@@ -6601,7 +6601,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "a4f44ec4-6849-4bcc-a58f-5aa2e1725ea7",
+                                    "id": "ebd8cbd2-d280-4c70-a574-88c2a857b6e9",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6664,7 +6664,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "229a7f2a-1c40-4c8a-8eb3-96554e776a1f",
+                                    "id": "e6f8e4fe-e92a-407f-99da-9ff85706d080",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6712,7 +6712,7 @@
                             "event": []
                         },
                         {
-                            "id": "2371b6fb-8c11-4cf0-afda-1f6ae7bf24b8",
+                            "id": "f3690548-6a68-4d3e-8e8f-20784b4396ab",
                             "name": "Update description and/or published version of a template.",
                             "request": {
                                 "name": "Update description and/or published version of a template.",
@@ -6771,7 +6771,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "31ea02fe-1b47-426f-b7f0-b65eb7e6a610",
+                                    "id": "8a0e29e4-5073-42b1-b85d-7857a5b1f552",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6854,7 +6854,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "bd6b5368-46be-4c61-9d27-b0c1c594d7ae",
+                                    "id": "8ec33e83-90dd-46ba-aef3-80770c272d45",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6922,7 +6922,7 @@
                             "event": []
                         },
                         {
-                            "id": "72f36b9d-81ca-4b8d-b659-1b614b9110f6",
+                            "id": "dd363ae8-4ed7-468c-9939-81788232d22e",
                             "name": "Deletes template with given id",
                             "request": {
                                 "name": "Deletes template with given id",
@@ -6954,7 +6954,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "233a2dab-fb7f-44a8-8662-a769cee3b86c",
+                                    "id": "d2377c67-0649-405a-ab25-96bcfdd3ecfb",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -6994,12 +6994,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "b1fbb9d5-1832-4b04-8e32-227ab05b0ec2",
+                                    "id": "b5433640-6558-4b8d-a36f-95572cde9de0",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -7047,11 +7047,11 @@
                             "event": []
                         },
                         {
-                            "id": "a7b16b3c-33a4-4960-9ca9-4d3801260c05",
+                            "id": "5fdd1580-64c3-440d-aa8d-79968f6f3b7e",
                             "name": "versions",
                             "item": [
                                 {
-                                    "id": "e66c83ec-bcf2-48c7-b86d-4b138b20ee7c",
+                                    "id": "259129f1-9ff3-4443-a60d-5f42d05a436d",
                                     "name": "List all template_versions",
                                     "request": {
                                         "name": "List all template_versions",
@@ -7109,7 +7109,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "93d4a8f0-8cb8-47dc-99eb-a647fc195505",
+                                            "id": "309ab6bc-4bf9-4bb0-86cc-74422dc115ef",
                                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                                             "originalRequest": {
                                                 "url": {
@@ -7190,7 +7190,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "14ecf849-0615-4103-9f11-2e8c097e7f3a",
+                                            "id": "8308a98c-1e4f-4e79-8284-b5517917f2f3",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -7256,7 +7256,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "9cf972b6-d1b9-49cd-9837-e9588c67fd7b",
+                                    "id": "0d413964-49df-4b75-a4d4-cb2d3b6a9f9d",
                                     "name": "Creates a new template_version object",
                                     "request": {
                                         "name": "Creates a new template_version object",
@@ -7317,7 +7317,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "1150efe4-1564-4e0a-b499-a31ce48be45d",
+                                            "id": "4882944f-f5ff-4615-8f28-f5a54542dc1a",
                                             "name": "Returns the template version with the given template and version ids.",
                                             "originalRequest": {
                                                 "url": {
@@ -7405,7 +7405,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "31c94b82-040e-44e6-aaef-329d3ff2819a",
+                                            "id": "d7acb46d-e2d7-441b-ab6a-a3e5203f9df8",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -7478,11 +7478,11 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "7d65f730-dd85-4428-8719-565992eaa2fc",
+                                    "id": "e1087285-575d-4af7-ab3d-eee77fe79a2e",
                                     "name": "{vrsn id}",
                                     "item": [
                                         {
-                                            "id": "660b5627-6bfd-4a2b-a117-f4d999d3e763",
+                                            "id": "55b2d382-bbc2-48c8-a9d8-6419b6342954",
                                             "name": "Retrieve template version with given template and version ids.",
                                             "request": {
                                                 "name": "Retrieve template version with given template and version ids.",
@@ -7523,7 +7523,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "128dab66-7f0c-47d7-bf90-013aa6f640fe",
+                                                    "id": "039d0ad7-df66-42ae-b1df-ebc504be10f2",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7592,7 +7592,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "0afddc90-7ec5-4d62-928d-8f39d4824901",
+                                                    "id": "de603574-445d-4393-b884-66183f460f2c",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7646,7 +7646,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "1befa0ad-30d2-48dc-9624-3cad7cd62042",
+                                            "id": "c5e9fad3-2b45-4cf0-a994-559244a87a03",
                                             "name": "Updates the template version with given template and version ids.",
                                             "request": {
                                                 "name": "Updates the template version with given template and version ids.",
@@ -7709,7 +7709,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "8d5f2c9b-1aaa-4738-ad94-e3acd58cac93",
+                                                    "id": "7b59c95d-08c6-47eb-8321-0fc5ea28c2e0",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7793,7 +7793,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "8c3164c1-d61a-4c53-b151-2976865117c9",
+                                                    "id": "e402909a-02d3-48aa-8ec2-852fe8ccc5ff",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7862,7 +7862,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "cc95d333-32ec-421a-9860-e5de72e807e1",
+                                            "id": "4bea27f5-0a62-4295-a2e9-9c5ffe031dd1",
                                             "name": "Deletes the template version with given template and version ids if possible.",
                                             "request": {
                                                 "name": "Deletes the template version with given template and version ids if possible.",
@@ -7903,7 +7903,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "7063d976-f29e-4ae6-8e48-2961d65fcc0b",
+                                                    "id": "47ea07f3-7c9a-4c1f-8a6c-43ce63298476",
                                                     "name": "Returns true if the delete was successful",
                                                     "originalRequest": {
                                                         "url": {
@@ -7949,12 +7949,12 @@
                                                             "value": "application/json"
                                                         }
                                                     ],
-                                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
+                                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
                                                     "cookie": [],
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "2b302670-fdf1-45f3-a33f-498df3843cf8",
+                                                    "id": "9aee8cea-e024-4e85-a32d-a71f31f25b92",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -8014,7 +8014,7 @@
                             "event": []
                         },
                         {
-                            "id": "be3d5903-dc9d-438c-a058-d2c5ad7641e8",
+                            "id": "d330eb6e-908c-4ae8-a037-e6bda623c71e",
                             "name": "Compile the template into html",
                             "request": {
                                 "name": "Compile the template into html",
@@ -8060,7 +8060,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "50e14a89-6d54-45f9-922b-f214ce8b88be",
+                                    "id": "0efb9248-ee0c-4e75-89fd-6df2a5a34479",
                                     "name": "Returns the compiled html",
                                     "originalRequest": {
                                         "url": {
@@ -8115,7 +8115,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "666b7500-7a6d-49f0-ad3a-7ff684bd8e29",
+                                    "id": "88cb74d2-c148-403b-97cc-8350437fadbf",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -8179,7 +8179,7 @@
             "event": []
         },
         {
-            "id": "ddc0f6f9-73d5-426c-89ba-2ab5ec47ecdf",
+            "id": "a726f735-0492-4f7d-ad4a-b5d5bbfe2a4c",
             "name": "Autocomplete a partial US address.",
             "request": {
                 "name": "Autocomplete a partial US address.",
@@ -8243,7 +8243,7 @@
             },
             "response": [
                 {
-                    "id": "d685178f-2b85-48dd-bf8f-a39ddd6f765b",
+                    "id": "e927f96d-d66f-4970-9bdc-71f234659f42",
                     "name": "Returns a US autocompletion object.",
                     "originalRequest": {
                         "url": {
@@ -8349,7 +8349,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "3cc323e7-2f8d-4b3f-8e27-585473b051a1",
+                    "id": "f7ea07e5-6307-4a4d-9b83-146ecbe257d3",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8440,7 +8440,7 @@
             "event": []
         },
         {
-            "id": "89dbdaa7-eeed-46b9-bbaf-fff6c82d6ef0",
+            "id": "b89df972-007c-4e5e-93a7-cc828e6220c6",
             "name": "Verify a US or US territory address with a live API key.",
             "request": {
                 "name": "Verify a US or US territory address with a live API key.",
@@ -8480,7 +8480,7 @@
             },
             "response": [
                 {
-                    "id": "e33a361a-bcba-4aff-99cf-16f5cca0dcda",
+                    "id": "aa710bd2-4127-47bc-a357-b492f5618322",
                     "name": "Returns a US verification object.",
                     "originalRequest": {
                         "url": {
@@ -8545,7 +8545,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "c5a3da3b-4fc0-4b3b-ad9f-dbda5b4b1dc9",
+                    "id": "7926f04d-7a34-4beb-ad5c-82f50fec2c01",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8595,7 +8595,7 @@
             "event": []
         },
         {
-            "id": "9fe9cda2-ad71-4524-ac6a-0b78004723da",
+            "id": "21cd8a5e-cebd-45be-a68c-bd918b516294",
             "name": "Looks up information pertaining to a given ZIP code",
             "request": {
                 "name": "Looks up information pertaining to a given ZIP code",
@@ -8635,7 +8635,7 @@
             },
             "response": [
                 {
-                    "id": "6230ba35-a541-4ee5-bcea-a6464d26ef84",
+                    "id": "d1cde43b-9e8e-49b2-8931-db6b5c5b6c71",
                     "name": "Returns a zip lookup object if a valid zip was provided.",
                     "originalRequest": {
                         "url": {
@@ -8700,12 +8700,12 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"e\",\n   \"county\": \"in officia nisi voluptate eiusmod\",\n   \"county_fips\": \"23445\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"\",\n   \"county\": \"in ut Ut ipsum anim\",\n   \"county_fips\": \"36335\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"\"\n}",
+                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"a\",\n   \"county\": \"ea\",\n   \"county_fips\": \"10763\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"do\",\n   \"county\": \"labore ut ex volu\",\n   \"county_fips\": \"71064\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"military\"\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "47779859-e95f-4010-b3b4-ed20833763e5",
+                    "id": "b1a279a1-d309-4fa6-b63f-cd3dc2776ee9",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8782,7 +8782,7 @@
         ]
     },
     "info": {
-        "_postman_id": "a223a2ea-bac4-4f93-9e83-47dc057ad8d0",
+        "_postman_id": "287950db-f4fb-4887-b46e-955bb2763bb4",
         "name": "Lob API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/dist/Lob-API-postman.json
+++ b/dist/Lob-API-postman.json
@@ -1,11 +1,11 @@
 {
     "item": [
         {
-            "id": "5febad24-b752-40e7-815b-0cea9bd38f8e",
+            "id": "6ad70734-3d02-4af9-9216-1796d3e10ef7",
             "name": "addresses",
             "item": [
                 {
-                    "id": "58dbdaac-7092-428c-a8eb-5425741c82f2",
+                    "id": "7b3cfd94-d097-4e0c-812f-d0a4803e16bc",
                     "name": "List all addresses",
                     "request": {
                         "name": "List all addresses",
@@ -53,7 +53,7 @@
                     },
                     "response": [
                         {
-                            "id": "9c1a1273-bdac-4a23-ba7c-4a88100ac997",
+                            "id": "aa92a366-ae68-4fcd-a183-bdad2470a843",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -117,7 +117,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2e158f80-c640-4288-b3fb-d260def2d462",
+                            "id": "b9287775-a35f-4628-aa8d-265d24948059",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -184,7 +184,7 @@
                     "event": []
                 },
                 {
-                    "id": "59b9c474-8b6e-41ef-bbf3-18cf5c478f6f",
+                    "id": "c7196baf-7e86-4e10-875b-84a5c75a2bbc",
                     "name": "Creates a new address object",
                     "request": {
                         "name": "Creates a new address object",
@@ -254,7 +254,7 @@
                     },
                     "response": [
                         {
-                            "id": "86530447-2954-41ec-91e3-a99e6b1fee8b",
+                            "id": "0c3b537d-30e4-4a87-a38a-bb76c69de9fd",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -351,7 +351,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "42f43ae2-e030-4f9d-b18c-a14411470852",
+                            "id": "5bf2b9c2-f35c-4895-b603-dc4da0c6d932",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -433,11 +433,11 @@
                     "event": []
                 },
                 {
-                    "id": "ed68da01-e818-4083-9ee7-e29ef32c13b5",
+                    "id": "56f87067-d4ef-49fd-87a2-04c0f6b6d492",
                     "name": "{adr id}",
                     "item": [
                         {
-                            "id": "cebabcb7-be29-4127-b1c2-f41e13719bb3",
+                            "id": "cfa663bd-d53f-488a-8afb-83cfad7be1a9",
                             "name": "Retrieve address with given id",
                             "request": {
                                 "name": "Retrieve address with given id",
@@ -469,7 +469,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "e04c34b5-7f56-4542-8a17-1dca48787b99",
+                                    "id": "2a86f04d-a932-4eb3-a864-18797cf647c6",
                                     "name": "Returns an address object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -527,12 +527,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_country\": \"UNITED STATES\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"1984-07-03T05:39:34.261Z\",\n \"date_modified\": \"2010-12-25T01:15:30.424Z\",\n \"id\": \"<string>\",\n \"object\": \"address\",\n \"address_line2\": \"<string>\",\n \"deleted\": true,\n \"recipient_moved\": true\n}",
+                                    "body": "{\n \"address_city\": \"<string>\",\n \"address_country\": \"UNITED STATES\",\n \"address_line1\": \"<string>\",\n \"address_state\": \"<string>\",\n \"address_zip\": \"<string>\",\n \"date_created\": \"1966-10-25T03:52:51.854Z\",\n \"date_modified\": \"2005-01-31T21:08:02.198Z\",\n \"id\": \"<string>\",\n \"object\": \"address\",\n \"address_line2\": \"<string>\",\n \"deleted\": false,\n \"recipient_moved\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "512fcaa0-5239-43ad-aedf-8c182d4bdfa0",
+                                    "id": "6cffd747-5502-4a16-af1a-3bc6410bff71",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -580,7 +580,7 @@
                             "event": []
                         },
                         {
-                            "id": "7f9dbd09-5956-4a52-a8a8-8d8cc8609d01",
+                            "id": "87d7eef8-8e8f-4c3a-aad5-ccd7811040ef",
                             "name": "Deletes address with given id",
                             "request": {
                                 "name": "Deletes address with given id",
@@ -612,7 +612,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "efab51f2-724b-4c72-ae97-7619910a5027",
+                                    "id": "4b5d9406-9801-493f-8d57-e03b82811b47",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -652,12 +652,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "028df7df-2511-4930-8cd0-27f37633b8ca",
+                                    "id": "a16e3b04-0b94-433a-a1d1-0bb13e45b5a3",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -711,11 +711,11 @@
             "event": []
         },
         {
-            "id": "529ade02-f000-4a54-8104-063ffb107665",
+            "id": "98dd39df-319e-4f54-8d6e-dd1d17bcff04",
             "name": "bank accounts",
             "item": [
                 {
-                    "id": "df0cae11-3620-4f99-a68a-ccb3a7b53f6e",
+                    "id": "6f2d9fec-726b-45b6-8a47-e70a49e11d07",
                     "name": "List all bank_accounts",
                     "request": {
                         "name": "List all bank_accounts",
@@ -763,7 +763,7 @@
                     },
                     "response": [
                         {
-                            "id": "03aa5886-cade-47a7-959d-54c4f918056d",
+                            "id": "0da94537-58da-4dcf-a499-d40618ff65ea",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -827,7 +827,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "741d4773-35bd-4551-ab3b-1470e2a3e981",
+                            "id": "20cec5e4-c561-404f-ab4c-f752b8a1fe4a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -894,7 +894,7 @@
                     "event": []
                 },
                 {
-                    "id": "e44d707a-b583-4344-a8e8-3a45afd388b5",
+                    "id": "7be92e63-d319-4913-8a61-503f49866df8",
                     "name": "Creates a new bank_account",
                     "request": {
                         "name": "Creates a new bank_account",
@@ -969,7 +969,7 @@
                     },
                     "response": [
                         {
-                            "id": "7f7a99f6-fda0-40d5-a912-fee780dfcf8b",
+                            "id": "f92bbc82-998b-4fbf-b53a-c026b0c13011",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1081,7 +1081,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f49a92a8-c84e-4a5c-b209-f8080de62e7b",
+                            "id": "1fb5dc95-08b1-4072-9fa3-96a7d2757c55",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1178,11 +1178,11 @@
                     "event": []
                 },
                 {
-                    "id": "88d15741-8422-447c-a462-dd0875756f6f",
+                    "id": "ab5aa10f-f654-4bb4-9342-6c1e2e2c39a8",
                     "name": "{bank id}",
                     "item": [
                         {
-                            "id": "6cafb6f4-4f49-4672-a91a-7f353d18f19d",
+                            "id": "1bf662fd-ea13-446a-9b49-ce96106940ad",
                             "name": "Retrieve bank_account with given id",
                             "request": {
                                 "name": "Retrieve bank_account with given id",
@@ -1214,7 +1214,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "45c1b476-d454-41a4-b201-34507e958f25",
+                                    "id": "dd59470c-4313-46ad-b30d-16bb64a4490a",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1277,7 +1277,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c56633d3-cd77-4c59-84b4-0d4a058c6dd4",
+                                    "id": "d47a0ea2-3c08-4c78-a08e-755e3666778e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1325,7 +1325,7 @@
                             "event": []
                         },
                         {
-                            "id": "15108ba1-ef0b-4a8f-9f46-ada9596bc06c",
+                            "id": "c81b40d4-22f3-46e2-9239-8e2f29252198",
                             "name": "Delete a bank_account",
                             "request": {
                                 "name": "Delete a bank_account",
@@ -1357,7 +1357,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0ab0fa48-94d3-4798-a4cc-76f70bf5d283",
+                                    "id": "927d4f09-84f8-4fbc-8918-4c5e2dae210d",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -1397,12 +1397,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "5e9893f1-f94c-41fb-bdc6-0f70c2e75046",
+                                    "id": "71e1ed52-db46-4ffe-bd35-d8d0a4fd696e",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1450,7 +1450,7 @@
                             "event": []
                         },
                         {
-                            "id": "eb3c9685-4bc7-46bc-ae5f-cc4e5b6ca0cf",
+                            "id": "4e5126aa-3c46-40a2-8e17-6f20fe1f55b6",
                             "name": "Verify a bank account",
                             "request": {
                                 "name": "Verify a bank account",
@@ -1512,7 +1512,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d0da975b-6a27-4fd8-937c-1d47e6f5cbd1",
+                                    "id": "c5896a59-d7f4-4274-ba61-8c4236781f31",
                                     "name": "Returns a bank_account object",
                                     "originalRequest": {
                                         "url": {
@@ -1604,7 +1604,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ba5bdcbb-e437-46b3-8118-bf71f1dae5a4",
+                                    "id": "7e2482bf-a263-465b-8c9c-eca20b4e4b59",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -1687,11 +1687,11 @@
             "event": []
         },
         {
-            "id": "afcf586b-1422-41c7-9a39-bfab7ef378f9",
+            "id": "c92f897b-f5c9-4039-9320-27941ce62f20",
             "name": "bulk",
             "item": [
                 {
-                    "id": "f335dd87-3113-4aab-9831-b74092f2ae0f",
+                    "id": "f81bffbf-c694-4c9d-9f7e-d41e7fb55582",
                     "name": "Verify a list of US or US territory address with a live API key.",
                     "request": {
                         "name": "Verify a list of US or US territory address with a live API key.",
@@ -1732,7 +1732,7 @@
                     },
                     "response": [
                         {
-                            "id": "e6e06ae9-dcdf-4f3d-a17f-0ba40c464d68",
+                            "id": "8df7d273-3d6c-4e42-8448-b76f5cbd25df",
                             "name": "Returns an US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -1798,7 +1798,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "49bf2664-ab32-4d0a-8c29-e732bc3f730a",
+                            "id": "bb510edf-ffe9-40a6-8a4a-233bfb1d0f3d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1849,7 +1849,7 @@
                     "event": []
                 },
                 {
-                    "id": "cf40620e-8c3a-4575-82c2-b793af743dd6",
+                    "id": "0b5e1989-d982-4ea3-bc99-8f6fef5a2284",
                     "name": "Verify a list of international addresses with a live API key.",
                     "request": {
                         "name": "Verify a list of international addresses with a live API key.",
@@ -1883,7 +1883,7 @@
                     },
                     "response": [
                         {
-                            "id": "b8758637-e99b-47a1-83a9-e843d452698b",
+                            "id": "e9d53386-8bef-4b25-ba4e-ed50184b3c70",
                             "name": "Returns an array of international verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -1944,7 +1944,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1166a631-e1e4-4179-a211-c2a5757d3e22",
+                            "id": "7cb68971-e505-4b9c-a51e-5fe1afb12394",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1993,11 +1993,11 @@
             "event": []
         },
         {
-            "id": "b5407042-671d-4fc2-80ba-a85f38a1e4ea",
+            "id": "bb7431f3-3e1b-452b-b675-229a37b117bf",
             "name": "certificates",
             "item": [
                 {
-                    "id": "bf46d915-e250-429c-946c-d3c2e2f5cbf7",
+                    "id": "822449b6-c30c-4aa0-a8fd-685f08a4fe94",
                     "name": "List all certificates",
                     "request": {
                         "name": "List all certificates",
@@ -2020,7 +2020,7 @@
                     },
                     "response": [
                         {
-                            "id": "1f4596f3-71a3-4bc4-9f40-4d9a259a55a0",
+                            "id": "a2bd4d24-6d05-4bab-aae0-3f77f068c2a7",
                             "name": "List of all certificates. Will to add wording about plans for the future.",
                             "originalRequest": {
                                 "url": {
@@ -2054,12 +2054,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"id dolor\",\n   \"date_created\": \"1982-10-15T22:22:05.257Z\",\n   \"date_modified\": \"1952-09-23T04:57:36.872Z\",\n   \"id\": \"cert_284B\",\n   \"name\": \"in\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": true,\n   \"account_id\": \"rYngeHjrQF\",\n   \"date_deleted\": \"1975-07-04T21:42:26.215Z\"\n  },\n  {\n   \"cert\": \"dolore velit\",\n   \"date_created\": \"2018-06-23T23:18:03.773Z\",\n   \"date_modified\": \"1954-07-23T09:12:00.857Z\",\n   \"id\": \"cert_M0BDsZO21oT\",\n   \"name\": \"Duis officia magna sunt occaecat\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"bnyxPz\",\n   \"date_deleted\": \"1972-05-20T19:58:31.841Z\"\n  }\n ],\n \"count\": -37845818,\n \"object\": \"exercitation Ut fugiat nisi\"\n}",
+                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"laboris in\",\n   \"date_created\": \"1942-11-22T01:29:33.252Z\",\n   \"date_modified\": \"1983-05-23T01:19:23.803Z\",\n   \"id\": \"cert_zg2\",\n   \"name\": \"proident quis\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"Y3pU0MOcm8N\",\n   \"date_deleted\": \"1957-03-03T14:23:33.694Z\"\n  },\n  {\n   \"cert\": \"mollit cillum anim\",\n   \"date_created\": \"1941-11-12T01:22:09.416Z\",\n   \"date_modified\": \"1981-02-06T00:41:35.904Z\",\n   \"id\": \"cert_rHHy\",\n   \"name\": \"ea\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"jsAK\",\n   \"date_deleted\": \"2012-01-19T15:59:43.579Z\"\n  }\n ],\n \"count\": -60996052,\n \"object\": \"cupidatat ipsum sit est Duis\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "71208477-5fff-4dc7-9f97-9b0861d89cb4",
+                            "id": "b48b6600-35bc-44f4-9641-6719d99fb177",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2101,7 +2101,7 @@
                     "event": []
                 },
                 {
-                    "id": "aff6e5d2-50d5-467d-a809-b74e17ab57c9",
+                    "id": "6444d730-efcc-4cdc-b214-8d2440e8da47",
                     "name": "Creates a new certificate object",
                     "request": {
                         "name": "Creates a new certificate object",
@@ -2145,7 +2145,7 @@
                                 {
                                     "disabled": false,
                                     "key": "name",
-                                    "value": "Excepteur officia laborum",
+                                    "value": "magna",
                                     "description": "(Required) "
                                 },
                                 {
@@ -2158,7 +2158,7 @@
                     },
                     "response": [
                         {
-                            "id": "b84ad794-bbff-4b5f-a31b-d737d9dd7f17",
+                            "id": "913f073b-b89d-4f61-9fae-cbceaa5e04df",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -2207,7 +2207,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "mollit sunt"
+                                            "value": "quis minim id officia"
                                         },
                                         {
                                             "disabled": false,
@@ -2225,12 +2225,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1957-04-03T08:48:08.900Z\",\n \"date_modified\": \"1963-01-29T23:04:05.752Z\",\n \"id\": \"cert_oGOj1ZacjV\",\n \"name\": \"officia in laborum\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"z\",\n \"date_deleted\": \"2008-03-10T15:10:24.938Z\"\n}",
+                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1978-10-28T08:59:38.194Z\",\n \"date_modified\": \"1997-05-24T18:54:36.538Z\",\n \"id\": \"cert_1tS5\",\n \"name\": \"adipisicing et\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"nvwKxKR\",\n \"date_deleted\": \"1956-06-02T20:28:11.805Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e375508a-7acb-4f54-977d-0b69e25d6938",
+                            "id": "ec5bcdc9-a387-4257-99aa-10cb2ba190d2",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2279,7 +2279,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "mollit sunt"
+                                            "value": "quis minim id officia"
                                         },
                                         {
                                             "disabled": false,
@@ -2305,11 +2305,11 @@
                     "event": []
                 },
                 {
-                    "id": "33a4cd60-5f23-4bb0-9e49-f129a1eb74e6",
+                    "id": "620f3649-8415-4af3-8892-df46fa01b3fe",
                     "name": "{id}",
                     "item": [
                         {
-                            "id": "4ded8691-b1c2-41bc-80cb-e08bf91201a5",
+                            "id": "c0d0f99e-ea77-4cc0-b9c2-ef2935bdc187",
                             "name": "Retrieve certificate with given id",
                             "request": {
                                 "name": "Retrieve certificate with given id",
@@ -2330,7 +2330,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_Bk7tzM6BTz",
+                                            "value": "cert_p73mcu9b",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2341,7 +2341,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "2a5a5529-2f97-4fea-832c-9cee73d3b552",
+                                    "id": "54aab39a-1df2-420f-8ad0-9339fdc244c0",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2381,12 +2381,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1957-04-03T08:48:08.900Z\",\n \"date_modified\": \"1963-01-29T23:04:05.752Z\",\n \"id\": \"cert_oGOj1ZacjV\",\n \"name\": \"officia in laborum\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"z\",\n \"date_deleted\": \"2008-03-10T15:10:24.938Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1978-10-28T08:59:38.194Z\",\n \"date_modified\": \"1997-05-24T18:54:36.538Z\",\n \"id\": \"cert_1tS5\",\n \"name\": \"adipisicing et\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"nvwKxKR\",\n \"date_deleted\": \"1956-06-02T20:28:11.805Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "fa84c9b2-ea09-4b28-8573-d31afb158e4e",
+                                    "id": "72ac733b-b307-444f-be7c-0f4dfd3decd7",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2434,7 +2434,7 @@
                             "event": []
                         },
                         {
-                            "id": "61189cea-ba5f-43cc-8f59-9a9612455397",
+                            "id": "24fa89df-4e5f-41f0-8997-fc60d0faadeb",
                             "name": "Update name and/or description of a certificate.",
                             "request": {
                                 "name": "Update name and/or description of a certificate.",
@@ -2455,7 +2455,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_Bk7tzM6BTz",
+                                            "value": "cert_p73mcu9b",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2475,7 +2475,7 @@
                                         {
                                             "disabled": false,
                                             "key": "name",
-                                            "value": "quis ipsum enim"
+                                            "value": "consequat ad labore esse qui"
                                         },
                                         {
                                             "disabled": false,
@@ -2487,7 +2487,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "4057e7ce-97fc-4fe0-ba37-9a3a0cd2dbbd",
+                                    "id": "16376401-bedd-4e22-b4ce-a21ba60327c1",
                                     "name": "Returns an certificate object if a valid identifier was provided.",
                                     "originalRequest": {
                                         "url": {
@@ -2523,7 +2523,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "elit ut"
+                                                    "value": "cillum nulla elit occaecat"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2541,12 +2541,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1957-04-03T08:48:08.900Z\",\n \"date_modified\": \"1963-01-29T23:04:05.752Z\",\n \"id\": \"cert_oGOj1ZacjV\",\n \"name\": \"officia in laborum\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"z\",\n \"date_deleted\": \"2008-03-10T15:10:24.938Z\"\n}",
+                                    "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1978-10-28T08:59:38.194Z\",\n \"date_modified\": \"1997-05-24T18:54:36.538Z\",\n \"id\": \"cert_1tS5\",\n \"name\": \"adipisicing et\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"nvwKxKR\",\n \"date_deleted\": \"1956-06-02T20:28:11.805Z\"\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "03c272ec-c69d-4980-84ee-00bb5fdd385f",
+                                    "id": "825e4e0d-2a14-49e7-971a-9088898e0bb5",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2582,7 +2582,7 @@
                                                 {
                                                     "disabled": false,
                                                     "key": "name",
-                                                    "value": "elit ut"
+                                                    "value": "cillum nulla elit occaecat"
                                                 },
                                                 {
                                                     "disabled": false,
@@ -2608,7 +2608,7 @@
                             "event": []
                         },
                         {
-                            "id": "d83a0f8e-a65f-43c5-a4cc-01ee9fd8d7fb",
+                            "id": "eb9ea84c-495a-466b-9fba-4ea1d11c9bbc",
                             "name": "Deletes certificate with given id",
                             "request": {
                                 "name": "Deletes certificate with given id",
@@ -2629,7 +2629,7 @@
                                         {
                                             "disabled": false,
                                             "type": "any",
-                                            "value": "cert_Bk7tzM6BTz",
+                                            "value": "cert_p73mcu9b",
                                             "key": "id",
                                             "description": "(Required) id of the certificate"
                                         }
@@ -2640,7 +2640,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "5ee9f336-b017-4171-b17a-24359baa4eb4",
+                                    "id": "49716ef6-8e43-4e85-9c59-088b3f29b2d6",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -2680,12 +2680,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "2bd840d8-45a9-4d94-8972-f3a58000bc09",
+                                    "id": "ce7ff8f3-3c12-4128-8e0d-0553d9746b34",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -2739,11 +2739,11 @@
             "event": []
         },
         {
-            "id": "fd5997ee-5611-4a89-a0f3-7dded5567621",
+            "id": "c2766b48-febe-4815-8230-36101ae22225",
             "name": "checks",
             "item": [
                 {
-                    "id": "fd6958ac-cfc4-48d6-8583-ff05be58b0c1",
+                    "id": "970aa6ad-60be-452b-91f6-922df895bbec",
                     "name": "List all checks",
                     "request": {
                         "name": "List all checks",
@@ -2791,7 +2791,7 @@
                     },
                     "response": [
                         {
-                            "id": "c57cf595-64c1-4884-97b1-6339f99756f0",
+                            "id": "6a438ae6-7777-4814-b6af-8af04615a61a",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -2855,7 +2855,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "89837f98-31f5-45a4-bd0f-1ce8eca459c5",
+                            "id": "175ccbad-d3fd-4267-9980-10fdc89a121b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2922,7 +2922,7 @@
                     "event": []
                 },
                 {
-                    "id": "fbc2abcc-297b-46ac-a5d1-cd3edb8df31a",
+                    "id": "17ffa890-ecb3-4fa4-a6b2-8accbd8fd5e1",
                     "name": "Creates a new check",
                     "request": {
                         "name": "Creates a new check",
@@ -2992,7 +2992,7 @@
                     },
                     "response": [
                         {
-                            "id": "777549f5-900e-4c45-8b27-a2c3ea003118",
+                            "id": "fd361c3b-5012-49f0-8408-80b97be3ad5c",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -3164,7 +3164,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "71c1cb32-da9d-4031-9a5b-4fff82df08b7",
+                            "id": "db84c51f-3fdc-4036-a3c3-d5c80934d7d1",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3321,11 +3321,11 @@
                     "event": []
                 },
                 {
-                    "id": "417bb5eb-e0cb-467a-a89b-d3a18f8aa05b",
+                    "id": "87dd27fb-f3ac-416f-8c90-d9fb8878a984",
                     "name": "{chk id}",
                     "item": [
                         {
-                            "id": "aeb4e85e-c398-4841-9978-32267bdec4d9",
+                            "id": "6605e3a0-9f33-4132-8f53-322090bca344",
                             "name": "Retrieve check with given id",
                             "request": {
                                 "name": "Retrieve check with given id",
@@ -3357,7 +3357,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "1c9c35e2-cb49-4989-8ac1-fb8c1eebeb5d",
+                                    "id": "a14e9f9b-2720-4e45-a7b6-7a8cf2701275",
                                     "name": "Returns a check object",
                                     "originalRequest": {
                                         "url": {
@@ -3420,7 +3420,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "25f70c1b-dcd2-40d5-a572-9425780ef563",
+                                    "id": "906ccc6e-d38a-4e54-acb4-5299cced89b8",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3468,7 +3468,7 @@
                             "event": []
                         },
                         {
-                            "id": "a0e6848f-9187-4835-8abf-f96459d3a3e9",
+                            "id": "cb4bace1-3f40-4aea-871e-98375d81232d",
                             "name": "Cancel a check",
                             "request": {
                                 "name": "Cancel a check",
@@ -3500,7 +3500,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c4028952-1a72-48d4-b780-443e41e02b89",
+                                    "id": "d85c14b6-cbd2-4678-bb7a-97f07e19dc25",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -3540,12 +3540,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "6102791f-4d0f-4fef-afb6-4163a53dd185",
+                                    "id": "aa79f42a-d0dc-4ed8-8f72-59e22efce6cf",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -3599,7 +3599,7 @@
             "event": []
         },
         {
-            "id": "e216a77e-aebd-427e-a449-c88df150fe82",
+            "id": "222f1f65-9baf-48bf-9f9b-fc47fa794b80",
             "name": "Verify an international (except US or US territories) address with a live API key.",
             "request": {
                 "name": "Verify an international (except US or US territories) address with a live API key.",
@@ -3674,7 +3674,7 @@
             },
             "response": [
                 {
-                    "id": "8ac7188e-df56-4c48-af76-94dfdaac7a9f",
+                    "id": "a6e3140e-5bf5-41f7-9486-f559992f366b",
                     "name": "Returns an international verification object.",
                     "originalRequest": {
                         "url": {
@@ -3776,7 +3776,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "aacf5532-c931-4aec-b75f-d22a3e952567",
+                    "id": "6e6f51bc-9f1d-4dfe-a60b-a1b35dcf8812",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -3863,11 +3863,11 @@
             "event": []
         },
         {
-            "id": "28500711-9f38-4a74-ab68-9eb16e53d7d9",
+            "id": "541c3e28-a81e-4467-98e3-5fba9cb46db0",
             "name": "letters",
             "item": [
                 {
-                    "id": "bc40b941-5ef1-471c-8929-57cfea2a47e4",
+                    "id": "6f9fe419-294b-430f-837d-7dc205cba224",
                     "name": "List all letters",
                     "request": {
                         "name": "List all letters",
@@ -3915,7 +3915,7 @@
                     },
                     "response": [
                         {
-                            "id": "d7fca385-0f69-476f-9b1f-5251bd8afb1a",
+                            "id": "e86bc1b8-38c6-4c89-b2d7-f4017753d6a9",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3979,7 +3979,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2a5e0541-01a4-46af-bd68-ba31336614bd",
+                            "id": "162782c7-6c1c-4564-aa8b-e83a83187d47",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4046,7 +4046,7 @@
                     "event": []
                 },
                 {
-                    "id": "16471df4-aea9-48c0-aa7f-f99a8c22e9aa",
+                    "id": "c446baac-35ad-40a9-beec-ba9c1ffb0a5a",
                     "name": "Creates a new letter object",
                     "request": {
                         "name": "Creates a new letter object",
@@ -4141,7 +4141,7 @@
                     },
                     "response": [
                         {
-                            "id": "fdc9204c-7883-4b59-b692-bc179b17a044",
+                            "id": "53eccfcc-7fd0-4b9e-913b-c596e8bd5e41",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -4273,7 +4273,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f9251ee4-c1cc-490f-ba1a-87be1b4135dd",
+                            "id": "efb96db0-0c13-44da-9727-9d6b53749364",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4390,11 +4390,11 @@
                     "event": []
                 },
                 {
-                    "id": "2658f26c-68aa-4dff-a192-24f4bd257f2e",
+                    "id": "47a64f66-f83a-4cbc-afd4-14ffc84d3d0f",
                     "name": "{ltr id}",
                     "item": [
                         {
-                            "id": "70d7dc10-8d6b-4aaf-9850-5c1df2930d15",
+                            "id": "d376f645-2ce2-4d0e-b851-40709d8b0d85",
                             "name": "Retrieve letter with given id",
                             "request": {
                                 "name": "Retrieve letter with given id",
@@ -4426,7 +4426,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "c41ee4e9-0d7c-40b1-9a6f-4526b0c0e419",
+                                    "id": "2efa03e2-bb1a-4692-a16d-77920377b267",
                                     "name": "Returns a letter object",
                                     "originalRequest": {
                                         "url": {
@@ -4489,7 +4489,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ec11be3c-f045-478a-bbbf-c70186ff20cc",
+                                    "id": "c5d74543-9de8-4934-a091-0561e5333927",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4537,7 +4537,7 @@
                             "event": []
                         },
                         {
-                            "id": "1cc24f8d-24d9-4e76-819f-6905dbe635f2",
+                            "id": "9a212d83-a40c-4c81-a84c-34674e3e8945",
                             "name": "Cancel a letter",
                             "request": {
                                 "name": "Cancel a letter",
@@ -4569,7 +4569,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "77ab5d72-3e1a-45ab-9daf-4a6680fb63a9",
+                                    "id": "83df18b4-d62a-4f4b-b4ec-d3c0db5eeb43",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -4609,12 +4609,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "cb4b4d0d-66df-4dc7-a1fc-6d4551ba0482",
+                                    "id": "587cdefd-e594-4d55-8deb-1f300943a43f",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -4668,11 +4668,11 @@
             "event": []
         },
         {
-            "id": "d3ed31c0-d6ea-4b52-994a-f2ac5fe85aac",
+            "id": "33cc8f57-f879-49b0-9654-cca204140b39",
             "name": "postcards",
             "item": [
                 {
-                    "id": "3ceff6c9-2fc5-4d7d-8a5a-a51ba09e8b45",
+                    "id": "d799c896-7955-47aa-9223-7a5f41bfc98e",
                     "name": "List all postcards",
                     "request": {
                         "name": "List all postcards",
@@ -4720,7 +4720,7 @@
                     },
                     "response": [
                         {
-                            "id": "40565e83-6871-4156-81ab-9de9c9cca28d",
+                            "id": "64d96452-a88c-4d77-b51e-50e60156eb19",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -4784,7 +4784,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3f598633-02d6-4e96-8a2d-bcd5f0ac42a4",
+                            "id": "209302fc-0094-4e6e-9194-8ac02bcfaa1b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4851,7 +4851,7 @@
                     "event": []
                 },
                 {
-                    "id": "5f314af5-ce20-4934-8d8d-1a7a600d9fae",
+                    "id": "a3d408de-0362-447c-98eb-dd0b027e6244",
                     "name": "Creates a new postcard object",
                     "request": {
                         "name": "Creates a new postcard object",
@@ -4921,7 +4921,7 @@
                     },
                     "response": [
                         {
-                            "id": "b632b444-6d82-49dc-8ba8-ab51520ff1fb",
+                            "id": "ef899e0f-fe49-4311-8608-90c210124613",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -5028,7 +5028,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "92b0bc0c-0529-4358-8251-4e4345c15945",
+                            "id": "cf114518-0891-47a6-88bf-1a79f6d58d51",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5120,11 +5120,11 @@
                     "event": []
                 },
                 {
-                    "id": "9029d254-cd75-46af-b6ec-419159f09acc",
+                    "id": "2eb6530f-22d3-4083-ab58-44a36d740c75",
                     "name": "{psc id}",
                     "item": [
                         {
-                            "id": "fae1402a-f444-4175-af12-c21c4bf352bf",
+                            "id": "42118fa5-8c9a-452e-95c1-d403709dedb3",
                             "name": "Retrieve postcard with given id",
                             "request": {
                                 "name": "Retrieve postcard with given id",
@@ -5156,7 +5156,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "b95a01b8-b982-436c-96ab-5cc0b4bfc799",
+                                    "id": "f4d85f9a-3fab-4bb7-a558-7b535d938c36",
                                     "name": "Returns a postcard object",
                                     "originalRequest": {
                                         "url": {
@@ -5219,7 +5219,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "dee4f6df-2b9d-452f-98e1-b22b6ea68c71",
+                                    "id": "8693d1e2-a2f0-49e2-8a67-0821c8bb53f0",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5267,7 +5267,7 @@
                             "event": []
                         },
                         {
-                            "id": "dd11d000-569c-42cb-98cb-22d9006b8f8f",
+                            "id": "b13a3fb6-7422-498a-a355-5663f2609126",
                             "name": "Cancels postcard with given id",
                             "request": {
                                 "name": "Cancels postcard with given id",
@@ -5299,7 +5299,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "ba2d3e58-f091-4dec-a04a-428ff008ce5c",
+                                    "id": "089ff762-bd99-472b-ab19-e530a653727f",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -5339,12 +5339,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "d9ef9519-9dc4-40f8-bb92-66adef8f1b79",
+                                    "id": "61a3a4f7-9b3e-4843-a95c-5dac123a7012",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -5398,11 +5398,11 @@
             "event": []
         },
         {
-            "id": "001f6178-926d-4605-8443-ad5faee5e251",
+            "id": "0b037e40-ca1d-4e58-9f5a-171a0559f7e9",
             "name": "self mailers",
             "item": [
                 {
-                    "id": "cffc8755-0f83-4c5a-9da6-584831bcb454",
+                    "id": "9bb53bee-6fa3-40fe-bc3a-0e49dd249081",
                     "name": "List all self_mailers",
                     "request": {
                         "name": "List all self_mailers",
@@ -5450,7 +5450,7 @@
                     },
                     "response": [
                         {
-                            "id": "db83be8e-41c6-4977-9b5b-7d69d84f8d34",
+                            "id": "660f6f59-81e2-4a56-a084-54369ded6221",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -5532,7 +5532,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "89f546d9-9ab5-4901-89f8-acda739045cf",
+                            "id": "55cd66d6-c28c-4513-aca1-b83f4e283aa3",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5599,7 +5599,7 @@
                     "event": []
                 },
                 {
-                    "id": "fc965ccf-24e7-42c7-bf1b-10c1037cfd1c",
+                    "id": "4955756b-69e9-4e50-acab-15a5f4e2b15c",
                     "name": "Creates a new self_mailer object",
                     "request": {
                         "name": "Creates a new self_mailer object",
@@ -5669,7 +5669,7 @@
                     },
                     "response": [
                         {
-                            "id": "1054f48c-0042-49ac-a6c0-dd90ba31bdb5",
+                            "id": "67d57908-907e-4ad0-9893-aa41a2fcbf3e",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -5776,7 +5776,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2d3db289-e936-414c-8474-60e24b4a33ac",
+                            "id": "5835bd4f-a1c2-4510-b38a-775be83ccb45",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5868,11 +5868,11 @@
                     "event": []
                 },
                 {
-                    "id": "98c8dbb4-35af-466a-80d8-e501c14da722",
+                    "id": "dff98d22-7f9d-48a2-b95a-23c3e9254215",
                     "name": "{sfm id}",
                     "item": [
                         {
-                            "id": "71f2f921-0b30-4577-a35e-102b9c4b5d70",
+                            "id": "7564c5a2-1211-4a2c-9793-fca24caabe9f",
                             "name": "Retrieve self_mailer with given id",
                             "request": {
                                 "name": "Retrieve self_mailer with given id",
@@ -5904,7 +5904,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "131d1401-26ed-4955-b198-0151834500c6",
+                                    "id": "4e883b64-4312-4da1-adad-4421c0745780",
                                     "name": "Returns a self_mailer object",
                                     "originalRequest": {
                                         "url": {
@@ -5967,7 +5967,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "4b2b83cd-b855-48a9-8fb1-ce7253a597f7",
+                                    "id": "9759e887-057f-43d2-b6e7-733d9d44b70c",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6015,7 +6015,7 @@
                             "event": []
                         },
                         {
-                            "id": "6fe3f52b-73b0-42ce-9427-077038774bd4",
+                            "id": "d3545029-7309-463b-9f39-333a411aa9d8",
                             "name": "Deletes self_mailer with given id",
                             "request": {
                                 "name": "Deletes self_mailer with given id",
@@ -6047,7 +6047,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "6d535d88-3be8-4150-bc2b-960850bbd76e",
+                                    "id": "dd38eb88-0e6c-4c76-a401-4ea2a148ddc6",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -6087,12 +6087,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "80467e84-187b-44b7-9d83-b076e4ec29cb",
+                                    "id": "8d107701-3eb3-49e1-9325-a2ef02954123",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6146,11 +6146,11 @@
             "event": []
         },
         {
-            "id": "db576008-041b-4952-8651-3c6b819ef4cb",
+            "id": "3a4a56dd-685e-497e-b0c5-56b5f3595b1e",
             "name": "templates",
             "item": [
                 {
-                    "id": "3f7efa3f-1dbf-47d0-a3a6-d9c0554d4447",
+                    "id": "031d761a-7a8c-4d99-9026-6799671c714a",
                     "name": "List all templates",
                     "request": {
                         "name": "List all templates",
@@ -6198,7 +6198,7 @@
                     },
                     "response": [
                         {
-                            "id": "f3398aec-ffe1-4477-967d-1c523ef56252",
+                            "id": "c8e93859-e857-417d-a4fc-9129ef44e0b7",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -6280,7 +6280,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0c849186-189c-4a53-8943-987cd0b4912b",
+                            "id": "07a0e024-a599-48ce-af4f-77d9f6f01bcb",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6347,7 +6347,7 @@
                     "event": []
                 },
                 {
-                    "id": "0118f4e1-3d64-4a47-902b-2d7840eb1bda",
+                    "id": "095e8a09-a21f-4a9f-9080-0ded36986419",
                     "name": "Creates a new template object",
                     "request": {
                         "name": "Creates a new template object",
@@ -6398,7 +6398,7 @@
                     },
                     "response": [
                         {
-                            "id": "b38b4a63-6753-4b0b-976b-c7ab211b088c",
+                            "id": "962465d5-9412-4cbb-8c40-e8246b8f0610",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -6489,7 +6489,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3fade44e-7f5f-4b15-85d1-fff5fb903a62",
+                            "id": "43124b78-d41b-468e-a664-d154b6765a3e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6565,11 +6565,11 @@
                     "event": []
                 },
                 {
-                    "id": "76c227d3-4464-459c-96b6-5b0776044475",
+                    "id": "d96791ef-007e-4f53-b7a6-99647b49b397",
                     "name": "{tmpl id}",
                     "item": [
                         {
-                            "id": "e7d53bc1-1124-44b3-a7c9-f3d7945364b1",
+                            "id": "8b3401cb-533a-44ea-a5f0-cb773beb6cab",
                             "name": "Retrieve template with given id",
                             "request": {
                                 "name": "Retrieve template with given id",
@@ -6601,7 +6601,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "ebd8cbd2-d280-4c70-a574-88c2a857b6e9",
+                                    "id": "9183d41e-f89f-4bff-93d8-ad3ddfbe3d7f",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6664,7 +6664,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "e6f8e4fe-e92a-407f-99da-9ff85706d080",
+                                    "id": "bafdccc3-f456-47a3-8b2c-3937e5a6a564",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6712,7 +6712,7 @@
                             "event": []
                         },
                         {
-                            "id": "f3690548-6a68-4d3e-8e8f-20784b4396ab",
+                            "id": "342fa089-6544-4e55-981e-61ccf9ea43c1",
                             "name": "Update description and/or published version of a template.",
                             "request": {
                                 "name": "Update description and/or published version of a template.",
@@ -6771,7 +6771,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "8a0e29e4-5073-42b1-b85d-7857a5b1f552",
+                                    "id": "28dcbfe7-66cb-4027-b8c2-b1648ec063c1",
                                     "name": "Returns a template object",
                                     "originalRequest": {
                                         "url": {
@@ -6854,7 +6854,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "8ec33e83-90dd-46ba-aef3-80770c272d45",
+                                    "id": "21ab662d-152e-4082-9efb-6ea5ae794bc7",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -6922,7 +6922,7 @@
                             "event": []
                         },
                         {
-                            "id": "dd363ae8-4ed7-468c-9939-81788232d22e",
+                            "id": "5c657773-c509-49b9-a143-685d69f52f8b",
                             "name": "Deletes template with given id",
                             "request": {
                                 "name": "Deletes template with given id",
@@ -6954,7 +6954,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d2377c67-0649-405a-ab25-96bcfdd3ecfb",
+                                    "id": "139e7f54-37c5-4187-a607-266a74158cfd",
                                     "name": "Returns true if the delete was successful",
                                     "originalRequest": {
                                         "url": {
@@ -6994,12 +6994,12 @@
                                             "value": "application/json"
                                         }
                                     ],
-                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "b5433640-6558-4b8d-a36f-95572cde9de0",
+                                    "id": "aee42cc3-0c32-4ed7-a19b-cb84866d6488",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -7047,11 +7047,11 @@
                             "event": []
                         },
                         {
-                            "id": "5fdd1580-64c3-440d-aa8d-79968f6f3b7e",
+                            "id": "f4753a02-1b2d-47ff-9ea7-ab8b90b5a904",
                             "name": "versions",
                             "item": [
                                 {
-                                    "id": "259129f1-9ff3-4443-a60d-5f42d05a436d",
+                                    "id": "be68c640-8d0e-4140-bfec-adf103f9c9b3",
                                     "name": "List all template_versions",
                                     "request": {
                                         "name": "List all template_versions",
@@ -7109,7 +7109,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "309ab6bc-4bf9-4bb0-86cc-74422dc115ef",
+                                            "id": "9f69273c-672a-4c14-91df-9c281e0f1cc2",
                                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                                             "originalRequest": {
                                                 "url": {
@@ -7190,7 +7190,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "8308a98c-1e4f-4e79-8284-b5517917f2f3",
+                                            "id": "6abe0d27-5ebf-40ca-8d75-470d40986c05",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -7256,7 +7256,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "0d413964-49df-4b75-a4d4-cb2d3b6a9f9d",
+                                    "id": "62d6e86f-9f7a-4b44-a2d8-448c1a7ed759",
                                     "name": "Creates a new template_version object",
                                     "request": {
                                         "name": "Creates a new template_version object",
@@ -7317,7 +7317,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "4882944f-f5ff-4615-8f28-f5a54542dc1a",
+                                            "id": "1e950951-d956-4df2-bf8b-05681a2663f8",
                                             "name": "Returns the template version with the given template and version ids.",
                                             "originalRequest": {
                                                 "url": {
@@ -7405,7 +7405,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d7acb46d-e2d7-441b-ab6a-a3e5203f9df8",
+                                            "id": "447edc58-1bf3-4358-b080-a0d3740a7b03",
                                             "name": "Error",
                                             "originalRequest": {
                                                 "url": {
@@ -7478,11 +7478,11 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "e1087285-575d-4af7-ab3d-eee77fe79a2e",
+                                    "id": "fcc4894d-d502-4897-b5ce-bfd11b3cb27a",
                                     "name": "{vrsn id}",
                                     "item": [
                                         {
-                                            "id": "55b2d382-bbc2-48c8-a9d8-6419b6342954",
+                                            "id": "944fd48d-eabb-43e7-92c9-2c9858144fe0",
                                             "name": "Retrieve template version with given template and version ids.",
                                             "request": {
                                                 "name": "Retrieve template version with given template and version ids.",
@@ -7523,7 +7523,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "039d0ad7-df66-42ae-b1df-ebc504be10f2",
+                                                    "id": "4c342428-a284-4aaf-84d1-e1474206182a",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7592,7 +7592,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "de603574-445d-4393-b884-66183f460f2c",
+                                                    "id": "13c4b782-1092-4914-a27d-7002d7ce304d",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7646,7 +7646,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "c5e9fad3-2b45-4cf0-a994-559244a87a03",
+                                            "id": "76db7a80-2593-492c-8778-bcc8e326355e",
                                             "name": "Updates the template version with given template and version ids.",
                                             "request": {
                                                 "name": "Updates the template version with given template and version ids.",
@@ -7709,7 +7709,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "7b59c95d-08c6-47eb-8321-0fc5ea28c2e0",
+                                                    "id": "dc30841e-4720-4890-ac87-60c360bbc30e",
                                                     "name": "Returns the template version with the given template and version ids.",
                                                     "originalRequest": {
                                                         "url": {
@@ -7793,7 +7793,7 @@
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "e402909a-02d3-48aa-8ec2-852fe8ccc5ff",
+                                                    "id": "fbef1804-1452-4dc2-9cf0-1d2d090308e6",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -7862,7 +7862,7 @@
                                             "event": []
                                         },
                                         {
-                                            "id": "4bea27f5-0a62-4295-a2e9-9c5ffe031dd1",
+                                            "id": "b3191834-3515-4bbb-9c74-da9f7b76cb57",
                                             "name": "Deletes the template version with given template and version ids if possible.",
                                             "request": {
                                                 "name": "Deletes the template version with given template and version ids if possible.",
@@ -7903,7 +7903,7 @@
                                             },
                                             "response": [
                                                 {
-                                                    "id": "47ea07f3-7c9a-4c1f-8a6c-43ce63298476",
+                                                    "id": "dadd43bd-465d-41ab-ab74-30d7a021edf0",
                                                     "name": "Returns true if the delete was successful",
                                                     "originalRequest": {
                                                         "url": {
@@ -7949,12 +7949,12 @@
                                                             "value": "application/json"
                                                         }
                                                     ],
-                                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": true\n}",
+                                                    "body": "{\n \"id\": \"<string>\",\n \"deleted\": false\n}",
                                                     "cookie": [],
                                                     "_postman_previewlanguage": "json"
                                                 },
                                                 {
-                                                    "id": "9aee8cea-e024-4e85-a32d-a71f31f25b92",
+                                                    "id": "6b73efed-8d9a-41f5-afd9-a0ba8a0dd76c",
                                                     "name": "Error",
                                                     "originalRequest": {
                                                         "url": {
@@ -8014,7 +8014,7 @@
                             "event": []
                         },
                         {
-                            "id": "d330eb6e-908c-4ae8-a037-e6bda623c71e",
+                            "id": "81302bd6-6cf9-40ac-bdd0-eb29e790e85a",
                             "name": "Compile the template into html",
                             "request": {
                                 "name": "Compile the template into html",
@@ -8060,7 +8060,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0efb9248-ee0c-4e75-89fd-6df2a5a34479",
+                                    "id": "8d17dba3-0bac-413c-b9ca-19a541719764",
                                     "name": "Returns the compiled html",
                                     "originalRequest": {
                                         "url": {
@@ -8115,7 +8115,7 @@
                                     "_postman_previewlanguage": "text"
                                 },
                                 {
-                                    "id": "88cb74d2-c148-403b-97cc-8350437fadbf",
+                                    "id": "e94044ca-ee20-4a41-88aa-7af40ffaf406",
                                     "name": "Error",
                                     "originalRequest": {
                                         "url": {
@@ -8179,7 +8179,7 @@
             "event": []
         },
         {
-            "id": "a726f735-0492-4f7d-ad4a-b5d5bbfe2a4c",
+            "id": "d8e6de43-5b88-4189-a61b-ffaff298a95c",
             "name": "Autocomplete a partial US address.",
             "request": {
                 "name": "Autocomplete a partial US address.",
@@ -8243,7 +8243,7 @@
             },
             "response": [
                 {
-                    "id": "e927f96d-d66f-4970-9bdc-71f234659f42",
+                    "id": "dae7a1f9-415d-45a2-a0f5-7a7531407a27",
                     "name": "Returns a US autocompletion object.",
                     "originalRequest": {
                         "url": {
@@ -8349,7 +8349,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "f7ea07e5-6307-4a4d-9b83-146ecbe257d3",
+                    "id": "9a69b29f-46a0-45a4-90d7-4c4ce7b91ffc",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8440,7 +8440,7 @@
             "event": []
         },
         {
-            "id": "b89df972-007c-4e5e-93a7-cc828e6220c6",
+            "id": "fe756643-edf2-40b6-a5e0-3866603a5866",
             "name": "Verify a US or US territory address with a live API key.",
             "request": {
                 "name": "Verify a US or US territory address with a live API key.",
@@ -8480,7 +8480,7 @@
             },
             "response": [
                 {
-                    "id": "aa710bd2-4127-47bc-a357-b492f5618322",
+                    "id": "a9e88785-901c-49dd-8f70-7de78d16b1de",
                     "name": "Returns a US verification object.",
                     "originalRequest": {
                         "url": {
@@ -8545,7 +8545,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "7926f04d-7a34-4beb-ad5c-82f50fec2c01",
+                    "id": "955a2fb1-5e73-4dab-bc6b-c95a308e5d67",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8595,7 +8595,7 @@
             "event": []
         },
         {
-            "id": "21cd8a5e-cebd-45be-a68c-bd918b516294",
+            "id": "44646b62-f764-4d43-bfae-fb428ef47fc1",
             "name": "Looks up information pertaining to a given ZIP code",
             "request": {
                 "name": "Looks up information pertaining to a given ZIP code",
@@ -8635,7 +8635,7 @@
             },
             "response": [
                 {
-                    "id": "d1cde43b-9e8e-49b2-8931-db6b5c5b6c71",
+                    "id": "9a1a99d1-da39-4b80-bf9a-819d3a734651",
                     "name": "Returns a zip lookup object if a valid zip was provided.",
                     "originalRequest": {
                         "url": {
@@ -8700,12 +8700,12 @@
                             "value": "application/json"
                         }
                     ],
-                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"a\",\n   \"county\": \"ea\",\n   \"county_fips\": \"10763\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"do\",\n   \"county\": \"labore ut ex volu\",\n   \"county_fips\": \"71064\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"military\"\n}",
+                    "body": "{\n \"cities\": [\n  {\n   \"city\": \"<string>\",\n   \"state\": \"m\",\n   \"county\": \"Lorem ut\",\n   \"county_fips\": \"76906\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"<string>\",\n   \"state\": \"n\",\n   \"county\": \"fugiat\",\n   \"county_fips\": \"49650\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"unique\"\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "b1a279a1-d309-4fa6-b63f-cd3dc2776ee9",
+                    "id": "39d68a10-187a-4165-b3e3-112bbcd70092",
                     "name": "Error",
                     "originalRequest": {
                         "url": {
@@ -8782,7 +8782,7 @@
         ]
     },
     "info": {
-        "_postman_id": "287950db-f4fb-4887-b46e-955bb2763bb4",
+        "_postman_id": "036d808e-94f7-4417-9407-e8d97a44e700",
         "name": "Lob API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/tests/checks_test.js
+++ b/tests/checks_test.js
@@ -11,97 +11,98 @@ const resource_endpoint = "/checks",
 
 const prism = new Prism(specFile, lobUri, process.env.LOB_API_TEST_TOKEN);
 
-// We need a verified bank account to create a check, so let's make that first
-prism
-  .setup()
-  .then((client) =>
-    client.post(
-      "/bank_accounts",
-      {
-        description: "Test Bank Account",
-        routing_number: "322271627",
-        account_number: "123456789",
-        signatory: "Jane Doe",
-        account_type: "individual",
-      },
-      { headers: prism.authHeader }
-    )
-  )
-  .then((result) => {
-    const bank_id = result.data.id;
+test.serial.before(
+  "create & validate verified bank account, and create & read a check",
+  async function (t) {
+    t.plan(3);
+    // We need a verified bank account to create a check, so let's make that first
+    let result = await prism.setup().then((client) =>
+      client.post(
+        "/bank_accounts",
+        {
+          description: "Test Bank Account",
+          routing_number: "322271627",
+          account_number: "123456789",
+          signatory: "Jane Doe",
+          account_type: "individual",
+        },
+        { headers: prism.authHeader }
+      )
+    );
 
-    test.serial("validate bank account to use for checks", async function (t) {
-      t.plan(1);
-      const verify = await prism
-        .setup()
-        .then((client) =>
-          client.post(
-            `/bank_accounts/${bank_id}/verify`,
-            { amounts: [42, 12] },
-            { headers: prism.authHeader }
-          )
-        );
-      t.assert(verify.status === 200);
-    });
+    t.context.bank_id = result.data.id;
 
-    test.serial("create, list, read then delete a check", async function (t) {
-      t.plan(4);
-      const create = await prism.setup({ errors: false }).then((client) =>
+    const verify = await prism
+      .setup()
+      .then((client) =>
         client.post(
-          resource_endpoint,
-          {
-            description: "Demo Check",
-            to: {
-              company: "Lob (old)",
-              address_line1: "185 Berry St",
-              address_line2: "# 6100",
-              address_city: "San Francisco",
-              address_state: "CA",
-              address_zip: "94107",
-              address_country: "US",
-            },
-            from: {
-              company: "Lob (new)",
-              address_line1: "210 King St",
-              address_city: "San Francisco",
-              address_state: "CA",
-              address_zip: "94107",
-              address_country: "US",
-            },
-            bank_account: bank_id,
-            amount: 101.01,
-            memo: "poodles",
-            message: "End Racism",
-          },
+          `/bank_accounts/${t.context.bank_id}/verify`,
+          { amounts: [42, 12] },
           { headers: prism.authHeader }
         )
       );
-      t.assert(create.status === 200);
+    t.assert(verify.status === 200);
 
-      const list = await prism
-        .setup()
-        .then((client) =>
-          client.get(resource_endpoint, { headers: prism.authHeader })
-        );
-      t.assert(list.status === 200);
+    t.context.create = await prism.setup({ errors: false }).then((client) =>
+      client.post(
+        resource_endpoint,
+        {
+          description: "Demo Check",
+          to: {
+            company: "Lob (old)",
+            address_line1: "185 Berry St",
+            address_line2: "# 6100",
+            address_city: "San Francisco",
+            address_state: "CA",
+            address_zip: "94107",
+            address_country: "US",
+          },
+          from: {
+            company: "Lob (new)",
+            address_line1: "210 King St",
+            address_city: "San Francisco",
+            address_state: "CA",
+            address_zip: "94107",
+            address_country: "US",
+          },
+          bank_account: t.context.bank_id,
+          amount: 101.01,
+          memo: "poodles",
+          message: "End Racism",
+        },
+        { headers: prism.authHeader }
+      )
+    );
+    t.assert(t.context.create.status === 200);
 
-      const read = await prism.setup().then((client) =>
-        client.get(`${resource_endpoint}/${create.data.id}`, {
-          headers: prism.authHeader,
-        })
-      );
-      t.assert(read.status === 200);
+    t.context.read = await prism.setup().then((client) =>
+      client.get(`${resource_endpoint}/${t.context.create.data.id}`, {
+        headers: prism.authHeader,
+      })
+    );
+    t.assert(t.context.read.status === 200);
+  }
+);
 
-      const remove = await prism.setup().then((client) =>
-        client.delete(`${resource_endpoint}/${read.data.id}`, {
-          headers: prism.authHeader,
-        })
-      );
-      t.assert(remove.status === 200);
-      prism.setup().then((client) =>
-        client.delete(`/bank_accounts/${bank_id}`, {
-          headers: prism.authHeader,
-        })
-      );
-    });
-  });
+test("list check", async function (t) {
+  const list = await prism
+    .setup()
+    .then((client) =>
+      client.get(resource_endpoint, { headers: prism.authHeader })
+    );
+  t.assert(list.status === 200);
+});
+
+test.after.always("delete a check", async function (t) {
+  const remove = await prism.setup().then((client) =>
+    client.delete(`${resource_endpoint}/${t.context.read.data.id}`, {
+      headers: prism.authHeader,
+    })
+  );
+  t.assert(remove.status === 200);
+  prism.setup().then((client) =>
+    client.delete(`/bank_accounts/${t.context.bank_id}`, {
+      headers: prism.authHeader,
+    })
+  );
+});

--- a/tests/template_versions_test.js
+++ b/tests/template_versions_test.js
@@ -10,85 +10,98 @@ const lobUri = "https://api.lob.com/v1",
 
 const prism = new Prism(specFile, lobUri, process.env.LOB_API_TEST_TOKEN);
 
-// create a template to use for test
-prism
-  .setup()
-  .then((client) =>
-    client.post(
-      "/templates",
-      {
-        description: "Test Template Versions",
-        html: "<html>HTML for other</html>",
-      },
-      { headers: prism.authHeader }
-    )
-  )
-  .then((result) => {
-    const tmpl_endpoint = `/templates/${result.data.id}`;
-    const resource_endpoint = `${tmpl_endpoint}/versions`;
+let vrsn_endpoint = "";
 
-    test("list, create, retrieve, update then delete a new template version", async function (t) {
-      t.plan(5);
-      // list version created when template was created
-      let response = await prism
-        .setup()
-        .then((client) =>
-          client.get(resource_endpoint, { headers: prism.authHeader })
-        );
+test.serial.before(
+  "create and update templates & endpoints to use in tests",
+  async function (t) {
+    t.plan(1);
+    // create a template to use for test
+    let result = await prism.setup().then((client) =>
+      client.post(
+        "/templates",
+        {
+          description: "Test Template Versions",
+          html: "<html>HTML for other</html>",
+        },
+        { headers: prism.authHeader }
+      )
+    );
 
-      t.assert(response.status === 200);
+    // ADDED THESE IN HERE
+    t.context.tmpl_endpoint = `/templates/${result.data.id}`;
+    t.context.resource_endpoint = `${t.context.tmpl_endpoint}/versions`;
 
-      // create new version
-      response = await prism.setup().then((client) =>
-        client.post(
-          resource_endpoint,
-          {
-            description: "Updated Template",
-            html: "<html>Updated HTML</html>",
-          },
-          { headers: prism.authHeader }
-        )
-      );
+    let response = await prism.setup().then((client) =>
+      client.post(
+        t.context.resource_endpoint,
+        {
+          description: "Updated Template",
+          html: "<html>Updated HTML</html>",
+        },
+        { headers: prism.authHeader }
+      )
+    );
 
-      t.assert(response.status === 200);
-      const vrsn_endpoint = `${resource_endpoint}/${response.data.id}`;
+    t.assert(response.status === 200);
+    t.context.vrsn_endpoint = `${t.context.resource_endpoint}/${response.data.id}`;
+  }
+);
 
-      // retrieve
-      response = await prism.setup().then((client) =>
-        client.get(vrsn_endpoint, {
-          headers: prism.authHeader,
-        })
-      );
+test.serial("retrieve a new template version", async function (t) {
+  t.plan(1);
+  let response = await prism.setup().then((client) =>
+    client.get(t.context.vrsn_endpoint, {
+      headers: prism.authHeader,
+    })
+  );
 
-      t.assert(response.status === 200);
+  t.assert(response.status === 200);
+});
 
-      // update
-      response = await prism
-        .setup()
-        .then((client) =>
-          client.post(
-            vrsn_endpoint,
-            { description: "new description " },
-            { headers: prism.authHeader }
-          )
-        );
+test.serial("update a new template version", async function (t) {
+  t.plan(1);
+  let response = await prism
+    .setup()
+    .then((client) =>
+      client.post(
+        t.context.vrsn_endpoint,
+        { description: "new description " },
+        { headers: prism.authHeader }
+      )
+    );
 
-      t.assert(response.status === 200);
+  t.assert(response.status === 200);
+});
 
-      // delete
-      response = await prism.setup().then((client) =>
-        client.delete(vrsn_endpoint, {
-          headers: prism.authHeader,
-        })
-      );
+test.serial("list template versions", async function (t) {
+  t.plan(1);
+  let response = await prism
+    .setup()
+    .then((client) =>
+      client.get(t.context.resource_endpoint, { headers: prism.authHeader })
+    );
 
-      t.assert(response.status === 200);
+  t.assert(response.status === 200);
+});
 
-      // clean up template too!
-      prism.setup().then((client) =>
-        client.delete(tmpl_endpoint, {
-          headers: prism.authHeader,
-        })
-      );
-    });
-  });
+test.serial("delete template", async function (t) {
+  t.plan(1);
+  // delete
+  let response = await prism.setup().then((client) =>
+    client.delete(t.context.vrsn_endpoint, {
+      headers: prism.authHeader,
+    })
+  );
+
+  t.assert(response.status === 200);
+});
+
+test.after.always("clean up template", async function (t) {
+  // clean up template too!
+  prism.setup().then((client) =>
+    client.delete(t.context.tmpl_endpoint, {
+      headers: prism.authHeader,
+    })
+  );
+});


### PR DESCRIPTION
The template tests could have benefited from use of `ava`'s `serial` mechanism, so I added it in.

What's cool is that you can add assertions into the hooks, so I moved some of the tests to the `serial.before` hooks in some files, in order to maintain the integrity of the async code. They're not counted as tests in the final count, but if they fail they'll definitely toss up some errors (pictured below–an openapi-alerts message triggered by a failed assertion within the `serial.before` hook in `checks_test.js`):

<img width="998" alt="Screen Shot 2021-06-25 at 12 51 07 PM" src="https://user-images.githubusercontent.com/15935019/123478278-13ec1280-d5b4-11eb-9407-06424edfbb7e.png">
