### PR TITLE
fix guide links

### DIFF
--- a/cypress/integration/links_test.js
+++ b/cypress/integration/links_test.js
@@ -120,23 +120,38 @@ describe("ensures introduction links and text are valid", () => {
     cy.get('*[class^="sc-hKFxyN dmghQN"]')
       .contains("Postcards")
       .should("have.attr", "href")
-      .and("include", "https://www.lob.com/guides#getting_started");
+      .and(
+        "include",
+        "https://www.lob.com/guides?tab=postcards-self-mailers#getting_started"
+      );
     cy.get('*[class^="sc-hKFxyN dmghQN"]')
       .contains("Self-Mailers")
       .should("have.attr", "href")
-      .and("include", "https://www.lob.com/guides#getting_started_selfmailers");
+      .and(
+        "include",
+        "https://www.lob.com/guides?tab=postcards-self-mailers#getting_started_selfmailers"
+      );
     cy.get('*[class^="sc-hKFxyN dmghQN"]')
       .contains("Letters")
       .should("have.attr", "href")
-      .and("include", "https://www.lob.com/guides#getting_started_letters");
+      .and(
+        "include",
+        "https://www.lob.com/guides?tab=letters#getting_started_letters"
+      );
     cy.get('*[class^="sc-hKFxyN dmghQN"]')
       .contains("Checks")
       .should("have.attr", "href")
-      .and("include", "https://www.lob.com/guides#getting_started_checks");
+      .and(
+        "include",
+        "https://www.lob.com/guides?tab=checks#getting_started_checks"
+      );
     cy.get('*[class^="sc-hKFxyN dmghQN"]')
       .contains("Address Verification Elements")
       .should("have.attr", "href")
-      .and("include", "https://www.lob.com/guides#av-elements-quickstart");
+      .and(
+        "include",
+        "https://www.lob.com/guides?tab=address-verification#av-elements-quickstart"
+      );
   });
 
   // sc-iBzEeX sc-cOifOu dFWqin rUYTT redoc-markdown

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -851,11 +851,11 @@ tags:
 
       ### 3. Learn more
       Review our "Getting Started" guides for more details on use cases:
-      * [Postcards](https://www.lob.com/guides#getting_started)
-      * [Self-Mailers](https://www.lob.com/guides#getting_started_selfmailers)
-      * [Letters](https://www.lob.com/guides#getting_started_letters)
-      * [Checks](https://www.lob.com/guides#getting_started_checks)
-      * [Address Verification Elements](https://www.lob.com/guides#av-elements-quickstart)
+      * [Postcards](https://www.lob.com/guides?tab=postcards-self-mailers#getting_started)
+      * [Self-Mailers](https://www.lob.com/guides?tab=postcards-self-mailers#getting_started_selfmailers)
+      * [Letters](https://www.lob.com/guides?tab=letters#getting_started_letters)
+      * [Checks](https://www.lob.com/guides?tab=checks#getting_started_checks)
+      * [Address Verification Elements](https://www.lob.com/guides?tab=address-verification#av-elements-quickstart)
 
   - name: Intl Verifications
     description: |
@@ -938,7 +938,7 @@ tags:
       product in their [Dashboard Settings](https://dashboard.lob.com/#). Upgrade to
       the appropriate [Print & Mail Edition](https://dashboard.lob.com/#/settings/editions)
       to automatically gain access to this ability. For more details on this feature,
-      check out our [Cancellation Guide](https://lob.com/guides#cancellation_windows).
+      check out our [Cancellation Guide](https://www.lob.com/guides?tab=general#cancellation_windows).
 
       If you schedule a postcard, self mailer, letter, or check for up to 180 days
       in the future by supplying the `send_date` parameter, that will override any
@@ -959,7 +959,7 @@ tags:
       take precedence.
 
       For implementation details, see documentation below for each respective
-      endpoint. For more help, see our [Scheduled Mailings Guide](https://lob.com/guides#scheduled_mailing).
+      endpoint. For more help, see our [Scheduled Mailings Guide](https://www.lob.com/guides?tab=general#scheduled_mailing).
 
       This feature is exclusive to certain customers. Upgrade to the appropriate
       [Print & Mail Edition](https://dashboard.lob.com/#/settings/editions) to
@@ -996,7 +996,7 @@ tags:
 
       **NOTE**: This feature is exclusive to certain customers. Upgrade to the appropriate <a href='https://dashboard.lob.com/#/settings/editions'>Print & Mail Editions</a> to gain access.
 
-      For more information, see our [NCOA guide](https://lob.com/guides#national_change).
+      For more information, see our [NCOA guide](https://www.lob.com/guides?tab=general#national_change).
 
       ## NCOA Live Environment
       Though there are no changes to API requests, there are significant changes to our API responses, but
@@ -1143,7 +1143,7 @@ tags:
       they do not require an additional idempotency key.
 
       For more help integrating idempotency keys, refer to our
-      [implementation guide](https://lob.com/guides#idempotent_request).
+      [implementation guide](https://www.lob.com/guides?tab=general#idempotent_request).
 
       **Headers**
       <table>
@@ -1327,7 +1327,7 @@ tags:
       independently, without having to touch your API integration. Templates can be created, edited,
       and viewed on your [Dashboard](https://dashboard.lob.com/#/templates). To use a template in a postcard,
       letter, or check, see the documentation for each endpoint below. For help using templates, check out our
-      [HTML Templates Guide](https://lob.com/guides#html_templates) or get started with a
+      [HTML Templates Guide](https://www.lob.com/guides?tab=general#html_templates) or get started with a
       [pre-designed template from our gallery](https://lob.com/template-gallery). In Live mode, you can only have
       as many templates as allotted in your current
       [Print & Mail Edition](https://dashboard.lob.com/#/settings/editions). There is no limit in Test mode.
@@ -2265,7 +2265,7 @@ tags:
       There is no limit in Test mode.
       You can view and create [webhooks](https://dashboard.lob.com/#/webhooks) on the
       Lob Dashboard, as well as view your [events](https://dashboard.lob.com/#/events).
-      See our [Webhooks Integration Guide](https://lob.com/guides#webhooks_block) for more
+      See our [Webhooks Integration Guide](https://www.lob.com/guides?tab=general#webhooks_block) for more
       details on how to integrate. Please see the full list of event types available for
       subscription here.
 


### PR DESCRIPTION
Fixes [ticket](https://lobsters.atlassian.net/browse/DXP-763)

## Checklist

- [X] Up to date with `main`
- [X] All the tests are passing
  - [] Delete all resources created in tests
- [X] Prettier
- [X] Spectral Lint
- [X] `npm run bundle` outputs nothing suspect
- [X] `npm run postman` outputs nothing suspect

## Changes
As per [this thread](https://lob.slack.com/archives/C573820BH/p1645045853598919), the broken anchors in the Guides is a known bug. As a fix, they created a "How to create a deeplink URL" guide on Notion which I followed in this PR.

## Areas of Concern
We'll probably need to change these links again when the Guides officially migrate to the Help Center starting next month.
