### PR TITLE
tr to sanitize branch name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr "\":<>|*?\\/" "_")"
         id: extract_branch
 
       - name: save builds as artifacts


### PR DESCRIPTION
From [this PR](https://github.com/lob/lob-openapi/pull/142#issue-687062991), realized that the artifact build failed when the branch name contained symbols forbidden in artifact names. Fixed that here by substituting those forbidden symbol with "_".