### PR TITLE
delete resources created in tests

### DIFF
--- a/tests/checks_test.js
+++ b/tests/checks_test.js
@@ -187,11 +187,13 @@ test.after.always("delete all checks", async function (t) {
     })
   );
   t.assert(remove.status === 200);
-  prism.setup().then((client) =>
+
+  const delete_bank_acc = await prism.setup().then((client) =>
     client.delete(`/bank_accounts/${t.context.bank_id}`, {
       headers: prism.authHeader,
     })
   );
+  t.assert(delete_bank_acc.status === 200);
 
   const remove2 = await prism.setup().then((client) =>
     client.delete(`${resource_endpoint}/${t.context.read2.data.id}`, {
@@ -199,9 +201,11 @@ test.after.always("delete all checks", async function (t) {
     })
   );
   t.assert(remove2.status === 200);
-  prism.setup().then((client) =>
+
+  const delete_bank_acc2 = await prism.setup().then((client) =>
     client.delete(`/bank_accounts/${t.context.bank_id2}`, {
       headers: prism.authHeader,
     })
   );
+  t.assert(delete_bank_acc2.status === 200);
 });

--- a/tests/postcards_test.js
+++ b/tests/postcards_test.js
@@ -189,7 +189,7 @@ test("create, list, read then cancel a postcard with full payload", async functi
 });
 
 test("creates a postcard given a local filepath as the front", async function (t) {
-  t.plan(1);
+  t.plan(2);
   function streamToString(stream) {
     const chunks = [];
     return new Promise((resolve, reject) => {
@@ -233,6 +233,13 @@ test("creates a postcard given a local filepath as the front", async function (t
     )
   );
   t.assert(create.status === 200);
+
+  const cancel = await prism.setup().then((client) =>
+    client.delete(`${resource_endpoint}/${create.data.id}`, {
+      headers: prism.authHeader,
+    })
+  );
+  t.assert(cancel.status === 200);
 });
 
 // select failure cases:

--- a/tests/template_versions_test.js
+++ b/tests/template_versions_test.js
@@ -99,9 +99,10 @@ test.serial("delete template", async function (t) {
 
 test.after.always("clean up template", async function (t) {
   // clean up template too!
-  prism.setup().then((client) =>
+  let clean_up = await prism.setup().then((client) =>
     client.delete(t.context.tmpl_endpoint, {
       headers: prism.authHeader,
     })
   );
+  t.assert(clean_up.status === 200);
 });


### PR DESCRIPTION
Similar to [this PR](https://github.com/lob/lob-openapi/pull/158), I'm ensuring that resources are being deleted when they're created for contract tests. Sorry I forgot to lump it in with that other PR.