### PR TITLE
fixed template a bit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,9 @@ Fixes #\<INSERT ISSUE NUMBER HERE\>
 
 - [ ] Up to date with `main`
 - [ ] All the tests are passing
-  - [ ] Prettier
-  - [ ] Spectral Lint
-  - [ ] Contract Tests
-    - [ ] Delete all resources created in contract tests
+  - [ ] Delete all resources created in tests
+- [ ] Prettier
+- [ ] Spectral Lint
 - [ ] `npm run bundle` outputs nothing suspect
 - [ ] `npm run postman` outputs nothing suspect
 


### PR DESCRIPTION
The contract test bullet point in the template wasn't quite correct, as we don't manually run contract tests––just running `npm test` should suffice, which is already covered in a previous bullet point.