### PR TITLE
Fixed summaries

### DIFF
--- a/resources/checks/models/check_editable_props.yml
+++ b/resources/checks/models/check_editable_props.yml
@@ -1,7 +1,6 @@
 allOf:
   - $ref: "check_base.yml"
   - $ref: "check_input_to.yml"
-  - $ref: "../../../shared/models/form_factor/input_from_us.yml"
   - type: object
 
     required:
@@ -11,6 +10,16 @@ allOf:
       - amount
 
     properties:
+      from:
+        description: >-
+          Must either be an address ID or an inline object with correct address
+          parameters. Must either be an address ID or an inline object with correct
+          address parameters. All addresses will be standardized into uppercase
+          without being modified by verification.
+        oneOf:
+          - $ref: "../../../shared/attributes/model_ids/adr_id.yml"
+          - $ref: "../../../shared/models/address/inline_address_us.yml"
+
       bank_account:
         allOf:
           - $ref: "../../../shared/attributes/model_ids/bank/bank_id_no_description.yml"

--- a/shared/models/form_factor/input_from.yml
+++ b/shared/models/form_factor/input_from.yml
@@ -3,10 +3,9 @@ type: object
 properties:
   from:
     description: >-
-      Must either be an address ID or an inline object with correct address
-      parameters. Must be a US address unless using a `custom_envelope`. All
-      addresses will be standardized into uppercase without being modified by
-      verification.
+      Must either be an address ID or an inline object with correct address parameters.
+      Must be a US address unless using a `custom_envelope`. All addresses will be
+      standardized into uppercase without being modified by verification.
     oneOf:
       - $ref: "../../attributes/model_ids/adr_id.yml"
       - $ref: "../../models/address/inline_address.yml"

--- a/shared/models/form_factor/input_from_us.yml
+++ b/shared/models/form_factor/input_from_us.yml
@@ -3,9 +3,10 @@ type: object
 properties:
   from:
     description: >-
-      Must either be an address ID or an inline object with correct address
-      parameters. All addresses will be standardized into uppercase without
-      being modified by verification.
+      *Required* if `to` address is international. Must either be an address ID
+      or an inline object with correct address parameters. Must either be an address ID
+      or an inline object with correct address parameters. All addresses will be
+      standardized into uppercase without being modified by verification.
     oneOf:
       - $ref: "../../attributes/model_ids/adr_id.yml"
       - $ref: "../../models/address/inline_address_us.yml"

--- a/tests/postcards_test.js
+++ b/tests/postcards_test.js
@@ -116,7 +116,7 @@ test("list postcards' params", async function (t) {
 });
 
 test.serial.before(
-  "create a postcardd, postcard with full payload, and postcard using remote template",
+  "create a postcard, postcard with full payload, and postcard using remote template",
   async function (t) {
     // NORMAL POSTCARD
     const makeAddress = async (address_data) => {


### PR DESCRIPTION
Specifies that `from` is required if `to` is international (openapi does not allow for marking this required, so I had to write it out in the summary).

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [x] Prettier
  - [x] Spectral Lint
  - [x] Contract Tests
    - [x] Delete all resources created in contract tests
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect