### PR TITLE
move html template example

### DIFF
--- a/Lob-API-public.yml
+++ b/Lob-API-public.yml
@@ -1319,6 +1319,16 @@ tags:
       to the [HTML Templates Endpoints](#tag/Templates).
 
       ### Example Create Request using HTML Templates
+      ```bash
+        curl https://api.lob.com/v1/postcards \
+          -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
+          -d "description=Demo Postcard job" \
+          -d "to=adr_78c304d54912c502" \
+          -d "from=adr_61a0865c8c573139" \
+          -d "front=tmpl_b846a20859ae11a" \
+          -d "back=tmpl_01b0d396a10c268" \
+          -d "merge_variables[name]=Harry"
+      ```
 
       ## HTML Examples
       Use a pre-designed template from our [gallery](https://lob.com/resources/template-gallery) or follow these
@@ -1339,17 +1349,6 @@ tags:
       always look identical to what is produced through the API. It is **strongly** recommended that you test all
       HTML requests by reviewing the final PDF files in your Test Environment, as these are the files that will be
       printed.
-
-      ```bash
-        curl https://api.lob.com/v1/postcards \
-          -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
-          -d "description=Demo Postcard job" \
-          -d "to=adr_78c304d54912c502" \
-          -d "from=adr_61a0865c8c573139" \
-          -d "front=tmpl_b846a20859ae11a" \
-          -d "back=tmpl_01b0d396a10c268" \
-          -d "merge_variables[name]=Harry"
-      ```
 
       ## Image Prepping
       Currently we support the following file types for all endpoints:


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-298)

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [x] Prettier
  - [x] Spectral Lint
  - [x] Contract Tests
    - [x] Delete all resources created in contract tests
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect

## Changes
Just moving the example piece of code that was mistakenly in HTML Examples into HTML Templates.