### PR TITLE
add billing_group_id prop

### DIFF
--- a/Lob-API-public.yml
+++ b/Lob-API-public.yml
@@ -1003,7 +1003,7 @@ tags:
   - name: Special Features
     x-traitTag: true
     description: |
-      The following are dsecriptions of Lob endpoints, like `v1/billing_groups`, which are available by special access to customers.
+      The following are descriptions of Lob endpoints, like `v1/billing_groups`, which are available by special access to customers.
 
   - name: Standard PDF Fonts
     x-traitTag: true

--- a/resources/checks/models/check_editable_props.yml
+++ b/resources/checks/models/check_editable_props.yml
@@ -82,3 +82,6 @@ allOf:
           - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
           - $ref: "../../../shared/attributes/remote_file_url.yml"
           - $ref: "../../../shared/attributes/local_file_path.yml"
+
+      billing_group_id:
+        $ref: "../../../shared/attributes/billing_group_id.yml"

--- a/resources/letters/models/letter_editable.yml
+++ b/resources/letters/models/letter_editable.yml
@@ -61,3 +61,6 @@ allOf:
             * `certified` - track and confirm delivery for domestic destinations. An extra sheet (1 PDF page single-sided or 2 PDF pages double-sided) is added to the beginning of your letter for address and barcode information. See here for templates: [#10 envelope](https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_certified_template.pdf) and [flat envelope](https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_certified_flat_template.pdf) (used for letters over 6 pages single-sided or 12 pages double-sided). You will not be charged for this extra sheet.
             * `certified_return_receipt` - request an electronic copy of the recipient's signature to prove delivery of your certified letter
             * `registered` - provides tracking and confirmation for international addresses
+
+      billing_group_id:
+        $ref: "../../../shared/attributes/billing_group_id.yml"

--- a/resources/postcards/models/postcard_editable.yml
+++ b/resources/postcards/models/postcard_editable.yml
@@ -58,3 +58,6 @@ allOf:
           - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
           - $ref: "../../../shared/attributes/remote_file_url.yml"
           - $ref: "../../../shared/attributes/local_file_path.yml"
+
+      billing_group_id:
+        $ref: "../../../shared/attributes/billing_group_id.yml"

--- a/resources/self_mailers/models/self_mailer_editable.yml
+++ b/resources/self_mailers/models/self_mailer_editable.yml
@@ -55,3 +55,6 @@ allOf:
           - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
           - $ref: "../../../shared/attributes/remote_file_url.yml"
           - $ref: "../../../shared/attributes/local_file_path.yml"
+
+      billing_group_id:
+        $ref: "../../../shared/attributes/billing_group_id.yml"

--- a/resources/self_mailers/responses/all_self_mailers.yml
+++ b/resources/self_mailers/responses/all_self_mailers.yml
@@ -83,7 +83,6 @@ content:
           date_modified: "2021-03-16T18:41:06.691Z"
           send_date: "2021-03-16T18:45:40.493Z"
           deleted: true
-          billing_group_id: bg_79a178f7171f5795d
           object: self_mailer
         - id: sfm_8ffbe811dea49dcf
           description: April Campaign
@@ -146,7 +145,6 @@ content:
           date_modified: "2021-03-16T18:41:06.691Z"
           send_date: "2021-03-16T18:45:40.493Z"
           deleted: true
-          billing_group_id: bg_79a178f7171f5795d
           object: self_mailer
       object: list
       next_url:

--- a/resources/self_mailers/responses/self_mailer.yml
+++ b/resources/self_mailers/responses/self_mailer.yml
@@ -63,5 +63,4 @@ application/json:
     date_created: "2021-03-16T18:40:40.504Z"
     date_modified: "2021-03-16T18:40:40.504Z"
     send_date: "2021-03-16T18:45:40.493Z"
-    billing_group_id: bg_79a178f7171f5795d
     object: self_mailer

--- a/shared/attributes/billing_group_id.yml
+++ b/shared/attributes/billing_group_id.yml
@@ -1,0 +1,7 @@
+type: string
+
+description: >-
+  An optional string with the billing group ID to tag your usage with.
+  Is used for billing purposes. Requires special activation to use.
+  See [Billing Group API](https://lob.github.io/lob-openapi/#tag/Billing-Groups)
+  for more information.


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-163)

Added this prop to 4 resources. Took it out from the examples since it's hidden behind a feature flag.
If you look at the UI, you'll see that CREATE A CHECK doesn't have `billing_group_id` because the `oneOf` is kind of botching things. Think that'll be resolved once `deep_dive2` is resolved, where I fix that weirdness.