### PR TITLE
fix prettier

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,9 +12,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: am I pretty?
-        uses: actionsx/prettier@v2
-        with:
-          args: --check .
+        shell: bash
+        run: |
+          set -x
+          npm i prettier
+          npm run pretty
 
       - name: run spectral
         uses: stoplightio/spectral-action@v0.7.0

--- a/dist/Lob-API-postman.json
+++ b/dist/Lob-API-postman.json
@@ -1,7 +1,7 @@
 {
     "item": [
         {
-            "id": "3d54c1c0-80af-4e70-bd35-6416caa1b847",
+            "id": "7cd62dff-a996-477e-bc92-e8a32379fb01",
             "name": "Addresses",
             "description": {
                 "content": "A frictionless address book for use with the print and mail API.",
@@ -9,7 +9,7 @@
             },
             "item": [
                 {
-                    "id": "c4a96bef-3ce8-49d3-8b86-4c768e953fa7",
+                    "id": "555bdf95-ea12-4105-8b56-526b7d71884f",
                     "name": "Retrieve address with given id",
                     "request": {
                         "name": "Retrieve address with given id",
@@ -30,7 +30,7 @@
                                 {
                                     "disabled": false,
                                     "type": "any",
-                                    "value": "adr_4PCLHG",
+                                    "value": "adr_wEi4U",
                                     "key": "adr_id",
                                     "description": "(Required) id of the address"
                                 }
@@ -41,7 +41,7 @@
                     },
                     "response": [
                         {
-                            "id": "4b096dd5-c864-465f-97d2-62e3edb7472e",
+                            "id": "3e98ec88-9c1b-4d6b-99ec-607fbe3c4db2",
                             "name": "Returns an address object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -104,7 +104,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1857a4c7-2d01-4753-b085-ceffc5ec3791",
+                            "id": "7e9986b5-8183-4083-a14c-b4a77e48716d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -152,7 +152,7 @@
                     "event": []
                 },
                 {
-                    "id": "5d49740d-8578-48ce-9e13-c28817f1e0eb",
+                    "id": "4b7aa7f9-8c8a-41e2-b719-240a5561ec48",
                     "name": "Deletes address with given id",
                     "request": {
                         "name": "Deletes address with given id",
@@ -173,7 +173,7 @@
                                 {
                                     "disabled": false,
                                     "type": "any",
-                                    "value": "adr_4PCLHG",
+                                    "value": "adr_wEi4U",
                                     "key": "adr_id",
                                     "description": "(Required) id of the address"
                                 }
@@ -184,7 +184,7 @@
                     },
                     "response": [
                         {
-                            "id": "9ce4b6f8-55aa-4f14-8574-0cdd2fde0604",
+                            "id": "8f044631-060c-4499-aceb-3a9a25a9bf16",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -224,12 +224,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "90555077-dc91-4017-a118-2e18dc978de3",
+                            "id": "c9df997e-54cc-463f-a706-f2de014cd4d7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -277,7 +277,7 @@
                     "event": []
                 },
                 {
-                    "id": "0dbf475e-1c78-439c-90a8-febb8209bcc3",
+                    "id": "095c7a6f-eadc-4218-abbb-a669645134d5",
                     "name": "List all addresses",
                     "request": {
                         "name": "List all addresses",
@@ -325,7 +325,7 @@
                     },
                     "response": [
                         {
-                            "id": "b9bb4873-d188-458f-ad70-81af932741d3",
+                            "id": "765ed3ea-e98c-497e-b9b2-3a6fd30b4222",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -389,7 +389,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cab08586-6c0f-43b5-aaf5-96b337cb9f22",
+                            "id": "9f5df376-e75a-4a9f-86b8-4793300000b8",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -456,7 +456,7 @@
                     "event": []
                 },
                 {
-                    "id": "e4d3aa14-d068-4672-ae8a-d431cc677441",
+                    "id": "ac357bcd-92e5-4b66-86a6-8f4e480f7de4",
                     "name": "Creates a new address object",
                     "request": {
                         "name": "Creates a new address object",
@@ -526,7 +526,7 @@
                     },
                     "response": [
                         {
-                            "id": "1701d80c-0210-4ffc-ab88-e8b58159e4bf",
+                            "id": "c8e28dd4-becc-454e-a8e3-7babd1bde5b4",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -623,7 +623,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c21a08cc-20fb-42f0-8efc-3b8ef9f11b25",
+                            "id": "587a7b77-1f78-47de-b75c-64f785974916",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -708,7 +708,7 @@
             "event": []
         },
         {
-            "id": "885ac2a1-abdd-475a-99db-497607dcbcdc",
+            "id": "9b3ab55c-c965-4e37-9301-fd9dff826e52",
             "name": "API Keys",
             "description": {
                 "content": "Lob authenticates your API requests using your account's API keys.\nIf you do not include your key when making an API request, or use\none that is incorrect or outdated, Lob returns an error with a `401`\nHTTP response code. You can find all API keys in your dashboard under Settings.\n\nThere are two types of API keys: *secret* and *publishable*.\n\n- **Secret API keys** should be kept confidential and only stored on your own servers.\nYour account's secret API key can perform any API request to Lob without restriction.\n\n- **Publishable API keys** are limited to US verifications, international verifications,\nand US autocomplete requests. While we encourage you to use a secret key for maximum\nsecurity, you can publish these keys to JavaScript code or in an Android or iPhone app\nwithout exposing print and mail services or your secret key. Publishable keys are always\nprefixed with `[environment]_pub`.\n\nEvery type comes with a pair of keys: one for the testing environment and one for the\nlive environment. We recommend reading Test and Live Environments for more information.\n",
@@ -718,7 +718,7 @@
             "event": []
         },
         {
-            "id": "44fb5d6c-0202-4ad4-9ccd-a3017611a9f6",
+            "id": "acda8069-1ba4-4059-82c6-ec6b5ef19249",
             "name": "Asset URLs",
             "description": {
                 "content": "All asset URLs returned by the Lob API (postcards, letters, thumbnails, etc) are signed links served over HTTPS. All links returned will expire in 30 days to prevent mis-sharing. Each time a GET request is initiated, a new signed URL will be generated.",
@@ -728,7 +728,7 @@
             "event": []
         },
         {
-            "id": "1ea12b13-beed-4965-b11c-280f0daf9d08",
+            "id": "6eb9e552-21a0-4245-bcb6-8fbf2e8b8ad0",
             "name": "Bank Accounts",
             "description": {
                 "content": "Bank Accounts allow you to store your bank account securely in our system.",
@@ -736,7 +736,7 @@
             },
             "item": [
                 {
-                    "id": "64d62317-bbfe-4b83-a00b-c77bf7159dcf",
+                    "id": "920141e6-caaf-4bc3-a131-f9034c752055",
                     "name": "Verify a bank account",
                     "request": {
                         "name": "Verify a bank account",
@@ -798,7 +798,7 @@
                     },
                     "response": [
                         {
-                            "id": "077136ee-419a-494e-8b71-7e153cf7c60a",
+                            "id": "6df31b54-f0ea-4ceb-a6f1-92c211e038d6",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -890,7 +890,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f1831ae8-2f04-4ddd-963e-d72cc2e41bc8",
+                            "id": "f5959524-9f0c-4006-8c1f-8260f3037cd3",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -967,7 +967,7 @@
                     "event": []
                 },
                 {
-                    "id": "e1c28e05-c163-451e-aafb-754f0413174e",
+                    "id": "f8cec432-42ed-44a0-b50a-43bf164ba599",
                     "name": "Retrieve bank_account with given id",
                     "request": {
                         "name": "Retrieve bank_account with given id",
@@ -999,7 +999,7 @@
                     },
                     "response": [
                         {
-                            "id": "b490ed07-c7c8-4cb9-ba8d-c5ded593ff0e",
+                            "id": "e82c8961-07e2-41c8-a6cc-48ed3e3b73fe",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1062,7 +1062,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5db0a50b-fc1c-4f09-a926-5bb1e9d5ea47",
+                            "id": "d3aceef7-4c4e-45f8-8301-cd89a2924192",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1110,7 +1110,7 @@
                     "event": []
                 },
                 {
-                    "id": "37355a63-225a-4881-808c-0b2a576dc2fa",
+                    "id": "33a55fb5-8361-43a4-a0f4-c18d16650bb3",
                     "name": "Delete a bank_account",
                     "request": {
                         "name": "Delete a bank_account",
@@ -1142,7 +1142,7 @@
                     },
                     "response": [
                         {
-                            "id": "a6683f7b-dbc0-4323-a048-66024a1c868e",
+                            "id": "864383c6-6860-4085-aa9d-5983dae2112e",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -1182,12 +1182,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a88a85c9-086b-4bf1-95f2-7625fd5b71c7",
+                            "id": "049b57b1-29d9-47f4-b780-da86385dbd59",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1235,7 +1235,7 @@
                     "event": []
                 },
                 {
-                    "id": "cb8909ed-cd94-4e33-8724-621308fc578f",
+                    "id": "fe78ce77-0477-48ac-88bc-0cd57905a15e",
                     "name": "List all bank_accounts",
                     "request": {
                         "name": "List all bank_accounts",
@@ -1283,7 +1283,7 @@
                     },
                     "response": [
                         {
-                            "id": "3857a5e0-f0d9-4015-888f-2e85de3d06a6",
+                            "id": "78491ebe-f9b9-4645-aee3-4c8dcfed9d2d",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -1347,7 +1347,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4353ffd8-6d8e-461f-8023-316dcda3bd5f",
+                            "id": "67d25711-f890-446f-96ba-d3c0c4dcfc32",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1414,7 +1414,7 @@
                     "event": []
                 },
                 {
-                    "id": "f040be97-a3a0-4d62-b5fb-ca8680e4eb8a",
+                    "id": "c30bc8e5-f367-4017-a06d-e3833867d63d",
                     "name": "Creates a new bank_account",
                     "request": {
                         "name": "Creates a new bank_account",
@@ -1483,7 +1483,7 @@
                     },
                     "response": [
                         {
-                            "id": "a972013a-c90a-4183-978e-e27f64b39d50",
+                            "id": "b7579a07-61b2-497c-bff8-7aec80df4cea",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1601,7 +1601,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "073db92f-3988-4f2b-89de-d4b4eba306b2",
+                            "id": "9ccfaf99-5f63-47a6-9d5f-a6e29e360226",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1707,7 +1707,7 @@
             "event": []
         },
         {
-            "id": "6077f40e-e214-4c5e-8063-b153f2e6cb7b",
+            "id": "de45a54c-b30a-4862-84f9-a2abff885fe2",
             "name": "Beta Program",
             "description": {
                 "content": "Here at Lob, we pride ourselves on building high quality platform capabilities rapidly\nand iteratively, so we can constantly be delivering additional value to our customers.\nWhen evaluating a new product or feature from Lob, you may see that it has been released in Beta.\n\nTypically, something in Beta means that the feature is early in its lifecycle here at\nLob. While we fully stand behind the quality of everything we release in Beta, we do\nanticipate receiving a higher level of customer feedback on Beta features, as well as a\nfaster pace of changes from our engineering team in response to that feedback.\n\nBy participating in a Lob Beta program, you will have the opportunity to get early access\nto a new product capability, as well as having a unique opportunity to influence the product's\ndirection with your feedback.\n\nYou should also anticipate that features in Beta may have functional or design limitations,\nand might change rapidly as we receive customer feedback and make improvements. In particular,\nnew APIs in Beta may also go through more frequent versioning and version deprecation cycles\nthan our more mature APIs.\n\nIf you are participating in a Beta program and want to provide feedback, please feel free to\n[contact us](https://lob.com/support#contact)!\n",
@@ -1717,7 +1717,7 @@
             "event": []
         },
         {
-            "id": "7619b241-4b75-4a28-bb0d-dc3bf55ce76e",
+            "id": "eae1bd5f-1236-42b9-9d5c-acb4e13b2ac0",
             "name": "Bulk Intl Verifications",
             "description": {
                 "content": "Verify a list of non-US addresses.",
@@ -1725,7 +1725,7 @@
             },
             "item": [
                 {
-                    "id": "3ddeb508-65c2-4e97-99f2-cbb3b130e1c9",
+                    "id": "44a619db-51fc-4baf-a6ec-65af4d5bccc3",
                     "name": "Verify a list of international addresses with a live API key.",
                     "request": {
                         "name": "Verify a list of international addresses with a live API key.",
@@ -1754,12 +1754,12 @@
                         "auth": null,
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n    \"addresses\": [\n        {\n            \"primary_line\": \"<string>\",\n            \"country\": \"<string>\",\n            \"recipient\": \"<string>\",\n            \"secondary_line\": \"<string>\",\n            \"city\": \"do in dolore sint\",\n            \"state\": \"<string>\",\n            \"postal_code\": \"<string>\"\n        }\n    ]\n}"
+                            "raw": "{\n    \"addresses\": [\n        {\n            \"primary_line\": \"<string>\",\n            \"country\": \"<string>\",\n            \"recipient\": \"<string>\",\n            \"secondary_line\": \"<string>\",\n            \"city\": \"laborum ut ea nostrud aliquip\",\n            \"state\": \"<string>\",\n            \"postal_code\": \"<string>\"\n        }\n    ]\n}"
                         }
                     },
                     "response": [
                         {
-                            "id": "279d6398-1398-46f7-b02a-2bb353854ed6",
+                            "id": "05188f9f-acbc-409f-b671-fd5d67ca0609",
                             "name": "Returns an array of international verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -1786,7 +1786,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n    \"addresses\": [\n        {\n            \"primary_line\": \"<string>\",\n            \"country\": \"<string>\",\n            \"recipient\": \"<string>\",\n            \"secondary_line\": \"<string>\",\n            \"city\": \"elit\",\n            \"state\": \"<string>\",\n            \"postal_code\": \"<string>\"\n        }\n    ]\n}"
+                                    "raw": "{\n    \"addresses\": [\n        {\n            \"primary_line\": \"<string>\",\n            \"country\": \"<string>\",\n            \"recipient\": \"<string>\",\n            \"secondary_line\": \"<string>\",\n            \"city\": \"voluptate proident cillum\",\n            \"state\": \"<string>\",\n            \"postal_code\": \"<string>\"\n        }\n    ]\n}"
                                 }
                             },
                             "status": "OK",
@@ -1820,7 +1820,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6c22b1dd-ebf6-44d2-9205-8f0bcd59d899",
+                            "id": "8d6c751a-7e72-4e77-bb4b-b591f87e6900",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1847,7 +1847,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n    \"addresses\": [\n        {\n            \"primary_line\": \"<string>\",\n            \"country\": \"<string>\",\n            \"recipient\": \"<string>\",\n            \"secondary_line\": \"<string>\",\n            \"city\": \"elit\",\n            \"state\": \"<string>\",\n            \"postal_code\": \"<string>\"\n        }\n    ]\n}"
+                                    "raw": "{\n    \"addresses\": [\n        {\n            \"primary_line\": \"<string>\",\n            \"country\": \"<string>\",\n            \"recipient\": \"<string>\",\n            \"secondary_line\": \"<string>\",\n            \"city\": \"voluptate proident cillum\",\n            \"state\": \"<string>\",\n            \"postal_code\": \"<string>\"\n        }\n    ]\n}"
                                 }
                             },
                             "status": "Internal Server Error",
@@ -1869,7 +1869,7 @@
             "event": []
         },
         {
-            "id": "3a1df0c7-939a-4b5e-b024-02d6c529f152",
+            "id": "1057f85f-8fa5-42e4-bcdb-1d365db85b48",
             "name": "Bulk US Verifications",
             "description": {
                 "content": "Verify a list of US addresses.",
@@ -1877,7 +1877,7 @@
             },
             "item": [
                 {
-                    "id": "fa80db85-e48d-456c-aed5-63cc6345d3d2",
+                    "id": "521384e4-1084-493b-b599-8a19c4cb527c",
                     "name": "Verify a list of US or US territory address with a live API key.",
                     "request": {
                         "name": "Verify a list of US or US territory address with a live API key.",
@@ -1918,7 +1918,7 @@
                     },
                     "response": [
                         {
-                            "id": "545f1b27-bd44-4c98-8e96-d6280b24aa6b",
+                            "id": "f164771e-06a7-48b8-833d-97ba8cce9b3e",
                             "name": "Returns an US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -1984,7 +1984,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f595ac39-d278-454c-b3c6-a9774bff4b8f",
+                            "id": "2c2cec2d-f107-443c-9768-97a93055b06c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2038,7 +2038,7 @@
             "event": []
         },
         {
-            "id": "0b0d7640-5846-4a41-9f56-45357104b4c4",
+            "id": "a8909651-bdb8-4b19-81d1-19dda7157dd7",
             "name": "Cancellation Windows",
             "description": {
                 "content": "By default, all new accounts have a 5 minute cancellation window for postcards,\nself mailers, letters, and checks. Within that timeframe, you can cancel\nmailings from production, free of charge. Once the window has passed for a\npostcard, self mailer, letter, or check, the mailing is no longer cancelable.\nIn addition, certain customers can customize their cancellation windows by\nproduct in their [Dashboard Settings](https://dashboard.lob.com/#). Upgrade to\nthe appropriate [Print & Mail Edition](https://dashboard.lob.com/#/settings/editions)\nto automatically gain access to this ability. For more details on this feature,\ncheck out our [Cancellation Guide](https://lob.com/guides#cancellation_windows).\n\nIf you schedule a postcard, self mailer, letter, or check for up to 180 days\nin the future by supplying the `send_date` parameter, that will override any\ncancellation window you may have for that product.\n",
@@ -2048,7 +2048,7 @@
             "event": []
         },
         {
-            "id": "4779e020-3221-457f-9503-ba9962dfe5da",
+            "id": "541e8573-f88b-4025-a687-39c4fe15e765",
             "name": "Certificates",
             "description": {
                 "content": "A certificate store to manage client identities.",
@@ -2056,7 +2056,7 @@
             },
             "item": [
                 {
-                    "id": "72016ae1-e647-440e-927e-e23a6312c669",
+                    "id": "fb8be5a5-38ce-40e4-9def-83e7482511a6",
                     "name": "Retrieve certificate with given id",
                     "request": {
                         "name": "Retrieve certificate with given id",
@@ -2088,7 +2088,7 @@
                     },
                     "response": [
                         {
-                            "id": "f1f084d3-e2ad-4433-b04f-b662b928912b",
+                            "id": "566905be-407f-4430-b076-1e3fe8314fff",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -2128,12 +2128,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"do elit Lorem\",\n \"date_created\": \"1948-02-06T13:58:01.004Z\",\n \"date_modified\": \"1942-03-21T15:34:15.215Z\",\n \"id\": \"<string>\",\n \"name\": \"Lorem enim velit ea\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"9oAGlqmO3eR\",\n \"date_deleted\": \"2018-12-10T16:13:14.656Z\"\n}",
+                            "body": "{\n \"cert\": \"nulla laborum sit\",\n \"date_created\": \"1974-12-24T09:15:09.273Z\",\n \"date_modified\": \"1981-01-20T13:51:33.719Z\",\n \"id\": \"<string>\",\n \"name\": \"eu pariatur d\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"ExDJx7\",\n \"date_deleted\": \"1999-06-15T22:34:22.294Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "051d7d95-c553-4b7f-9931-731e15faf1c2",
+                            "id": "9582fb24-00fd-4fe8-b247-050c2a934063",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2181,7 +2181,7 @@
                     "event": []
                 },
                 {
-                    "id": "72655b29-0170-4ab8-97a5-bb46c88f1c5f",
+                    "id": "bd543b0c-b884-41bf-93ec-0fd98ba4211c",
                     "name": "Update name and/or description of a certificate.",
                     "request": {
                         "name": "Update name and/or description of a certificate.",
@@ -2222,7 +2222,7 @@
                                 {
                                     "disabled": false,
                                     "key": "name",
-                                    "value": "qui aute ullamco"
+                                    "value": "velit sed ex"
                                 },
                                 {
                                     "disabled": false,
@@ -2234,7 +2234,7 @@
                     },
                     "response": [
                         {
-                            "id": "434094d0-2778-453a-9433-bbf926e0bee3",
+                            "id": "fd6f02ee-3bb4-43a8-b7d7-4008f1cad5bd",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -2270,7 +2270,7 @@
                                         {
                                             "disabled": false,
                                             "key": "name",
-                                            "value": "fugiat consectetur"
+                                            "value": "Excepteur ut adipisicing est do"
                                         },
                                         {
                                             "disabled": false,
@@ -2288,12 +2288,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"do elit Lorem\",\n \"date_created\": \"1948-02-06T13:58:01.004Z\",\n \"date_modified\": \"1942-03-21T15:34:15.215Z\",\n \"id\": \"<string>\",\n \"name\": \"Lorem enim velit ea\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": false,\n \"account_id\": \"9oAGlqmO3eR\",\n \"date_deleted\": \"2018-12-10T16:13:14.656Z\"\n}",
+                            "body": "{\n \"cert\": \"nulla laborum sit\",\n \"date_created\": \"1974-12-24T09:15:09.273Z\",\n \"date_modified\": \"1981-01-20T13:51:33.719Z\",\n \"id\": \"<string>\",\n \"name\": \"eu pariatur d\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"ExDJx7\",\n \"date_deleted\": \"1999-06-15T22:34:22.294Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c3b7ee2d-f657-413e-ad05-95f3e9a1aa31",
+                            "id": "8d5ebd71-1427-4732-b6c0-af03456d0957",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2329,7 +2329,7 @@
                                         {
                                             "disabled": false,
                                             "key": "name",
-                                            "value": "fugiat consectetur"
+                                            "value": "Excepteur ut adipisicing est do"
                                         },
                                         {
                                             "disabled": false,
@@ -2355,7 +2355,7 @@
                     "event": []
                 },
                 {
-                    "id": "7cd128b3-fb70-4600-be37-12182c9bc185",
+                    "id": "f8de4062-6b7f-4654-82fb-8fd390825b86",
                     "name": "Deletes certificate with given id",
                     "request": {
                         "name": "Deletes certificate with given id",
@@ -2387,7 +2387,7 @@
                     },
                     "response": [
                         {
-                            "id": "da5f86b3-87c7-49f9-93ac-4a41f41b54db",
+                            "id": "1214a2b7-e7cf-4ec0-8f1f-c5895c3b9537",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -2427,12 +2427,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6fdcc3b2-e8d6-489f-980a-20e4b3f1e427",
+                            "id": "872f1a85-7671-45a2-b11f-641ed10c776f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2480,7 +2480,7 @@
                     "event": []
                 },
                 {
-                    "id": "ab11dab4-c44e-4b55-92e5-d893b117beb4",
+                    "id": "2fb3e722-aad0-44f0-9b27-89a5ef91a5d3",
                     "name": "List all certificates",
                     "request": {
                         "name": "List all certificates",
@@ -2503,7 +2503,7 @@
                     },
                     "response": [
                         {
-                            "id": "d3995272-4135-40c6-ac14-0fee44d92cb4",
+                            "id": "238c2cb4-c552-47a4-8951-bd7abefe3084",
                             "name": "List of all certificates. Will to add wording about plans for the future.",
                             "originalRequest": {
                                 "url": {
@@ -2537,12 +2537,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"sint ut\",\n   \"date_created\": \"1967-12-31T07:42:27.681Z\",\n   \"date_modified\": \"1975-04-24T21:12:21.334Z\",\n   \"id\": \"<string>\",\n   \"name\": \"cillum esse qui incididunt\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"4lFNiN7\",\n   \"date_deleted\": \"1981-09-05T01:02:19.481Z\"\n  },\n  {\n   \"cert\": \"dolore sit irure\",\n   \"date_created\": \"2004-06-08T12:18:33.751Z\",\n   \"date_modified\": \"1981-07-06T07:41:39.972Z\",\n   \"id\": \"<string>\",\n   \"name\": \"incididunt\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": true,\n   \"account_id\": \"K9ueVMr9\",\n   \"date_deleted\": \"1987-02-13T17:31:40.571Z\"\n  }\n ],\n \"count\": -42328271,\n \"object\": \"voluptate\"\n}",
+                            "body": "{\n \"data\": [\n  {\n   \"cert\": \"dolor incididunt proident\",\n   \"date_created\": \"1978-04-09T08:31:14.430Z\",\n   \"date_modified\": \"1996-06-01T18:17:48.874Z\",\n   \"id\": \"<string>\",\n   \"name\": \"nostrud ad labore non magna\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"41z\",\n   \"date_deleted\": \"1982-09-21T05:57:07.726Z\"\n  },\n  {\n   \"cert\": \"in consequat\",\n   \"date_created\": \"1996-06-11T10:39:35.589Z\",\n   \"date_modified\": \"1987-12-14T22:22:07.077Z\",\n   \"id\": \"<string>\",\n   \"name\": \"exe\",\n   \"object\": \"certificate\",\n   \"description\": \"<string>\",\n   \"deleted\": false,\n   \"account_id\": \"Ul3S7lk\",\n   \"date_deleted\": \"2015-10-27T10:54:05.700Z\"\n  }\n ],\n \"count\": 49306901,\n \"object\": \"cillum aliquip ea Excepteur\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7f955318-84f0-4f6e-8db8-a1e63fdf4619",
+                            "id": "08d4ac23-e7de-4a6a-982d-54ab9829b8ea",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2584,7 +2584,7 @@
                     "event": []
                 },
                 {
-                    "id": "7d543541-804a-4066-beef-f5d8ccc1c3b2",
+                    "id": "2fba8615-1c92-4090-a831-e33395e00689",
                     "name": "Creates a new certificate object",
                     "request": {
                         "name": "Creates a new certificate object",
@@ -2628,7 +2628,7 @@
                                 {
                                     "disabled": false,
                                     "key": "name",
-                                    "value": "id consequat esse e",
+                                    "value": "ad ea",
                                     "description": "(Required) "
                                 },
                                 {
@@ -2641,7 +2641,7 @@
                     },
                     "response": [
                         {
-                            "id": "277d27a7-ab5a-46c1-92ef-a0fe798cec5f",
+                            "id": "b74c70e3-1000-44cb-ae08-d12eab0a07f3",
                             "name": "Returns an certificate object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -2690,7 +2690,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "in minim"
+                                            "value": "officia Duis cupidatat"
                                         },
                                         {
                                             "disabled": false,
@@ -2708,12 +2708,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1994-09-28T14:00:26.413Z\",\n \"date_modified\": \"1970-06-10T19:16:21.474Z\",\n \"id\": \"<string>\",\n \"name\": \"dolore est officia ex\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"q4017pLXH6\",\n \"date_deleted\": \"2007-04-22T00:48:59.357Z\"\n}",
+                            "body": "{\n \"cert\": \"<string>\",\n \"date_created\": \"1950-05-20T14:56:03.671Z\",\n \"date_modified\": \"1976-09-30T04:03:43.239Z\",\n \"id\": \"<string>\",\n \"name\": \"dolor ex dolor et\",\n \"object\": \"certificate\",\n \"description\": \"<string>\",\n \"deleted\": true,\n \"account_id\": \"FUCAte1wPF\",\n \"date_deleted\": \"1992-10-13T21:20:13.835Z\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d6016e50-ea70-426c-baeb-2546bf6b7add",
+                            "id": "d39c783b-9e60-484c-9545-30476ffd8567",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2762,7 +2762,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "name",
-                                            "value": "in minim"
+                                            "value": "officia Duis cupidatat"
                                         },
                                         {
                                             "disabled": false,
@@ -2791,7 +2791,7 @@
             "event": []
         },
         {
-            "id": "5c4e049f-b1d3-4928-8007-7f5edc56544e",
+            "id": "27147c02-d6c8-4443-905d-330c51c54c5e",
             "name": "Checks",
             "description": {
                 "content": "Checks allow you to send payments via physical checks.",
@@ -2799,7 +2799,7 @@
             },
             "item": [
                 {
-                    "id": "3831a885-9bee-45d6-9994-8c6a4d778d34",
+                    "id": "ee9fcf2e-e8e0-4585-83f5-fe719e88eb74",
                     "name": "Retrieve check with given id",
                     "request": {
                         "name": "Retrieve check with given id",
@@ -2831,7 +2831,7 @@
                     },
                     "response": [
                         {
-                            "id": "c1cca68a-cb39-40f9-8726-b76e7c1c2a2d",
+                            "id": "33143a69-8962-459e-aece-817023a7f40f",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -2894,7 +2894,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5ba2ccaa-5c5b-4740-9a49-a34a43f4f60c",
+                            "id": "eddce5c0-06e7-41c0-b8ce-9f57cd351ea7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2942,7 +2942,7 @@
                     "event": []
                 },
                 {
-                    "id": "617291dc-8121-4bef-affb-fc2cabf0044a",
+                    "id": "1480f1bb-7a08-49aa-ae23-a6ab3b92a292",
                     "name": "Cancel a check",
                     "request": {
                         "name": "Cancel a check",
@@ -2974,7 +2974,7 @@
                     },
                     "response": [
                         {
-                            "id": "263fb9cf-6727-4ffc-8f17-79bbcbd1499e",
+                            "id": "da11dc58-08d9-4f96-b376-6de0f33a703c",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -3014,12 +3014,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5e73340c-5e1a-43ad-a773-f7fef723c80f",
+                            "id": "985207e9-5c33-4530-a75f-ac1aed63d128",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3067,7 +3067,7 @@
                     "event": []
                 },
                 {
-                    "id": "7f11e1d7-9c5d-4a6b-a52c-b342302c84e5",
+                    "id": "1891673e-e4b8-4992-844e-e5cf3002f2ed",
                     "name": "List all checks",
                     "request": {
                         "name": "List all checks",
@@ -3115,7 +3115,7 @@
                     },
                     "response": [
                         {
-                            "id": "7fded8b5-a522-40c7-8c3f-a4dd395558f1",
+                            "id": "d2ddcda3-05e5-4a7e-8a48-9a7c4ca5bf39",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3179,7 +3179,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3d168f54-8610-4048-aad0-4d88444148e0",
+                            "id": "959b6ed3-5192-474a-ab77-755f0b70deee",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3246,7 +3246,7 @@
                     "event": []
                 },
                 {
-                    "id": "35ecc8f8-bc9c-4c32-9f8d-8514b6b8c837",
+                    "id": "edd9dd67-fdf7-4f46-a8fc-1efe381f0981",
                     "name": "Creates a new check",
                     "request": {
                         "name": "Creates a new check",
@@ -3316,7 +3316,7 @@
                     },
                     "response": [
                         {
-                            "id": "6a3f7968-76bf-4c5b-b920-01abc6dc0150",
+                            "id": "67ecc49d-d6a8-4f2b-bc96-3e8851721185",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -3488,7 +3488,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "06647ee6-8c4d-4f2f-933a-d204be2135b4",
+                            "id": "3298cfe2-3d03-41f7-80b1-8b2faf64f016",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3648,7 +3648,7 @@
             "event": []
         },
         {
-            "id": "b75a0555-1e31-4bd5-96ab-ea1c63b1130f",
+            "id": "b3725885-b4ce-49c1-b0a5-16902f2b7a0f",
             "name": "Intl Verifications",
             "description": {
                 "content": "Address verification for non-US addresses",
@@ -3656,7 +3656,7 @@
             },
             "item": [
                 {
-                    "id": "8f297290-c088-4ce6-aee4-5fb69743ea0b",
+                    "id": "e55b9f01-2c2e-4999-858b-02edea5c63bf",
                     "name": "Verify an international (except US or US territories) address with a live API key.",
                     "request": {
                         "name": "Verify an international (except US or US territories) address with a live API key.",
@@ -3714,7 +3714,7 @@
                                 {
                                     "disabled": false,
                                     "key": "city",
-                                    "value": "ad sint fugiat culpa"
+                                    "value": "Excepteur dolore aute"
                                 },
                                 {
                                     "disabled": false,
@@ -3731,7 +3731,7 @@
                     },
                     "response": [
                         {
-                            "id": "51c2dfda-e751-4427-b067-ff26a6de4485",
+                            "id": "4372edfa-edde-48ef-b4d7-31816f4008c0",
                             "name": "Returns an international verification object.",
                             "originalRequest": {
                                 "url": {
@@ -3787,7 +3787,7 @@
                                         {
                                             "disabled": false,
                                             "key": "city",
-                                            "value": "nisi"
+                                            "value": "labore minim irure adipisicing proident"
                                         },
                                         {
                                             "disabled": false,
@@ -3833,7 +3833,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "dad6271b-aea8-4e01-b41f-bf30a5ecaf97",
+                            "id": "92acce28-bd08-4c7a-97ca-f7c05172cf11",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3889,7 +3889,7 @@
                                         {
                                             "disabled": false,
                                             "key": "city",
-                                            "value": "nisi"
+                                            "value": "labore minim irure adipisicing proident"
                                         },
                                         {
                                             "disabled": false,
@@ -3923,7 +3923,7 @@
             "event": []
         },
         {
-            "id": "638a4470-05c4-4604-900f-1d5b2a351074",
+            "id": "b5cdc351-d436-49e2-a28f-e7bfb02832d8",
             "name": "Letters",
             "description": {
                 "content": "Easily print and mail letters.",
@@ -3931,7 +3931,7 @@
             },
             "item": [
                 {
-                    "id": "44fd7130-be6d-4ee0-9b71-894d78847b0b",
+                    "id": "fbd1967e-cecf-48fa-9596-11e7c40baf67",
                     "name": "Retrieve letter with given id",
                     "request": {
                         "name": "Retrieve letter with given id",
@@ -3963,7 +3963,7 @@
                     },
                     "response": [
                         {
-                            "id": "c1846042-2c51-49c1-8907-ffe6d6d7bb89",
+                            "id": "980b1281-0d4c-4ecd-ae46-11e6d093cdb3",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -4026,7 +4026,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e9d1cf03-ace1-4be0-94ec-61f5fab1bef0",
+                            "id": "3e7c04dc-ab22-4b7b-8fc3-05ad1b686281",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4074,7 +4074,7 @@
                     "event": []
                 },
                 {
-                    "id": "d3ebff5c-551c-40d4-b135-2c5e90168f93",
+                    "id": "4f3eab84-fe7f-45c2-a91d-0a8410e17710",
                     "name": "Cancel a letter",
                     "request": {
                         "name": "Cancel a letter",
@@ -4106,7 +4106,7 @@
                     },
                     "response": [
                         {
-                            "id": "3fcaa498-317f-4ad6-bf7a-08c32a775376",
+                            "id": "804592f1-a821-4534-8e27-a084521ce6bb",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -4146,12 +4146,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cd1cfec0-35bd-4bcd-8ba9-bfe3f98fbb1e",
+                            "id": "1e46e690-5003-423f-a389-d9eed19043d6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4199,7 +4199,7 @@
                     "event": []
                 },
                 {
-                    "id": "625e5986-0d1e-4c95-b175-b57ddcad45e2",
+                    "id": "31b34169-eee5-4fb8-9417-e5380f47e144",
                     "name": "List all letters",
                     "request": {
                         "name": "List all letters",
@@ -4247,7 +4247,7 @@
                     },
                     "response": [
                         {
-                            "id": "3b7ebd46-c162-46dc-967c-e3201d8b5b89",
+                            "id": "b6a7d81f-a794-4bb8-b0f9-b61c752be93f",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -4311,7 +4311,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "99274699-154b-4785-b993-b3c37800ac96",
+                            "id": "c58924d9-09f5-47d8-aa15-50da9b63088f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4378,7 +4378,7 @@
                     "event": []
                 },
                 {
-                    "id": "f8eaaf13-5866-4f11-a31d-9d5a0138bca1",
+                    "id": "17545752-fa6e-4fb2-9642-6d5fecc2e3d1",
                     "name": "Creates a new letter object",
                     "request": {
                         "name": "Creates a new letter object",
@@ -4473,7 +4473,7 @@
                     },
                     "response": [
                         {
-                            "id": "6126fb59-a299-49e1-baab-79a9bd573527",
+                            "id": "fefd3308-8731-4a33-bdbb-fe857982337a",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -4605,7 +4605,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "401deedc-05f1-4ecf-bece-15d71bc46770",
+                            "id": "34c818cc-5a29-4edc-9028-628c44af6ca1",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4725,7 +4725,7 @@
             "event": []
         },
         {
-            "id": "6cee1246-3f7f-4f48-8103-76fad0d70752",
+            "id": "68636143-ce78-4fe2-af00-0ce1204097c7",
             "name": "Libraries",
             "description": {
                 "content": "Please visit our [Github](https://www.github.com/lob) for a list of our supported libraries.\n- [Ruby](https://github.com/lob/lob-ruby)\n- [PHP](https://github.com/lob/lob-php)\n- [Node.js](https://github.com/lob/lob-node)\n- [Python](https://github.com/lob/lob-python)\n- [Java](https://github.com/lob/lob-java)\n- [Elixir](https://github.com/lob/lob-elixir)\n",
@@ -4735,7 +4735,7 @@
             "event": []
         },
         {
-            "id": "0402ea4d-6529-4b2a-89be-a8dd110749e7",
+            "id": "754df418-4cba-4eee-afef-34d0783f66b8",
             "name": "Postcards",
             "description": {
                 "content": "Easily print and mail postcards.",
@@ -4743,7 +4743,7 @@
             },
             "item": [
                 {
-                    "id": "30a3b089-414d-4bdf-9ce7-6ad1bad0227a",
+                    "id": "63c115e5-25a4-43bf-93b3-94ea553205ab",
                     "name": "Retrieve postcard with given id",
                     "request": {
                         "name": "Retrieve postcard with given id",
@@ -4775,7 +4775,7 @@
                     },
                     "response": [
                         {
-                            "id": "abf46ed8-0e63-4efd-ab21-ae80371378c2",
+                            "id": "0f24ae44-3f2b-446e-a8c5-0f0463875cc7",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -4838,7 +4838,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1b665a3b-4307-4a61-b80d-3a2f26ffffa1",
+                            "id": "8677b076-b668-459f-89e1-88b968a80bf9",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4886,7 +4886,7 @@
                     "event": []
                 },
                 {
-                    "id": "414756a1-accd-4e8f-886f-87715b210988",
+                    "id": "9d794d43-a4d4-4f17-a98d-9293a0651461",
                     "name": "Cancels postcard with given id",
                     "request": {
                         "name": "Cancels postcard with given id",
@@ -4918,7 +4918,7 @@
                     },
                     "response": [
                         {
-                            "id": "211e735a-0e4d-4876-bda4-f104bdac9583",
+                            "id": "022b524a-5a49-4cda-828d-8c578ba3c2c5",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -4958,12 +4958,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "77419ee4-9a5f-4c36-a82f-74dd4e57fe99",
+                            "id": "31459eca-8077-45ea-9406-881da7e50434",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5011,7 +5011,7 @@
                     "event": []
                 },
                 {
-                    "id": "87333d5d-23a0-4e14-8d3d-ca52e46628f2",
+                    "id": "600b3478-ef1a-46aa-ad92-3231f9d51473",
                     "name": "List all postcards",
                     "request": {
                         "name": "List all postcards",
@@ -5059,7 +5059,7 @@
                     },
                     "response": [
                         {
-                            "id": "e745d8e4-4df6-411c-ad99-1994b8a24328",
+                            "id": "06fc1420-0e03-4f3c-a2f7-bd7a48b3569d",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -5123,7 +5123,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ae50865b-894f-48e3-9559-e69030f5c65c",
+                            "id": "92100c7f-2873-4fbc-ba03-a55fd0bf826f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5190,7 +5190,7 @@
                     "event": []
                 },
                 {
-                    "id": "785cbd83-06a4-4c96-b33b-e0c292b1cc33",
+                    "id": "7e2cef89-0a98-4010-85ad-36373269bcd6",
                     "name": "Creates a new postcard object",
                     "request": {
                         "name": "Creates a new postcard object",
@@ -5260,7 +5260,7 @@
                     },
                     "response": [
                         {
-                            "id": "8772cdd8-e74d-49e0-bf53-fd0124528417",
+                            "id": "f229d053-45b9-4a5d-8d8f-c333ac01d89d",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -5367,7 +5367,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "429c1ea1-0bba-498b-944a-78bc812c2099",
+                            "id": "14d5cea8-199b-4870-9758-9546259edbc4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5462,7 +5462,7 @@
             "event": []
         },
         {
-            "id": "032c706c-4374-4e4a-9952-6ffd1fc5a2cb",
+            "id": "12588cb7-b753-474e-8bee-8cfdefccb0ba",
             "name": "Self Mailers",
             "description": {
                 "content": "Easily print and mail self mailers.",
@@ -5470,7 +5470,7 @@
             },
             "item": [
                 {
-                    "id": "74bd98e3-b618-49af-b9d9-eac6d9fecb05",
+                    "id": "05b8b878-ce1e-4fdb-8eed-c40a445b5ff1",
                     "name": "Retrieve self_mailer with given id",
                     "request": {
                         "name": "Retrieve self_mailer with given id",
@@ -5502,7 +5502,7 @@
                     },
                     "response": [
                         {
-                            "id": "4607f368-c3f2-42e1-ae0a-a6ee896fd3fc",
+                            "id": "dd3fc6a4-d913-4432-9bef-2336e0f1e1e0",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -5565,7 +5565,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "935ba4bd-30a1-4dd4-8c6d-6cf13564556f",
+                            "id": "144d4d0b-e5f2-43e6-b339-1c4e9fa69eb3",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5613,7 +5613,7 @@
                     "event": []
                 },
                 {
-                    "id": "fac0b61f-1647-4f0f-b60f-86bf342a0b48",
+                    "id": "18ec949d-4caf-42cc-ac40-ee416586126a",
                     "name": "Deletes self_mailer with given id",
                     "request": {
                         "name": "Deletes self_mailer with given id",
@@ -5645,7 +5645,7 @@
                     },
                     "response": [
                         {
-                            "id": "3946a99e-b10f-43e2-912e-96b29a10eb63",
+                            "id": "a6ac9ddd-ca94-4d61-bf58-1681a8f6ed0e",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -5685,12 +5685,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "99509c27-10c6-49cf-8c02-6765dc640895",
+                            "id": "6967ce67-5cc0-4a08-b2c3-7ab9124d53e0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5738,7 +5738,7 @@
                     "event": []
                 },
                 {
-                    "id": "94671bd0-0340-4825-ab41-087151e01187",
+                    "id": "b49f46b3-8cfa-4410-8aaa-eb66787b1795",
                     "name": "List all self_mailers",
                     "request": {
                         "name": "List all self_mailers",
@@ -5786,7 +5786,7 @@
                     },
                     "response": [
                         {
-                            "id": "bc53efd6-e39e-4ff5-a496-9eb27d667e0e",
+                            "id": "9e6ca090-e83a-4dc2-9f59-d98b7d2ef374",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -5868,7 +5868,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d596b793-8b8c-4c87-bcfc-0603a3f47d10",
+                            "id": "f4daf62a-ff78-47ab-a26f-449ab387e693",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5935,7 +5935,7 @@
                     "event": []
                 },
                 {
-                    "id": "a2c81399-6d4d-4a75-88e4-61c8490295f3",
+                    "id": "4b425e90-32f1-46d0-9da8-86c677c349d4",
                     "name": "Creates a new self_mailer object",
                     "request": {
                         "name": "Creates a new self_mailer object",
@@ -6005,7 +6005,7 @@
                     },
                     "response": [
                         {
-                            "id": "17530b73-fe1f-45a5-8cda-2c3355f900c4",
+                            "id": "7ed25038-727a-4c57-9784-19afa0d2c969",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -6112,7 +6112,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c5b03969-a26d-41fc-8f2f-98328ce46d0e",
+                            "id": "149caf9d-072d-4c79-90ab-027e53b80e31",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6207,7 +6207,7 @@
             "event": []
         },
         {
-            "id": "159cd6bb-7624-4c19-a671-c368b1459a11",
+            "id": "7074f00a-f5bf-450f-a577-1f0be0c50413",
             "name": "Template Versions",
             "description": {
                 "content": "Versioning for your reusable HTML print and mail templates.",
@@ -6215,7 +6215,7 @@
             },
             "item": [
                 {
-                    "id": "b82fe949-ec92-43b1-af54-c89e1a4e1666",
+                    "id": "e6c3ee82-b1d5-454c-8653-d478b33b7a49",
                     "name": "Retrieve template version with given template and version ids.",
                     "request": {
                         "name": "Retrieve template version with given template and version ids.",
@@ -6256,7 +6256,7 @@
                     },
                     "response": [
                         {
-                            "id": "52067981-def6-4c3b-985d-39fd4a7940d8",
+                            "id": "bb8933fb-03fc-4e87-a66f-099f12b3b1f5",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -6325,7 +6325,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3f65c5e0-ba52-416c-8390-0cb2cb91bd91",
+                            "id": "74dc0b60-5a4e-42b0-abe2-0378fc887f2c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6379,7 +6379,7 @@
                     "event": []
                 },
                 {
-                    "id": "caf099a6-3c3f-48f1-9363-165fcbe2d8d1",
+                    "id": "2b968510-c51b-4369-a773-782687900cd6",
                     "name": "Updates the template version with given template and version ids.",
                     "request": {
                         "name": "Updates the template version with given template and version ids.",
@@ -6442,7 +6442,7 @@
                     },
                     "response": [
                         {
-                            "id": "a7578c03-11cc-4089-8185-c70db8568c13",
+                            "id": "f7dcdd22-4e21-424b-97eb-bfca6e777aab",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -6526,7 +6526,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "051539a1-3916-44df-89e6-aec2e45e3ffd",
+                            "id": "1a76bbac-b9bf-4246-9ea6-538839b30b33",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6595,7 +6595,7 @@
                     "event": []
                 },
                 {
-                    "id": "472d72af-005b-4fdc-a45e-4d6ec0d9218c",
+                    "id": "5958c757-55c9-432d-8fc0-bca101e5b0b7",
                     "name": "Deletes the template version with given template and version ids if possible.",
                     "request": {
                         "name": "Deletes the template version with given template and version ids if possible.",
@@ -6636,7 +6636,7 @@
                     },
                     "response": [
                         {
-                            "id": "b4e686d3-d319-4542-b2a6-7b1e1ac4f9be",
+                            "id": "1a8dfb30-3adb-4cfe-94ca-067f3bef70a6",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -6682,12 +6682,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c96b8b1f-12c6-4c1f-97f9-9435b4b27557",
+                            "id": "1aa5b2c1-777e-4af0-b129-d341b049cf66",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6741,7 +6741,7 @@
                     "event": []
                 },
                 {
-                    "id": "beff6257-b675-4e56-8650-4387d9f9ff2b",
+                    "id": "99fa2d97-bfee-4ba9-bfe3-6ae8a94763e6",
                     "name": "List all template_versions",
                     "request": {
                         "name": "List all template_versions",
@@ -6799,7 +6799,7 @@
                     },
                     "response": [
                         {
-                            "id": "3295af93-8c20-42d3-9509-7ff54e907ab3",
+                            "id": "ccef4966-cfec-40b7-a05f-de9bd706cd6e",
                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -6880,7 +6880,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0d9d0a67-0cbf-426a-9ea9-58c549261540",
+                            "id": "1e00b576-262b-4ee9-94a7-82d126327e29",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6946,7 +6946,7 @@
                     "event": []
                 },
                 {
-                    "id": "12420fe5-9424-4120-a1fe-b26e047a4441",
+                    "id": "9c4aeb68-3df5-4890-98a7-50357d5178fa",
                     "name": "Creates a new template_version object",
                     "request": {
                         "name": "Creates a new template_version object",
@@ -7007,7 +7007,7 @@
                     },
                     "response": [
                         {
-                            "id": "d4acd773-406c-450a-a9bd-e9d8f7d1137c",
+                            "id": "76dcb4ec-d099-446a-ad04-c6a3cc22f69a",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -7095,7 +7095,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "998dc177-3605-4e94-b5ec-2f9ebe669f45",
+                            "id": "0f9903ae-ad1f-490b-92e3-d2ece9e824a4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7171,7 +7171,7 @@
             "event": []
         },
         {
-            "id": "f2e20564-3066-491d-91dc-421b86f6716b",
+            "id": "2ea87bf7-a25a-4dd7-af98-e02444c05b24",
             "name": "Templates",
             "description": {
                 "content": "Versioned, reusable HTML Templates for use with the print and mail API.",
@@ -7179,7 +7179,7 @@
             },
             "item": [
                 {
-                    "id": "69fc6124-3666-4efc-9019-99d748154587",
+                    "id": "17f7b6a9-29d7-4fb4-b6ec-ec66ea3d97ce",
                     "name": "Compile the template into html",
                     "request": {
                         "name": "Compile the template into html",
@@ -7225,7 +7225,7 @@
                     },
                     "response": [
                         {
-                            "id": "8628df8c-cb6a-4e82-9826-468ce938ba4f",
+                            "id": "a89d2b92-3718-4770-8632-095ad4f0e30b",
                             "name": "Returns the compiled html",
                             "originalRequest": {
                                 "url": {
@@ -7280,7 +7280,7 @@
                             "_postman_previewlanguage": "text"
                         },
                         {
-                            "id": "2b6580c8-24d4-482d-9ebe-c1260e48dfb5",
+                            "id": "ada598f2-3788-496d-8b9c-467be7a91c07",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7338,7 +7338,7 @@
                     "event": []
                 },
                 {
-                    "id": "544edbd9-8e13-4601-844f-df16abac39e8",
+                    "id": "637889f0-640e-47e4-bf90-c812d766ad8b",
                     "name": "Retrieve template with given id",
                     "request": {
                         "name": "Retrieve template with given id",
@@ -7370,7 +7370,7 @@
                     },
                     "response": [
                         {
-                            "id": "94fb831f-8271-4e91-8f70-950207b1d32a",
+                            "id": "de58ed91-122a-425f-b7f7-b5f02f6963b7",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -7433,7 +7433,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2b3ad9f4-b9f9-4495-b464-10695fa9fcde",
+                            "id": "d6a6fbb6-f75e-4acf-8a26-71bcfb9f0510",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7481,7 +7481,7 @@
                     "event": []
                 },
                 {
-                    "id": "0aa1daa8-caff-4ea8-87ae-6d171d0fed3c",
+                    "id": "16d23a40-d759-4f0d-8a89-00ff343a0908",
                     "name": "Update description and/or published version of a template.",
                     "request": {
                         "name": "Update description and/or published version of a template.",
@@ -7540,7 +7540,7 @@
                     },
                     "response": [
                         {
-                            "id": "0454866c-d845-4543-93b7-54a60c7a63d8",
+                            "id": "acb61372-be1c-4fde-85b0-8ea7dcb6ff2d",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -7623,7 +7623,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a68456db-5886-42ae-b68a-0807ec2ac00e",
+                            "id": "415d7ec0-4684-4e2d-8c78-23a05ccdf990",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7691,7 +7691,7 @@
                     "event": []
                 },
                 {
-                    "id": "7969a511-1556-44cc-9635-2443d0cd3a3d",
+                    "id": "1dfa5cde-2b0b-4af6-aa6c-f7dc75ac5b40",
                     "name": "Deletes template with given id",
                     "request": {
                         "name": "Deletes template with given id",
@@ -7723,7 +7723,7 @@
                     },
                     "response": [
                         {
-                            "id": "928d29e3-7399-4878-bdf3-e9e72d1773d5",
+                            "id": "6211e34b-b0f2-4007-b237-1c52fce8ffdd",
                             "name": "Returns true if the delete was successful",
                             "originalRequest": {
                                 "url": {
@@ -7763,12 +7763,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"id\": \"adr_vmKS6pTFdK\",\n \"deleted\": true\n}",
+                            "body": "{\n \"id\": \"adr_FUIl\",\n \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b7e63c90-4de4-4790-8eec-eecdfd005ef9",
+                            "id": "1e7867a1-860b-4979-af4d-b64d115f2645",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7816,7 +7816,7 @@
                     "event": []
                 },
                 {
-                    "id": "e1dd39ab-cabf-4668-af30-7bac7736cbee",
+                    "id": "d955a0eb-fb6e-4a8a-b5f5-426aac60058d",
                     "name": "List all templates",
                     "request": {
                         "name": "List all templates",
@@ -7864,7 +7864,7 @@
                     },
                     "response": [
                         {
-                            "id": "c93c1c43-1c80-4539-86f6-f554673e0419",
+                            "id": "def93bdd-cf8d-47e9-99dc-27eed8aa580d",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -7946,7 +7946,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "931a6ec2-f4cc-471c-b5c7-6bb36cf1653b",
+                            "id": "1c29343d-c2c2-4ce4-9482-e0df81c50ec7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8013,7 +8013,7 @@
                     "event": []
                 },
                 {
-                    "id": "ed76e54c-164a-4eac-b9ea-33d359454e51",
+                    "id": "fdb9d51a-a81f-44a1-baaf-7f123bd3e53e",
                     "name": "Creates a new template object",
                     "request": {
                         "name": "Creates a new template object",
@@ -8064,7 +8064,7 @@
                     },
                     "response": [
                         {
-                            "id": "51907c99-6352-42c1-ac51-15c93f6e1d2d",
+                            "id": "91173986-9b18-4bac-bce1-1676c495d79f",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -8155,7 +8155,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "19b16fc2-a0f6-45c7-8de4-32c313c6119a",
+                            "id": "02841ef1-d352-4d3d-9d8d-fe7e09c57fc8",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8234,7 +8234,7 @@
             "event": []
         },
         {
-            "id": "7163ad61-82e2-4d45-8fb1-1f4a0d101b18",
+            "id": "217139c1-15cd-4fab-b3a9-4ed62b676017",
             "name": "Test and Live Environments",
             "description": {
                 "content": "To make the API as explorable as possible, accounts have test and live environment API keys. You're not charged any fees in the test environment, so we encourage you to use it to try out services, perform quality assurance, and run automated testing. Objects―addresses, letters, checks, etc―in one environment cannot be manipulated by objects in the other. In general, a payment method (either credit card or ACH account) must be added to your account to make live API requests. However, a payment method is not required for the first 300 live requests per month to the `/v1/us_verifications` endpoint. After the first 300 requests, you will begin receiving errors with status code `403`. Requests made in the test environment always validate request arguments, simulate live environment behavior, and enforce rate limits. _They never print, mail nor, for verification services, verify addresses._ The US & International verification services trigger behavior with specific argument values, and, if you plan on using those, we recommend reading US Verification Test Environment and Intl Verification Test Environment. To switch between environments, use the appropriate key for that environment when performing a request. You can find each environment's API key in your dashboard under Settings; test API keys are always prefixed with `test_` and production API keys with `live_`.",
@@ -8244,7 +8244,7 @@
             "event": []
         },
         {
-            "id": "3d5213b4-213b-48d6-a38a-1ae50e44a95b",
+            "id": "a681ae47-91f8-48c5-a662-5e4c21eb702f",
             "name": "US Autocompletions",
             "description": {
                 "content": "Given partial address information, this endpoint returns up to 10 address suggestions.\n",
@@ -8252,7 +8252,7 @@
             },
             "item": [
                 {
-                    "id": "33c2a18b-0944-4bdf-a1b2-134ead65ad6a",
+                    "id": "7bc84e4f-edf0-4bbb-ad97-dc6a4e8e6067",
                     "name": "Autocomplete a partial US address.",
                     "request": {
                         "name": "Autocomplete a partial US address.",
@@ -8316,7 +8316,7 @@
                     },
                     "response": [
                         {
-                            "id": "1ac4c0f8-286a-41b4-aa5c-9959bd30b752",
+                            "id": "24e53bef-de9d-44a8-b24d-a9d811366c11",
                             "name": "Returns a US autocompletion object.",
                             "originalRequest": {
                                 "url": {
@@ -8422,7 +8422,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "84d46349-a18a-4522-8ccc-0fa375a04db6",
+                            "id": "d6a2256f-aaff-42c2-82d8-defee866915b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8516,7 +8516,7 @@
             "event": []
         },
         {
-            "id": "0e155976-24df-4bf3-b510-f3ed19f99da5",
+            "id": "771f22a0-22c3-4f57-9b5d-c4d5de685b57",
             "name": "US Verifications",
             "description": {
                 "content": "Validate, automatically correct, and standardize the addresses in your address book based on USPS's [Coding Accuracy Support System (CASS)](https://postalpro.usps.com/certifications/cass).\n",
@@ -8524,7 +8524,7 @@
             },
             "item": [
                 {
-                    "id": "4fc48081-b204-4a0b-95b6-3cc112b536e7",
+                    "id": "727c431b-f738-4dde-8688-81d9b51442f5",
                     "name": "Verify a US or US territory address with a live API key.",
                     "request": {
                         "name": "Verify a US or US territory address with a live API key.",
@@ -8564,7 +8564,7 @@
                     },
                     "response": [
                         {
-                            "id": "82875d59-be70-47e3-9a97-3aef1e417fd1",
+                            "id": "18078a8f-a1db-47d5-828a-48155874e994",
                             "name": "Returns a US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -8629,7 +8629,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "64873f0d-46a4-45c1-847f-6fa56b3142bf",
+                            "id": "d261612b-00d8-4404-b66a-3bdcc846dd2d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8682,7 +8682,7 @@
             "event": []
         },
         {
-            "id": "5e106ffc-4210-4af2-b65a-ecb93de31d29",
+            "id": "187f51a2-7a90-49e8-a920-25ba965709a3",
             "name": "Webhooks",
             "description": {
                 "content": "Webhooks are an easy way to get notifications on events happening asynchronously\nwithin Lob's architecture. For example, when a postcard gets a \"Processed For\nDelivery\" tracking event, an event object of type `postcard.processed_for_delivery`\nwill be created. If you are subscribed to that event type in that Environment\n(Test vs. Live), Lob will send that event to any URLs you've specified via an\nHTTP POST request. In Live mode, you can only have as many webhooks as allotted\nin your current [Print & Mail Edition](https://dashboard.lob.com/#/settings/editions).\nThere is no limit in Test mode.\n\nYou can view and create [webhooks](https://dashboard.lob.com/#/webhooks) on the\nLob Dashboard, as well as view your [events](https://dashboard.lob.com/#/events).\nSee our [Webhooks Integration Guide](https://lob.com/guides#webhooks_block) for more\ndetails on how to integrate. Please see the full list of event types available for\nsubscription here.\n",
@@ -8692,7 +8692,7 @@
             "event": []
         },
         {
-            "id": "0e350717-40ef-4b6e-b1aa-eee5c076e825",
+            "id": "899cc04b-3c60-4d97-a091-8b262e52f316",
             "name": "Zip Lookups",
             "description": {
                 "content": "Find a list of cities, states and associated information about a US ZIP code.\n",
@@ -8700,7 +8700,7 @@
             },
             "item": [
                 {
-                    "id": "66d618f2-85ae-4b37-a6df-6afd825432d4",
+                    "id": "4236631a-ecfa-475b-a84a-5140887557ae",
                     "name": "Looks up information pertaining to a given ZIP code",
                     "request": {
                         "name": "Looks up information pertaining to a given ZIP code",
@@ -8740,7 +8740,7 @@
                     },
                     "response": [
                         {
-                            "id": "cc77f909-a089-45f8-a275-9082fb2db85f",
+                            "id": "c83d9235-db49-4b4d-ad3a-03dc76058142",
                             "name": "Returns a zip lookup object if a valid zip was provided.",
                             "originalRequest": {
                                 "url": {
@@ -8805,12 +8805,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n \"cities\": [\n  {\n   \"city\": \"Excepteur\",\n   \"state\": \"\",\n   \"county\": \"eiusmod ad amet in culpa\",\n   \"county_fips\": \"17120\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"ex irure\",\n   \"state\": \"v\",\n   \"county\": \"dolore sit nulla\",\n   \"county_fips\": \"08707\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"military\"\n}",
+                            "body": "{\n \"cities\": [\n  {\n   \"city\": \"quis deserunt conse\",\n   \"state\": \"a\",\n   \"county\": \"sed\",\n   \"county_fips\": \"83865\",\n   \"preferred\": true\n  },\n  {\n   \"city\": \"velit\",\n   \"state\": \"\",\n   \"county\": \"Excepteur labore est cillum\",\n   \"county_fips\": \"83506\",\n   \"preferred\": true\n  }\n ],\n \"id\": \"us_zip_c7cb63d68f8d6\",\n \"object\": \"us_zip_lookup\",\n \"zip_code\": \"94107\",\n \"zip_code_type\": \"po_box\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d8c197cf-cb57-4697-8af9-92fa29099bd3",
+                            "id": "cfdb3e3c-cac6-4fa7-9a4b-6decfee505ca",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8890,7 +8890,7 @@
         ]
     },
     "info": {
-        "_postman_id": "f7873693-f970-43a1-8618-effa29c588a6",
+        "_postman_id": "55cdb009-2c00-4a3c-9a72-fd40081adc61",
         "name": "Lob API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "husky": "^5.0.9",
         "joi": "^17.4.0",
         "openapi-to-postmanv2": "^2.6.0",
-        "prettier": "^2.3.1",
+        "prettier": "^2.3.2",
         "redoc-cli": "^0.12.1",
         "uuid": "^8.3.2"
       },
@@ -6358,9 +6358,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -15628,9 +15628,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
-      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
     },
     "pretty-data": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "husky": "^5.0.9",
     "joi": "^17.4.0",
     "openapi-to-postmanv2": "^2.6.0",
-    "prettier": "^2.3.1",
+    "prettier": "^2.3.2",
     "redoc-cli": "^0.12.1",
     "uuid": "^8.3.2"
   },

--- a/tests/letters_test.js
+++ b/tests/letters_test.js
@@ -56,8 +56,7 @@ test("create, list, read, then cancel, a letter with no extra services", async f
         to: to,
         from: from,
         color: true,
-        file:
-          "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
+        file: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
       },
       { headers: prism.authHeader }
     )
@@ -149,8 +148,7 @@ test("create, list, read, then cancel, a letter with no extra services and full 
         from: from,
         send_date: date.toISOString(),
         color: true,
-        file:
-          "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
+        file: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
         double_sided: false,
         address_placement: "insert_blank_page",
         mail_type: "usps_first_class",
@@ -217,8 +215,7 @@ test("create, list, read then cancel a certified letter", async function (t) {
         },
         color: true,
         extra_service: "certified",
-        file:
-          "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
+        file: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf",
       },
       { headers: prism.authHeader }
     )

--- a/tests/postcards_test.js
+++ b/tests/postcards_test.js
@@ -61,8 +61,7 @@ test("create, list, read then cancel a postcard", async function (t) {
         from: from,
         front:
           "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
-        back:
-          "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
+        back: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
       },
       { headers: prism.authHeader }
     )
@@ -154,8 +153,7 @@ test("create, list, read then cancel a postcard with full payload", async functi
         send_date: date.toISOString(),
         front:
           "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/6x11_pc_template.pdf",
-        back:
-          "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/6x11_pc_template.pdf",
+        back: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/6x11_pc_template.pdf",
         size: "6x11",
         mail_type: "usps_standard",
         merge_variables: { name: "Harry" },
@@ -262,8 +260,7 @@ test("throws errors when input is not validated", async function (t) {
         },
         front:
           "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
-        back:
-          "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
+        back: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
       },
       { headers: prism.authHeader }
     )
@@ -292,8 +289,7 @@ test("throws errors when input is not validated", async function (t) {
         },
         front:
           "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
-        back:
-          "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
+        back: "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/4x6_pc_template.pdf",
       },
       { headers: prism.authHeader }
     )


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-228)

Rather than relying on a 3rd party Prettier Action and downgrading prettier to match that 3rd party's package version, decided to have workflow install prettier on every run and run that local version.

Note: the latest version of prettier is 2.3.2 and was only slightly above our last version. And this version thinks we should delete such newlines 
![image](https://user-images.githubusercontent.com/45194378/125118444-9096ea80-e0a4-11eb-95ab-1c34035607a6.png)

![image](https://user-images.githubusercontent.com/45194378/125118061-05b5f000-e0a4-11eb-9e9c-1e9fc05b3747.png)