### PR TITLE
FAILURE CASE FOR SPECTRAL

### DIFF
--- a/resources/postcards/models/postcard.yml
+++ b/resources/postcards/models/postcard.yml
@@ -18,12 +18,10 @@ allOf:
         $ref: "../attributes/psc_id.yml"
 
       front_template_id:
-        oneOf:
-          - allOf:
-              - description: The unique ID of the HTML template used for the front of the postcard.
-              - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
-          - type: string
-            nullable: true
+        - description: The unique ID of the HTML template used for the front of the postcard.
+        - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+        - type: string
+          nullable: true
 
       back_template_id:
         oneOf:


### PR DESCRIPTION
# DO NOT MERGE.

Surfaces vague Spectral error for the folks at Stoplight.io to check out.

The changed file is referenced by `resources/postcards/responses/all_postcards.yml`, which in turn is referenced by `resources/postcards/postcards.yml`.