### PR TITLE
default template version engine

### DIFF
--- a/resources/templates/template_versions/models/template_version.yml
+++ b/resources/templates/template_versions/models/template_version.yml
@@ -26,6 +26,7 @@ allOf:
           - legacy
           - handlebars
         nullable: true
+        default: legacy
 
       object:
         allOf:


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-220) doesn't have any extra info but just proving that this is an existing issue and me not going rogue...

Know the default should be 'legacy' from [this](https://github.com/lob/lob-api/blob/abcdf9dcd490cedfe78a2a5501da1d7ca18939c5/src/validators/template-versions/create.js#L19)