### PR TITLE
feat(urlencoded): add urlencoded tests

### DIFF
--- a/tests/bank_accounts_test.js
+++ b/tests/bank_accounts_test.js
@@ -11,22 +11,22 @@ const resource_endpoint = "/bank_accounts",
 
 const prism = new Prism(specFile, lobUri, process.env.LOB_API_TEST_TOKEN);
 
+const payload = {
+  description: "Test Bank Account",
+  routing_number: "322271627",
+  account_number: "123456789",
+  signatory: "Jane Doe",
+  account_type: "individual",
+};
+
 // contract tests happy path
 test("create, list, read, verify, then delete a bank_account", async function (t) {
   t.plan(6);
-  const create = await prism.setup().then((client) =>
-    client.post(
-      resource_endpoint,
-      {
-        description: "Test Bank Account",
-        routing_number: "322271627",
-        account_number: "123456789",
-        signatory: "Jane Doe",
-        account_type: "individual",
-      },
-      { headers: prism.authHeader }
-    )
-  );
+  const create = await prism
+    .setup()
+    .then((client) =>
+      client.post(resource_endpoint, payload, { headers: prism.authHeader })
+    );
   t.assert(create.status === 200);
 
   const list = await prism
@@ -65,16 +65,10 @@ test("create, list, read, verify, then delete a bank_account", async function (t
 
 test("create, list, read, verify, then delete a bank_account urlencoded", async function (t) {
   t.plan(6);
-  const payload = new URLSearchParams({
-    description: "Test Bank Account",
-    routing_number: "322271627",
-    account_number: "123456789",
-    signatory: "Jane Doe",
-    account_type: "individual",
-  }).toString();
+  const body = new URLSearchParams(payload).toString();
 
   const create = await prism.setup().then((client) =>
-    client.post(resource_endpoint, payload, {
+    client.post(resource_endpoint, body, {
       headers: {
         ...prism.authHeader,
         "content-type": "application/x-www-form-urlencoded; charset=UTF-8",

--- a/tests/checks_test.js
+++ b/tests/checks_test.js
@@ -11,6 +11,13 @@ const resource_endpoint = "/checks",
 
 const prism = new Prism(specFile, lobUri, process.env.LOB_API_TEST_TOKEN);
 
+const payload = {
+  description: "Demo Check",
+  amount: 101.01,
+  memo: "poodles",
+  message: "End Racism",
+};
+
 // TODO: add full payload req
 test.serial.before(
   "create & validate verified bank account, and create & read a check",
@@ -48,7 +55,7 @@ test.serial.before(
       client.post(
         resource_endpoint,
         {
-          description: "Demo Check",
+          ...payload,
           to: {
             company: "Lob (old)",
             address_line1: "185 Berry St",
@@ -67,9 +74,6 @@ test.serial.before(
             address_country: "US",
           },
           bank_account: t.context.bank_id,
-          amount: 101.01,
-          memo: "poodles",
-          message: "End Racism",
         },
         { headers: prism.authHeader }
       )
@@ -85,6 +89,88 @@ test.serial.before(
   }
 );
 
+test.serial.before(
+  "create & validate verified bank account, and create & read a check urlencoded",
+  async function (t) {
+    t.plan(3);
+    // We need a verified bank account to create a check, so let's make that first
+    let result = await prism.setup().then((client) =>
+      client.post(
+        "/bank_accounts",
+        {
+          description: "Test Bank Account",
+          routing_number: "322271627",
+          account_number: "123456789",
+          signatory: "Jane Doe",
+          account_type: "individual",
+        },
+        { headers: prism.authHeader }
+      )
+    );
+
+    t.context.bank_id2 = result.data.id;
+
+    const verify = await prism
+      .setup()
+      .then((client) =>
+        client.post(
+          `/bank_accounts/${t.context.bank_id2}/verify`,
+          { amounts: [42, 12] },
+          { headers: prism.authHeader }
+        )
+      );
+    t.assert(verify.status === 200);
+
+    let body = new URLSearchParams({
+      ...payload,
+      bank_account: t.context.bank_id2,
+    });
+
+    const deepObjs = {
+      to: {
+        company: "Lob (old)",
+        address_line1: "185 Berry St",
+        address_line2: "# 6100",
+        address_city: "San Francisco",
+        address_state: "CA",
+        address_zip: "94107",
+        address_country: "US",
+      },
+      from: {
+        company: "Lob (new)",
+        address_line1: "210 King St",
+        address_city: "San Francisco",
+        address_state: "CA",
+        address_zip: "94107",
+        address_country: "US",
+      },
+    };
+    for (const key in deepObjs) {
+      Object.entries(deepObjs[key]).forEach(([innerKey, innerVal]) => {
+        body.append(`${key}[${innerKey}]`, `${innerVal}`);
+      });
+    }
+    body = body.toString();
+
+    t.context.create2 = await prism.setup({ errors: false }).then((client) =>
+      client.post(resource_endpoint, body, {
+        headers: {
+          ...prism.authHeader,
+          "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+        },
+      })
+    );
+    t.assert(t.context.create2.status === 200);
+
+    t.context.read2 = await prism.setup().then((client) =>
+      client.get(`${resource_endpoint}/${t.context.create2.data.id}`, {
+        headers: prism.authHeader,
+      })
+    );
+    t.assert(t.context.read2.status === 200);
+  }
+);
+
 test("list check", async function (t) {
   const list = await prism
     .setup()
@@ -94,7 +180,7 @@ test("list check", async function (t) {
   t.assert(list.status === 200);
 });
 
-test.after.always("delete a check", async function (t) {
+test.after.always("delete all checks", async function (t) {
   const remove = await prism.setup().then((client) =>
     client.delete(`${resource_endpoint}/${t.context.read.data.id}`, {
       headers: prism.authHeader,
@@ -103,6 +189,18 @@ test.after.always("delete a check", async function (t) {
   t.assert(remove.status === 200);
   prism.setup().then((client) =>
     client.delete(`/bank_accounts/${t.context.bank_id}`, {
+      headers: prism.authHeader,
+    })
+  );
+
+  const remove2 = await prism.setup().then((client) =>
+    client.delete(`${resource_endpoint}/${t.context.read2.data.id}`, {
+      headers: prism.authHeader,
+    })
+  );
+  t.assert(remove2.status === 200);
+  prism.setup().then((client) =>
+    client.delete(`/bank_accounts/${t.context.bank_id2}`, {
       headers: prism.authHeader,
     })
   );

--- a/tests/us_autocompletions_test.js
+++ b/tests/us_autocompletions_test.js
@@ -45,6 +45,28 @@ test("autocomplete an address given a prefix with full payload", async function 
   t.assert(response.status === 200);
 });
 
+test("autocomplete an address given a prefix with full payload urlencoded", async function (t) {
+  t.plan(1);
+  const payload = new URLSearchParams({
+    address_prefix: address_prefix,
+    city: "San Francisco",
+    state: "CA",
+    zip_code: "94107",
+    geo_ip_sort: false,
+  }).toString();
+
+  const response = await prism.setup().then((client) =>
+    client.post(resource_endpoint, payload, {
+      headers: {
+        ...prism.authHeader,
+        "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+      },
+    })
+  );
+
+  t.assert(response.status === 200);
+});
+
 test("errors when address_prefix is not passed in", async function (t) {
   t.plan(2);
   const response = await prism


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/jira/software/projects/DXP/boards/73?selectedIssue=DXP-174)

Aditi advised that I should just do one test for each group (PMAPI, billing, AV) rather than each resource. Chose checks_test, bank_accounts_test, and us_autocompletions_test.

Credit to [this post](https://github.com/OpenAPITools/openapi-generator/issues/7564) for helping me get URL encoding with deep Objects to work.