### PR TITLE
put ratelimits in right places

### DIFF
--- a/resources/addresses/responses/address.yml
+++ b/resources/addresses/responses/address.yml
@@ -1,13 +1,5 @@
 description: Returns an address object if a valid identifier was provided.
 
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
 content:
   application/json:
     schema:

--- a/resources/bank_accounts/bank_account.yml
+++ b/resources/bank_accounts/bank_account.yml
@@ -20,7 +20,9 @@ get:
 
   responses:
     "200":
-      $ref: responses/bank_account.yml
+      description: Returns a bank_account object
+      content:
+        $ref: responses/bank_account.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/bank_accounts/bank_account_verify.yml
+++ b/resources/bank_accounts/bank_account_verify.yml
@@ -48,7 +48,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/bank_account.yml
+      $ref: responses/post_bank_account.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/bank_accounts/bank_accounts.yml
+++ b/resources/bank_accounts/bank_accounts.yml
@@ -84,7 +84,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/bank_account.yml
+      $ref: responses/post_bank_account.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/bank_accounts/responses/bank_account.yml
+++ b/resources/bank_accounts/responses/bank_account.yml
@@ -1,29 +1,18 @@
-description: Returns a bank_account object
+application/json:
+  schema:
+    $ref: "../models/bank_account.yml"
 
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/bank_account.yml"
-
-    example:
-      id: bank_8cad8df5354d33f
-      signature_url: "https://lob-assets.com/letters/asd_asdfghjklqwertyu.pdf?version=45&expires=1234567890&signature=a"
-      description: Test Bank Account
-      metadata: {}
-      routing_number: "322271627"
-      account_number: "123456789"
-      account_type: company
-      signatory: John Doe
-      bank_name: J.P. MORGAN CHASE BANK, N.A.
-      verified: false
-      date_created: "2015-11-06T19:24:24.440Z"
-      date_modified: "2015-11-06T19:24:24.440Z"
-      object: bank_account
+  example:
+    id: bank_8cad8df5354d33f
+    signature_url: "https://lob-assets.com/letters/asd_asdfghjklqwertyu.pdf?version=45&expires=1234567890&signature=a"
+    description: Test Bank Account
+    metadata: {}
+    routing_number: "322271627"
+    account_number: "123456789"
+    account_type: company
+    signatory: John Doe
+    bank_name: J.P. MORGAN CHASE BANK, N.A.
+    verified: false
+    date_created: "2015-11-06T19:24:24.440Z"
+    date_modified: "2015-11-06T19:24:24.440Z"
+    object: bank_account

--- a/resources/bank_accounts/responses/post_bank_account.yml
+++ b/resources/bank_accounts/responses/post_bank_account.yml
@@ -1,0 +1,12 @@
+description: Returns a bank_account object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "bank_account.yml"

--- a/resources/certificates/certificate.yml
+++ b/resources/certificates/certificate.yml
@@ -20,7 +20,9 @@ get:
 
   responses:
     "200":
-      $ref: responses/certificate.yml
+      description: Returns an certificate object if a valid identifier was provided.
+      content:
+        $ref: responses/certificate.yml
 
     default:
       $ref: "../../shared/responses/error.yml"
@@ -53,7 +55,9 @@ patch:
 
   responses:
     "200":
-      $ref: responses/certificate.yml
+      description: Returns an certificate object if a valid identifier was provided.
+      content:
+        $ref: responses/certificate.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/certificates/certificates.yml
+++ b/resources/certificates/certificates.yml
@@ -48,7 +48,7 @@ post:
 
   responses:
     "201":
-      $ref: responses/certificate.yml
+      $ref: responses/post_certificate.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/certificates/responses/certificate.yml
+++ b/resources/certificates/responses/certificate.yml
@@ -1,16 +1,13 @@
-description: Returns an certificate object if a valid identifier was provided.
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/certificate.yml"
-    example:
-      description: Certificate 1
-      name: Lob PEM Key
-      cert: --Key--
-      date_created: "2019-08-24T14:15:22Z"
-      date_modified: "2019-08-24T14:15:22Z"
-      date_deleted: "2020-08-24T14:15:22Z"
-      object: certificate
-      id: cert_1
-      account_id: asdf
+application/json:
+  schema:
+    $ref: "../models/certificate.yml"
+  example:
+    description: Certificate 1
+    name: Lob PEM Key
+    cert: --Key--
+    date_created: "2019-08-24T14:15:22Z"
+    date_modified: "2019-08-24T14:15:22Z"
+    date_deleted: "2020-08-24T14:15:22Z"
+    object: certificate
+    id: cert_1
+    account_id: asdf

--- a/resources/certificates/responses/post_certificate.yml
+++ b/resources/certificates/responses/post_certificate.yml
@@ -1,0 +1,12 @@
+description: Returns an certificate object if a valid identifier was provided.
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "certificate.yml"

--- a/resources/checks/check.yml
+++ b/resources/checks/check.yml
@@ -20,7 +20,9 @@ get:
 
   responses:
     "200":
-      $ref: responses/check.yml
+      description: Returns a check object
+      content:
+        $ref: responses/check.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/checks/checks.yml
+++ b/resources/checks/checks.yml
@@ -174,7 +174,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/check.yml
+      $ref: responses/post_check.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/checks/responses/check.yml
+++ b/resources/checks/responses/check.yml
@@ -1,87 +1,76 @@
-description: Returns a check object
+application/json:
+  schema:
+    $ref: "../models/check.yml"
 
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/check.yml"
-
-    example:
-      id: chk_534f10783683daa0
-      description: Demo Check
+  example:
+    id: chk_534f10783683daa0
+    description: Demo Check
+    metadata: {}
+    check_number: 10062
+    memo: rent
+    amount: 22.5
+    url: https://lob-assets.com/checks/chk_534f10783683daa0.pdf?expires=1540372221&signature=Ty3IV2bGPEoQfrdraYHlNYTaarnHLXb
+    to:
+      id: adr_bae820679f3f536b
+      description: Harry - Office
+      name: HARRY ZHANG
+      company: LOB
+      email: harry@lob.com
+      phone: "5555555555"
+      address_line1: 185 BERRY ST STE 6100
+      address_line2: ""
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
       metadata: {}
-      check_number: 10062
-      memo: rent
-      amount: 22.5
-      url: https://lob-assets.com/checks/chk_534f10783683daa0.pdf?expires=1540372221&signature=Ty3IV2bGPEoQfrdraYHlNYTaarnHLXb
-      to:
-        id: adr_bae820679f3f536b
-        description: Harry - Office
-        name: HARRY ZHANG
-        company: LOB
-        email: harry@lob.com
-        phone: "5555555555"
-        address_line1: 185 BERRY ST STE 6100
-        address_line2: ""
-        address_city: SAN FRANCISCO
-        address_state: CA
-        address_zip: 94107-1741
-        address_country: UNITED STATES
-        metadata: {}
-        date_created: "2018-12-08T03:08:43.446Z"
-        date_modified: "2018-12-08T03:08:43.446Z"
-        object: address
-        recipient_moved: false
-      from:
-        id: adr_b8fb5acf3a2b55db
-        name: LEORE AVIDAR
-        address_line1: 185 BERRY ST STE 6100
-        address_city: SAN FRANCISCO
-        address_state: CA
-        address_zip: 94107-1741
-        address_country: UNITED STATES
-        metadata: {}
-        date_created: "2017-09-05T17:47:53.767Z"
-        date_modified: "2017-09-05T17:47:53.767Z"
-        object: address
-      bank_account:
-        id: bank_8cad8df5354d33f
-        description: Test Bank Account
-        metadata: {}
-        routing_number: "322271627"
-        account_number: "123456789"
-        signatory: John Doe
-        bank_name: J.P. MORGAN CHASE BANK, N.A.
-        verified: true
-        account_type: company
-        date_created: "2015-11-06T19:24:24.440Z"
-        date_modified: "2015-11-06T19:41:28.312Z"
-        object: bank_account
-        signature_url: https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf
-      carrier: USPS
-      tracking_events: []
-      thumbnails:
-        - small: https://lob-assets.com/checks/chk_534f10783683daa0_thumb_small_1.png?expires=1540372221&signature=ShhPpH74wYkNiAj7Il9B6q8ZKkzlGd4
-          medium: https://lob-assets.com/checks/chk_534f10783683daa0_thumb_medium_1.png?expires=1540372221&signature=tmIOq6aAyKgzAECp7STj1rvJuMS5Svd
-          large: https://lob-assets.com/checks/chk_534f10783683daa0_thumb_large_1.png?expires=1540372221&signature=04nLEwE9d2qgQJNgJYWSOgPnU0FZbEv
-      merge_variables:
-        name: Harry
-      expected_delivery_date: "2017-09-12"
-      mail_type: usps_first_class
-      date_created: "2017-09-05T17:47:53.896Z"
-      date_modified: "2017-09-05T17:47:53.896Z"
-      send_date: "2017-09-05"
-      object: check
-      message: pancakes are good
-      check_bottom_template_id: tmpl_a
-      attachment_template_id: tmpl_a
-      check_bottom_template_version_id: vrsn_a
-      attachment_template_version_id: vrsn_a
-      deleted: true
+      date_created: "2018-12-08T03:08:43.446Z"
+      date_modified: "2018-12-08T03:08:43.446Z"
+      object: address
+      recipient_moved: false
+    from:
+      id: adr_b8fb5acf3a2b55db
+      name: LEORE AVIDAR
+      address_line1: 185 BERRY ST STE 6100
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
+      metadata: {}
+      date_created: "2017-09-05T17:47:53.767Z"
+      date_modified: "2017-09-05T17:47:53.767Z"
+      object: address
+    bank_account:
+      id: bank_8cad8df5354d33f
+      description: Test Bank Account
+      metadata: {}
+      routing_number: "322271627"
+      account_number: "123456789"
+      signatory: John Doe
+      bank_name: J.P. MORGAN CHASE BANK, N.A.
+      verified: true
+      account_type: company
+      date_created: "2015-11-06T19:24:24.440Z"
+      date_modified: "2015-11-06T19:41:28.312Z"
+      object: bank_account
+      signature_url: https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf
+    carrier: USPS
+    tracking_events: []
+    thumbnails:
+      - small: https://lob-assets.com/checks/chk_534f10783683daa0_thumb_small_1.png?expires=1540372221&signature=ShhPpH74wYkNiAj7Il9B6q8ZKkzlGd4
+        medium: https://lob-assets.com/checks/chk_534f10783683daa0_thumb_medium_1.png?expires=1540372221&signature=tmIOq6aAyKgzAECp7STj1rvJuMS5Svd
+        large: https://lob-assets.com/checks/chk_534f10783683daa0_thumb_large_1.png?expires=1540372221&signature=04nLEwE9d2qgQJNgJYWSOgPnU0FZbEv
+    merge_variables:
+      name: Harry
+    expected_delivery_date: "2017-09-12"
+    mail_type: usps_first_class
+    date_created: "2017-09-05T17:47:53.896Z"
+    date_modified: "2017-09-05T17:47:53.896Z"
+    send_date: "2017-09-05T17:47:53.896Z"
+    object: check
+    message: pancakes are good
+    check_bottom_template_id: tmpl_a
+    attachment_template_id: tmpl_a
+    check_bottom_template_version_id: vrsn_a
+    attachment_template_version_id: vrsn_a
+    deleted: true

--- a/resources/checks/responses/post_check.yml
+++ b/resources/checks/responses/post_check.yml
@@ -1,0 +1,12 @@
+description: Returns a check object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "check.yml"

--- a/resources/letters/letter.yml
+++ b/resources/letters/letter.yml
@@ -20,7 +20,9 @@ get:
 
   responses:
     "200":
-      $ref: responses/letter.yml
+      description: Returns a letter object
+      content:
+        $ref: responses/letter.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/letters/letters.yml
+++ b/resources/letters/letters.yml
@@ -174,7 +174,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/letter.yml
+      $ref: responses/post_letter.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/letters/responses/letter.yml
+++ b/resources/letters/responses/letter.yml
@@ -1,77 +1,66 @@
-description: Returns a letter object
-
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/letter.yml"
-    example:
-      id: ltr_4868c3b754655f90
-      description: Demo Letter
+application/json:
+  schema:
+    $ref: "../models/letter.yml"
+  example:
+    id: ltr_4868c3b754655f90
+    description: Demo Letter
+    metadata: {}
+    to:
+      id: adr_d3489cd64c791ab5
+      description: null
+      name: HARRY ZHANG
+      company: null
+      phone: null
+      email: null
+      address_line1: 185 BERRY ST STE 6100
+      address_line2: null
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
       metadata: {}
-      to:
-        id: adr_d3489cd64c791ab5
-        description: null
-        name: HARRY ZHANG
-        company: null
-        phone: null
-        email: null
-        address_line1: 185 BERRY ST STE 6100
-        address_line2: null
-        address_city: SAN FRANCISCO
-        address_state: CA
-        address_zip: 94107-1741
-        address_country: UNITED STATES
-        metadata: {}
-        date_created: "2017-09-05T15:54:53.264Z"
-        date_modified: "2017-09-05T15:54:53.264Z"
-        deleted: true
-        object: address
-      from:
-        id: adr_b8fb5acf3a2b55db
-        description: null
-        name: LEORE AVIDAR
-        company: null
-        phone: null
-        email: null
-        address_line1: 185 BERRY ST STE 6100
-        address_line2: null
-        address_city: SAN FRANCISCO
-        address_state: CA
-        address_zip: 94107-1741
-        address_country: UNITED STATES
-        metadata: {}
-        date_created: "2017-09-05T15:54:53.264Z"
-        date_modified: "2017-09-05T15:54:53.264Z"
-        deleted: true
-        object: address
-      color: true
-      double_sided: true
-      address_placement: top_first_page
-      return_envelope: false
-      perforated_page: null
-      custom_envelope: null
-      extra_service: null
-      mail_type: usps_first_class
-      url: https://lob-assets.com/letters/ltr_4868c3b754655f90.pdf?expires=1540372221&signature=8r94fse8uam7wGWmW5baxXulU88X2CA
-      carrier: USPS
-      tracking_number: null
-      tracking_events: []
-      thumbnails:
-        - small: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha
-          medium: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF
-          large: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW
-      merge_variables:
-        name: Harry
-      expected_delivery_date: "2017-09-12"
-      date_created: "2017-09-05T15:54:53.346Z"
-      date_modified: "2017-09-05T15:54:53.346Z"
-      send_date: "2017-09-05T15:54:53.346Z"
-      object: letter
+      date_created: "2017-09-05T15:54:53.264Z"
+      date_modified: "2017-09-05T15:54:53.264Z"
+      deleted: true
+      object: address
+    from:
+      id: adr_b8fb5acf3a2b55db
+      description: null
+      name: LEORE AVIDAR
+      company: null
+      phone: null
+      email: null
+      address_line1: 185 BERRY ST STE 6100
+      address_line2: null
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
+      metadata: {}
+      date_created: "2017-09-05T15:54:53.264Z"
+      date_modified: "2017-09-05T15:54:53.264Z"
+      deleted: true
+      object: address
+    color: true
+    double_sided: true
+    address_placement: top_first_page
+    return_envelope: false
+    perforated_page: null
+    custom_envelope: null
+    extra_service: null
+    mail_type: usps_first_class
+    url: https://lob-assets.com/letters/ltr_4868c3b754655f90.pdf?expires=1540372221&signature=8r94fse8uam7wGWmW5baxXulU88X2CA
+    carrier: USPS
+    tracking_number: null
+    tracking_events: []
+    thumbnails:
+      - small: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha
+        medium: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF
+        large: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW
+    merge_variables:
+      name: Harry
+    expected_delivery_date: "2017-09-12"
+    date_created: "2017-09-05T15:54:53.346Z"
+    date_modified: "2017-09-05T15:54:53.346Z"
+    send_date: "2017-09-05T15:54:53.346Z"
+    object: letter

--- a/resources/letters/responses/post_letter.yml
+++ b/resources/letters/responses/post_letter.yml
@@ -1,0 +1,12 @@
+description: Returns a letter object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "letter.yml"

--- a/resources/postcards/postcard.yml
+++ b/resources/postcards/postcard.yml
@@ -20,7 +20,9 @@ get:
 
   responses:
     "200":
-      $ref: "responses/postcard.yml"
+      description: Returns a postcard object
+      content:
+        $ref: "responses/postcard.yml"
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/postcards/postcards.yml
+++ b/resources/postcards/postcards.yml
@@ -174,7 +174,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/postcard.yml
+      $ref: responses/post_postcard.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/postcards/responses/post_postcard.yml
+++ b/resources/postcards/responses/post_postcard.yml
@@ -1,0 +1,12 @@
+description: Returns a postcard object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "postcard.yml"

--- a/resources/postcards/responses/postcard.yml
+++ b/resources/postcards/responses/postcard.yml
@@ -1,107 +1,96 @@
-description: Returns a postcard object
+application/json:
+  schema:
+    $ref: "../models/postcard.yml"
 
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/postcard.yml"
-
-    examples:
-      basic:
-        value:
-          id: "psc_208e45e48d271294"
+  examples:
+    basic:
+      value:
+        id: "psc_208e45e48d271294"
+        description: null
+        metadata: {}
+        to:
+          id: adr_210a8d4b0b76d77b
           description: null
+          name: null
+          company: LOB
+          phone: null
+          email: null
+          address_line1: 185 BERRY ST STE 6100
+          address_line2: null
+          address_city: SAN FRANCISCO
+          address_state: CA
+          address_zip: 94107-1741
+          address_country: UNITED STATES
           metadata: {}
-          to:
-            id: adr_210a8d4b0b76d77b
-            description: null
-            name: null
-            company: LOB
-            phone: null
-            email: null
-            address_line1: 185 BERRY ST STE 6100
-            address_line2: null
-            address_city: SAN FRANCISCO
-            address_state: CA
-            address_zip: 94107-1741
-            address_country: UNITED STATES
-            metadata: {}
-            date_created: "2018-12-08T03:01:07.651Z"
-            date_modified: "2018-12-08T03:01:07.651Z"
-            object: address
-          url: "https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA"
-          carrier: USPS
-          front_template_id: null
-          back_template_id: null
-          front_template_version_id: null
-          back_template_version_id: null
-          date_created: "2021-03-24T22:51:42.838Z"
-          date_modified: "2021-03-24T22:51:42.838Z"
-          send_date: "2021-03-24T22:51:42.838Z"
-          object: "postcard"
-      full:
-        value:
-          id: "psc_0e03d1ad7d31f151"
+          date_created: "2018-12-08T03:01:07.651Z"
+          date_modified: "2018-12-08T03:01:07.651Z"
+          object: address
+        url: "https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA"
+        carrier: USPS
+        front_template_id: null
+        back_template_id: null
+        front_template_version_id: null
+        back_template_version_id: null
+        date_created: "2021-03-24T22:51:42.838Z"
+        date_modified: "2021-03-24T22:51:42.838Z"
+        send_date: "2021-03-24T22:51:42.838Z"
+        object: "postcard"
+    full:
+      value:
+        id: "psc_0e03d1ad7d31f151"
+        description: null
+        metadata: {}
+        to:
+          id: adr_c7cb63d68f8d6
           description: null
+          name: JANE DOE
+          company: LOB
+          phone: "5555555555"
+          email: jane.doe@lob.com
+          address_line1: 370 WATER ST
+          address_line2: ""
+          address_city: SUMMERSIDE
+          address_state: PE
+          address_zip: C1N 1C4
+          address_country: CANADA
           metadata: {}
-          to:
-            id: adr_c7cb63d68f8d6
-            description: null
-            name: JANE DOE
-            company: LOB
-            phone: "5555555555"
-            email: jane.doe@lob.com
-            address_line1: 370 WATER ST
-            address_line2: ""
-            address_city: SUMMERSIDE
-            address_state: PE
-            address_zip: C1N 1C4
-            address_country: CANADA
-            metadata: {}
-            date_created: "2018-12-08T03:01:07.651Z"
-            date_modified: "2018-12-08T03:01:07.651Z"
-            object: address
-            recipient_moved: false
-          from:
-            id: adr_210a8d4b0b76d77b
-            description: null
-            name: LEORE AVIDAR
-            company: null
-            phone: null
-            email: null
-            address_line1: 185 BERRY ST STE 6100
-            address_line2: null
-            address_city: SAN FRANCISCO
-            address_state: CA
-            address_zip: 94107-1741
-            address_country: UNITED STATES
-            metadata: {}
-            date_created: "2018-12-08T03:01:07.651Z"
-            date_modified: "2018-12-08T03:01:07.651Z"
-            object: address
-          url: "https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA"
-          carrier: USPS
-          front_template_id: null
-          back_template_id: null
-          front_template_version_id: null
-          back_template_version_id: null
-          tracking_events: []
-          size: 6x11
-          mail_type: usps_first_class
-          merge_variables: {}
-          thumbnails:
-            - small: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha
-              medium: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF
-              large: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW
-          expected_delivery_date: "2021-03-30"
-          date_created: "2021-03-24T22:51:42.838Z"
-          date_modified: "2021-03-24T22:51:42.838Z"
-          send_date: "2021-03-25"
-          object: "postcard"
+          date_created: "2018-12-08T03:01:07.651Z"
+          date_modified: "2018-12-08T03:01:07.651Z"
+          object: address
+          recipient_moved: false
+        from:
+          id: adr_210a8d4b0b76d77b
+          description: null
+          name: LEORE AVIDAR
+          company: null
+          phone: null
+          email: null
+          address_line1: 185 BERRY ST STE 6100
+          address_line2: null
+          address_city: SAN FRANCISCO
+          address_state: CA
+          address_zip: 94107-1741
+          address_country: UNITED STATES
+          metadata: {}
+          date_created: "2018-12-08T03:01:07.651Z"
+          date_modified: "2018-12-08T03:01:07.651Z"
+          object: address
+        url: "https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA"
+        carrier: USPS
+        front_template_id: null
+        back_template_id: null
+        front_template_version_id: null
+        back_template_version_id: null
+        tracking_events: []
+        size: 6x11
+        mail_type: usps_first_class
+        merge_variables: {}
+        thumbnails:
+          - small: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha
+            medium: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF
+            large: https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW
+        expected_delivery_date: "2021-03-30"
+        date_created: "2021-03-24T22:51:42.838Z"
+        date_modified: "2021-03-24T22:51:42.838Z"
+        send_date: "2021-03-24T22:51:42.838Z"
+        object: "postcard"

--- a/resources/self_mailers/responses/all_self_mailers.yml
+++ b/resources/self_mailers/responses/all_self_mailers.yml
@@ -7,14 +7,6 @@ description: >-
   more self_mailers are available beyond the current set of returned results,
   the `next_url` field will be empty.
 
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
 content:
   application/json:
     schema:

--- a/resources/self_mailers/responses/post_self_mailer.yml
+++ b/resources/self_mailers/responses/post_self_mailer.yml
@@ -1,0 +1,12 @@
+description: Returns a self_mailer object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "self_mailer.yml"

--- a/resources/self_mailers/responses/self_mailer.yml
+++ b/resources/self_mailers/responses/self_mailer.yml
@@ -1,78 +1,67 @@
-description: Returns a self_mailer object
-
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/self_mailer.yml"
-    example:
-      id: sfm_8ffbe811dea49dcf
-      description: April Campaign
+application/json:
+  schema:
+    $ref: "../models/self_mailer.yml"
+  example:
+    id: sfm_8ffbe811dea49dcf
+    description: April Campaign
+    metadata: {}
+    to:
+      id: adr_bae820679f3f536b
+      description:
+      name: HARRY ZHANG
+      company:
+      phone:
+      email:
+      address_line1: 185 BERRY ST STE 6100
+      address_line2:
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
       metadata: {}
-      to:
-        id: adr_bae820679f3f536b
-        description:
-        name: HARRY ZHANG
-        company:
-        phone:
-        email:
-        address_line1: 185 BERRY ST STE 6100
-        address_line2:
-        address_city: SAN FRANCISCO
-        address_state: CA
-        address_zip: 94107-1741
-        address_country: UNITED STATES
-        metadata: {}
-        date_created: "2017-09-05T17:47:53.767Z"
-        date_modified: "2017-09-05T17:47:53.767Z"
-        deleted: true
-        object: address
-      from:
-        id: adr_210a8d4b0b76d77b
-        description:
-        name: LEORE AVIDAR
-        company:
-        phone:
-        email:
-        address_line1: 185 BERRY ST STE 6100
-        address_line2:
-        address_city: SAN FRANCISCO
-        address_state: CA
-        address_zip: 94107-1741
-        address_country: UNITED STATES
-        metadata: {}
-        date_created: "2017-09-05T17:47:53.767Z"
-        date_modified: "2017-09-05T17:47:53.767Z"
-        deleted: true
-        object: address
-      url: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA
-      outside_template_id: tmpl_a3cb937f26d7eec
-      inside_template_id: tmpl_a3cb937f26d7eec
-      inside_template_version_id: vrsn_bfdf70893b00a85
-      outside_template_version_id: vrsn_bfdf70893b00a85
-      carrier: USPS
-      tracking_events: []
-      thumbnails:
-        - small: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA
-          medium: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ
-          large: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg
-        - small: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ
-          medium: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA
-          large: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw
-      merge_variables:
-        name:
-      size: 6x18_bifold
-      mail_type: usps_first_class
-      expected_delivery_date: "2021-03-24"
-      date_created: "2021-03-16T18:40:40.504Z"
-      date_modified: "2021-03-16T18:40:40.504Z"
-      send_date: "2021-03-16T18:45:40.493Z"
-      billing_group_id: bg_79a178f7171f5795d
-      object: self_mailer
+      date_created: "2017-09-05T17:47:53.767Z"
+      date_modified: "2017-09-05T17:47:53.767Z"
+      deleted: true
+      object: address
+    from:
+      id: adr_210a8d4b0b76d77b
+      description:
+      name: LEORE AVIDAR
+      company:
+      phone:
+      email:
+      address_line1: 185 BERRY ST STE 6100
+      address_line2:
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
+      metadata: {}
+      date_created: "2017-09-05T17:47:53.767Z"
+      date_modified: "2017-09-05T17:47:53.767Z"
+      deleted: true
+      object: address
+    url: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA
+    outside_template_id: tmpl_a3cb937f26d7eec
+    inside_template_id: tmpl_a3cb937f26d7eec
+    inside_template_version_id: vrsn_bfdf70893b00a85
+    outside_template_version_id: vrsn_bfdf70893b00a85
+    carrier: USPS
+    tracking_events: []
+    thumbnails:
+      - small: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA
+        medium: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ
+        large: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg
+      - small: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ
+        medium: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA
+        large: https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw
+    merge_variables:
+      name:
+    size: 6x18_bifold
+    mail_type: usps_first_class
+    expected_delivery_date: "2021-03-24"
+    date_created: "2021-03-16T18:40:40.504Z"
+    date_modified: "2021-03-16T18:40:40.504Z"
+    send_date: "2021-03-16T18:45:40.493Z"
+    billing_group_id: bg_79a178f7171f5795d
+    object: self_mailer

--- a/resources/self_mailers/self_mailer.yml
+++ b/resources/self_mailers/self_mailer.yml
@@ -20,7 +20,9 @@ get:
 
   responses:
     "200":
-      $ref: responses/self_mailer.yml
+      description: Returns a self_mailer object
+      content:
+        $ref: responses/self_mailer.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/self_mailers/self_mailers.yml
+++ b/resources/self_mailers/self_mailers.yml
@@ -102,7 +102,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/self_mailer.yml
+      $ref: responses/post_self_mailer.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/templates/responses/all_templates.yml
+++ b/resources/templates/responses/all_templates.yml
@@ -7,14 +7,6 @@ description: >-
   more templates are available beyond the current set of returned results,
   the `next_url` field will be empty.
 
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
 content:
   application/json:
     schema:

--- a/resources/templates/responses/post_template.yml
+++ b/resources/templates/responses/post_template.yml
@@ -1,0 +1,12 @@
+description: Returns a self_mailer object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "template.yml"

--- a/resources/templates/responses/template.yml
+++ b/resources/templates/responses/template.yml
@@ -1,39 +1,28 @@
-description: Returns a template object
-
-headers:
-  ratelimit-limit:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/template.yml"
-    example:
-      id: "tmpl_c94e83ca2cd5121"
-      description: "Test Template" # TODO: add `description` to ../models/template.yml
-      versions:
-        - id: "vrsn_362184d96d9b0c9"
-          suggest_json_editor: true
-          description: "Test Template"
-          engine: legacy
-          html: "<html>HTML for {{name}}</html>"
-          date_created: "2017-11-07T22:56:10.962Z"
-          date_modified: "2017-11-07T22:56:10.962Z"
-          object: "version"
-      published_version:
-        id: "vrsn_362184d96d9b0c9"
-        suggest_json_editor: false
+application/json:
+  schema:
+    $ref: "../models/template.yml"
+  example:
+    id: "tmpl_c94e83ca2cd5121"
+    description: "Test Template" # TODO: add `description` to ../models/template.yml
+    versions:
+      - id: "vrsn_362184d96d9b0c9"
+        suggest_json_editor: true
         description: "Test Template"
-        engine: handlebars
+        engine: legacy
         html: "<html>HTML for {{name}}</html>"
         date_created: "2017-11-07T22:56:10.962Z"
         date_modified: "2017-11-07T22:56:10.962Z"
         object: "version"
-      metadata: {}
+    published_version:
+      id: "vrsn_362184d96d9b0c9"
+      suggest_json_editor: false
+      description: "Test Template"
+      engine: handlebars
+      html: "<html>HTML for {{name}}</html>"
       date_created: "2017-11-07T22:56:10.962Z"
       date_modified: "2017-11-07T22:56:10.962Z"
-      object: "template"
+      object: "version"
+    metadata: {}
+    date_created: "2017-11-07T22:56:10.962Z"
+    date_modified: "2017-11-07T22:56:10.962Z"
+    object: "template"

--- a/resources/templates/template.yml
+++ b/resources/templates/template.yml
@@ -20,7 +20,9 @@ get:
 
   responses:
     "200":
-      $ref: responses/template.yml
+      description: Returns a self_mailer object
+      content:
+        $ref: "responses/template.yml"
 
     default:
       $ref: "../../shared/responses/error.yml"
@@ -66,7 +68,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/template.yml
+      $ref: responses/post_template.yml
 
     default:
       $ref: "../../shared/responses/error.yml"

--- a/resources/templates/template_versions/responses/all_template_versions.yml
+++ b/resources/templates/template_versions/responses/all_template_versions.yml
@@ -7,14 +7,6 @@ description: >-
   beyond the current set of returned results, the `next_url` field will be
   empty.
 
-headers:
-  ratelimit-limit:
-    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
 content:
   application/json:
     schema:

--- a/resources/templates/template_versions/responses/post_template_version.yml
+++ b/resources/templates/template_versions/responses/post_template_version.yml
@@ -1,0 +1,12 @@
+description: Returns the template version with the given template and version ids.
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "template_version.yml"

--- a/resources/templates/template_versions/responses/template_version.yml
+++ b/resources/templates/template_versions/responses/template_version.yml
@@ -1,21 +1,10 @@
-description: Returns the template version with the given template and version ids.
-
-headers:
-  ratelimit-limit:
-    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-limit"
-  ratelimit-remaining:
-    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
-  ratelimit-reset:
-    $ref: "../../../../shared/headers/ratelimit.yml#/ratelimit-reset"
-
-content:
-  application/json:
-    schema:
-      $ref: "../models/template_version.yml"
-    example:
-      id: "vrsn_534e339882d2282"
-      description: "Second Version"
-      html: "<html>Second HTML for {{name}}</html>"
-      date_created: "2017-11-09T04:49:38.016Z"
-      date_modified: "2017-11-09T04:49:38.016Z"
-      object: version
+application/json:
+  schema:
+    $ref: "../models/template_version.yml"
+  example:
+    id: "vrsn_534e339882d2282"
+    description: "Second Version"
+    html: "<html>Second HTML for {{name}}</html>"
+    date_created: "2017-11-09T04:49:38.016Z"
+    date_modified: "2017-11-09T04:49:38.016Z"
+    object: version

--- a/resources/templates/template_versions/template_version.yml
+++ b/resources/templates/template_versions/template_version.yml
@@ -26,7 +26,9 @@ get:
 
   responses:
     "200":
-      $ref: "responses/template_version.yml"
+      description: Returns the template version with the given template and version ids.
+      content:
+        $ref: "responses/template_version.yml"
 
     default:
       $ref: "../../../shared/responses/error.yml"
@@ -68,7 +70,7 @@ post:
 
   responses:
     "200":
-      $ref: "responses/template_version.yml"
+      $ref: "responses/post_template_version.yml"
 
     default:
       $ref: "../../../shared/responses/error.yml"

--- a/resources/templates/template_versions/template_versions.yml
+++ b/resources/templates/template_versions/template_versions.yml
@@ -73,7 +73,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/template_version.yml
+      $ref: "responses/post_template_version.yml"
 
     default:
       $ref: "../../../shared/responses/error.yml"

--- a/resources/templates/templates.yml
+++ b/resources/templates/templates.yml
@@ -74,7 +74,7 @@ post:
 
   responses:
     "200":
-      $ref: responses/template.yml
+      $ref: responses/post_template.yml
 
     default:
       $ref: "../../shared/responses/error.yml"


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-230)

Added to all POST reqs and removed from all non-POST reqs. Some non-POST and POST reqs referenced the same schema so added a new file in the `responses` folder of those resources that contains the headers for POST reqs which references the content schema, i.e. the original `responses/xxx.yml`. Thereby minimized repeated code by a lot.