### PR TITLE
bug(slack-alerts): collapsing verbose slack alerts

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -2,7 +2,7 @@ name: Monitor API contracts
 
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/30 * * * *"
 
 jobs:
   monitor_av:

--- a/actions/contract_tests/goalieruns.js
+++ b/actions/contract_tests/goalieruns.js
@@ -22,13 +22,8 @@ module.exports.runTests = async function runTests() {
         test_command = 'ava "' + test + '"';
         exec(test_command, async function (err, stdout, stderr) {
           if (err) {
-            const startIndex = stdout.indexOf("─");
-            const endIndex = stdout.lastIndexOf("─");
-            if (stdout.slice(startIndex, endIndex)) {
-              const formatted =
-                "```" + stdout.slice(startIndex, endIndex) + "```";
-              failures.push(formatted);
-            }
+            const formatted = "```" + stdout + "```";
+            failures.push(formatted);
           }
           // async: the code won't proceed to the next block until
           // this block is resolved, so a resolve is returned after
@@ -60,10 +55,14 @@ module.exports.runTests = async function runTests() {
           errorMessage = `There was 1 failure in the contract tests`;
         }
         try {
-          const result = await web.chat.postMessage({
+          const parent = await web.chat.postMessage({
             channel: pkg.config.goalieMappings[validated_arg].slackChannel,
-            text: `:party-dead: ${errorMessage}
-  ${failures.join("\n")}`,
+            text: `:party-dead: ${errorMessage}`,
+          });
+          const reply = await web.chat.postMessage({
+            channel: pkg.config.goalieMappings[validated_arg].slackChannel,
+            thread_ts: parent.ts,
+            text: `${failures.join("\n")}`,
           });
         } catch (slackError) {
           console.error(JSON.stringify(slackError, null, 2));

--- a/actions/contract_tests/goalieruns.js
+++ b/actions/contract_tests/goalieruns.js
@@ -22,7 +22,7 @@ module.exports.runTests = async function runTests() {
         test_command = 'ava "' + test + '"';
         exec(test_command, async function (err, stdout, stderr) {
           if (err) {
-            const formatted = "```" + stdout + "```";
+            const formatted = "```" + stdout.replaceAll("```", " ") + "```";
             failures.push(formatted);
           }
           // async: the code won't proceed to the next block until

--- a/actions/contract_tests/goalieruns.js
+++ b/actions/contract_tests/goalieruns.js
@@ -46,6 +46,7 @@ module.exports.runTests = async function runTests() {
             core.setFailed(
               "An unexpected error surfaced in the contract tests."
             );
+            return 1;
           }
         });
         let errorMessage = "";


### PR DESCRIPTION
Alright, so slack alerts pooped all over some of the error channels again. I'll make sure all the lob-openapi secrets work as intended ASAP. Here's a fix which should help:

- Gets rid of the fancy string indexing, since there are some external errors that doesn't work for
- Collapses the actual errors into a reply to the original message, so all you'll see is:
<img width="331" alt="Screen Shot 2021-07-12 at 3 57 58 PM" src="https://user-images.githubusercontent.com/15935019/125366115-50489e00-e32a-11eb-9e79-9bc821752d66.png">
- Changes the frequency of the contract tests: they're now run every 30 minutes.

It's been a little difficult for me to figure out how much information to include in the tests, since I don't have any kind of design I'm working off 😓 But I think this marries the potential usefulness of the verbose errors with a neat display, since the channel won't be clogged up by a giant set of errors each time GitHub decides to get the stomach flu.