### PR TITLE
chore: add use cases to getting started

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -343,7 +343,7 @@ tags:
         <tr>
           <td style="white-space: nowrap"><code>422</code></td>
           <td style="white-space: nowrap">FAILED_DELIVERABILITY_STRICTNESS</td>
-          <td style="white-space: nowrap">The to address doesn't meet strictness requirements. 
+          <td style="white-space: nowrap">The to address doesn't meet strictness requirements.
           See <a href="https://dashboard.lob.com/#/settings/account" target="_blank">Account Settings</a> to configure strictness.</td>
         </tr>
         <tr>
@@ -555,7 +555,7 @@ tags:
         <tr>
           <td style="white-space: nowrap"><code>self_mailer.mailed</code></td>
           <td style="white-space: nowrap"><code>true</code></td>
-          <td style="white-space: nowrap">A self_mailer receives a "Mailed" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain 
+          <td style="white-space: nowrap">A self_mailer receives a "Mailed" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain
           <a href="https://dashboard.lob.com/#/settings/editions" target="_blank">Print & Mail Editions</a>.</td>
         </tr>
         <tr>
@@ -616,7 +616,7 @@ tags:
         <tr>
           <td style="white-space: nowrap"><code>letter.mailed</code></td>
           <td style="white-space: nowrap"><code>true</code></td>
-          <td style="white-space: nowrap">A letter receives a "Mailed" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain 
+          <td style="white-space: nowrap">A letter receives a "Mailed" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain
           <a href="https://dashboard.lob.com/#/settings/editions" target="_blank">Print & Mail Editions</a>.</td>
         </tr>
         <tr>
@@ -647,7 +647,7 @@ tags:
         <tr>
           <td style="white-space: nowrap"><code>letter.certified.mailed</code></td>
           <td style="white-space: nowrap"><code>true</code></td>
-          <td style="white-space: nowrap">A certified letter receives a "Mailed" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain 
+          <td style="white-space: nowrap">A certified letter receives a "Mailed" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain
           <a href="https://dashboard.lob.com/#/settings/editions" target="_blank">Print & Mail Editions</a>.</td>
         </tr>
         <tr>
@@ -871,8 +871,10 @@ tags:
       * <a href="https://help.lob.com/en_US/developer-documentation/developer-quickstart-guide" target="_blank">Send your first Postcards</a>
 
       Use Case guides
-      * <a href="https://help.lob.com/use-case-guides/massdeletion" target="_blank">Mass Deletion</a>
+      * <a href="https://help.lob.com/use-case-guides/massdeletion" target="_blank">Mass Deletion Best Practices</a>
       * <a href="https://help.lob.com/en_US/use-case-guides/ncoa-restrictions" target="_blank">NCOALink Restrictions</a>
+      * <a href="https://help.lob.com/use-case-guides/override-cancellation-window" target="_blank">Override Cancellation Window</a>
+      * <a href="https://help.lob.com/en_US/use-case-guides/tracking-address-changes" target="_blank">Tracking Address Changes</a>
       <div class="back-to-top" ><a href="#" onclick="toTopLink()">back to top</a></div>
 
   - name: Intl Autocompletions


### PR DESCRIPTION
Fixes [this](https://lob.slack.com/archives/C02ET5CHPTN/p1655322880986609)

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [x] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes
Added those links to the public spec yaml.

## Areas of Concern (optional)
When I did a fresh `npm install`, it said that the `openapi` command for bundling isn't found.
