### PR TITLE
55s timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "clean": "rm -rf dist",
     "lint": "spectral lint $npm_package_config_specfile",
     "mock": "prism mock $npm_package_config_--dynamic $npm_package_config_specfile",
-    "singleTest": "func() { ava ./tests/\"$1\"_test.js; }; func",
+    "singleTest": "func() { ava --timeout=55s ./tests/\"$1\"_test.js; }; func",
     "pergoalie": "node actions/contract_tests/goalieruns.js",
     "postinstall": "husky install",
     "postman": "npm run bundle && openapi2postmanv2 --pretty --spec dist/$npm_package_config_bundlefile --output dist/$npm_package_config_postmanfile -O folderStrategy=Tags",
@@ -59,7 +59,7 @@
     "pretty:check": "prettier --check .",
     "proxy": "prism proxy --errors $npm_package_config_specfile https://api.lob.com/v1",
     "redoc": "redoc-cli bundle $npm_package_config_specfile -t actions/redoc/template.hbs --options.maxDisplayedEnumValues=15 --options.theme.sidebar.backgroundColor: \"#f7f9fa\" --options.expandResponses='200,201' --options.jsonSampleExpandLevel=3 --options.requiredPropsFirst=true -o docs/index.html",
-    "test": "ava './tests/**_test.js'"
+    "test": "ava --timeout=55s './tests/**_test.js'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-207)

~~According to [Paul](https://lob.slack.com/archives/C3DQ3K9U6/p1626387456343400?thread_ts=1626385041.343200&cid=C3DQ3K9U6), there seems to just be a uniform 45s timeout threshold for all endpoints.~~
According to [Adrian](https://github.com/lob/lob-openapi/pull/154#issuecomment-881064813) (in comments below), there seems to just be a uniform 55s timeout threshold for all endpoints.

# Areas of Concern
1. Not sure if the global timeout (to be applied to all tests) is reset after each assertion, like `t.timeout()` proclaims to do.

To address the above concern, I temporarily commented out all other tests in addresses and used setTimeout of 10s and 11s while keeping Ava's default timeout of 10s.
  - **Results** 
    1. Test passes with 9999ms so it's prob a safe bet that it resets after each assertion, even with the CLI
      - <img width="1071" alt="Screen Shot 2021-07-15 at 4 05 32 PM" src="https://user-images.githubusercontent.com/45194378/125869132-a74d072d-cd3a-4a08-b3d6-964eb9ac279b.png">

    2. Test quit without passing or failing on 10s and 11s
      - <img width="837" alt="Screen Shot 2021-07-15 at 3 48 25 PM" src="https://user-images.githubusercontent.com/45194378/125867883-24b707fa-d988-4e07-b9a8-d713a0f9677f.png">

Trying to do more research showed that [nobody cares](https://stackoverflow.com/questions/65054637/difference-between-timeout-and-t-timeout-in-ava) :'(