### PR TITLE
Adds merge_variables field to template-version

### DIFF
--- a/resources/templates/template_versions/models/template_version.yml
+++ b/resources/templates/template_versions/models/template_version.yml
@@ -16,6 +16,11 @@ allOf:
         description: >
           Used by frontend, true if the template uses advanced features.
 
+      merge_variables:
+        type: oject
+        description: >
+          Used by frontend, an object representing the keys of every merge variable present in the template.
+
       engine:
         $ref: "../../../../shared/attributes/engine.yml"
 

--- a/resources/templates/template_versions/models/template_version.yml
+++ b/resources/templates/template_versions/models/template_version.yml
@@ -17,7 +17,7 @@ allOf:
           Used by frontend, true if the template uses advanced features.
 
       merge_variables:
-        type: oject
+        type: object
         description: >
           Used by frontend, an object representing the keys of every merge variable present in the template.
 

--- a/resources/templates/template_versions/models/template_version.yml
+++ b/resources/templates/template_versions/models/template_version.yml
@@ -19,7 +19,7 @@ allOf:
       merge_variables:
         type: object
         description: >
-          Used by frontend, an object representing the keys of every merge variable present in the template.
+          Used by frontend, an object representing the keys of every merge variable present in the template. It has one key named 'keys', and its value is an array of strings.
 
       engine:
         $ref: "../../../../shared/attributes/engine.yml"


### PR DESCRIPTION
Fixes or related to https://github.com/lob/lob-api/pull/7254

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

We are now always returning the merge_variables field in template-version, so this PR adds the field to the docs. Previously it was only returned for admin users, but that is no longer the case.
