### PR TITLE
larsseit + fontweights

### DIFF
--- a/actions/redoc/template.hbs
+++ b/actions/redoc/template.hbs
@@ -694,6 +694,9 @@
     .react-tabs__tab-panel > div > pre > .token.operator,
     .react-tabs__tab-panel > div > pre > .token.variable{color:#324350}
     div.react-tabs__tab-panel.react-tabs__tab-panel--selected{border-radius:10px}
+
+    {{!-- sidebars fontweight --}}
+    ul[role='navigation'] li > label > span { font-weight: 300; }
   </style>
 </body>
 

--- a/docs/redocOptions.json
+++ b/docs/redocOptions.json
@@ -25,7 +25,11 @@
         "textDecoration": "none"
       },
       "fontFamily": "Larsseit,sans-serif;",
-      "fontSize": 16
+      "fontSize": "16px",
+      "headings": {
+        "fontFamily": "Larsseit,sans-serif",
+        "fontWeight": 300
+      }
     },
     "codeBlock": {
       "backgroundColor": "#ecf0f5"


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-327)

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [x] Prettier
  - [x] Spectral Lint
  - [x] Contract Tests
    - [x] Delete all resources created in contract tests
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect

## Changes
Changed fontfams in redoc template options and tweaked subsequent fontweights a bit since they were lookin a bit chunky with Larsseit