### PR TITLE
chore: cmp update is_draft acceptable vals

### DIFF
--- a/resources/campaigns/models/campaign_updatable.yml
+++ b/resources/campaigns/models/campaign_updatable.yml
@@ -21,9 +21,8 @@ properties:
   metadata:
     $ref: "../../../shared/models/metadata.yml"
   is_draft:
-    description: Whether or not the campaign is still a draft.
+    description: Whether or not the campaign is still a draft. Can either be excluded or `false`.
     type: boolean
-    default: true
   use_type:
     $ref: "../attributes/cmp_use_type.yml"
   auto_cancel_if_ncoa:


### PR DESCRIPTION
Fixes [ticket](https://lobsters.atlassian.net/browse/DXP-1376)

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [x] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect

## Changes

Got rid of the `default: true` bit in `is_draft` for Campaign Update.
