### PR TITLE
PMAPI-2194 update crv docs

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -7589,19 +7589,17 @@ components:
         - HTML merge variables should not include delimiting whitespace.
 
         - PDF, PNG, and JPGs must be sized at 4.25"x6.25", 6.25"x9.25", or
-        6.25"x11.25" at 300 DPI, while supplied HTML will be rendered to the
-        specified `size`.
+        6.25"x11.25" at 300 DPI, while supplied HTML template will be rendered
+        to the specified `size`.
 
 
         See [here](#section/HTML-Examples) for HTML examples.
       oneOf:
-        - $ref: '#/components/schemas/html_string'
         - $ref: '#/components/schemas/tmpl_id'
-        - $ref: '#/components/schemas/remote_file_url'
         - $ref: '#/components/schemas/local_file_path'
     back:
       description: >
-        The artwork to use as the back of your postcard.
+        The artwork to use as the back of your postcard creative.
 
 
         Notes:
@@ -7609,8 +7607,8 @@ components:
         - HTML merge variables should not include delimiting whitespace.
 
         - PDF, PNG, and JPGs must be sized at 4.25"x6.25", 6.25"x9.25", or
-        6.25"x11.25" at 300 DPI, while supplied HTML will be rendered to the
-        specified `size`.
+        6.25"x11.25" at 300 DPI, while supplied HTML template will be rendered
+        to the specified `size`.
 
         - Be sure to leave room for address and postage information by following
         the templates provided here:
@@ -7621,9 +7619,7 @@ components:
 
         See [here](#section/HTML-Examples) for HTML examples.
       oneOf:
-        - $ref: '#/components/schemas/html_string'
         - $ref: '#/components/schemas/tmpl_id'
-        - $ref: '#/components/schemas/remote_file_url'
         - $ref: '#/components/schemas/local_file_path'
     writable:
       description: Properties that the postcards in your Creative should have.
@@ -7734,11 +7730,8 @@ components:
         See <a href="https://lob.com/pricing/print-mail#compare"
         target="_blank">pricing</a> for extra costs incurred.
       oneOf:
-        - $ref: '#/components/schemas/html_string'
         - $ref: '#/components/schemas/tmpl_id'
-        - $ref: '#/components/schemas/remote_file_url'
-        - type: string
-          pattern: ^(?!https://)[a-zA-Z0-9@:%._+~#=/]{1,256}.(html?|pdf)$
+        - $ref: '#/components/schemas/local_file_path'
     creative_writable:
       oneOf:
         - allOf:
@@ -8676,6 +8669,45 @@ components:
           $ref: '#/components/schemas/merge_variables'
         send_date:
           $ref: '#/components/schemas/send_date'
+    file-2:
+      description: >-
+        Notes:
+
+        - HTML merge variables should not include delimiting whitespace.
+
+        - All pages of a supplied PDF file must be sized at 8.5"x11", while
+        supplied HTML will be rendered and trimmed to as many 8.5"x11" pages as
+        necessary.
+
+        - For design specifications, please see our <a
+        href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_template.pdf"
+        target="_blank">PDF</a> and [HTML](#section/HTML-Examples) templates.
+
+        - If a `custom_envelope` is used, follow <a
+        href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_custom_envelope.pdf"
+        target="_blank">this template</a>.
+
+        - For domestic destinations, the file limit is 60 pages single-sided or
+        120 pages double-sided. For international destinations, the file limit
+        is 6 pages single-sided or 12 pages double-sided. PDFs that surpass the
+        file limit will error, while HTML that renders more pages than the file
+        limit will be trimmed.
+
+        - Any letters over 6 pages single-sided or 12 pages double-sided will be
+        placed in a <a
+        href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_flat_template.pdf"
+        target="_blank">flat envelope</a> instead of the standard double window
+        envelope.
+
+
+        See <a href="https://lob.com/pricing/print-mail#compare"
+        target="_blank">pricing</a> for extra costs incurred.
+      oneOf:
+        - $ref: '#/components/schemas/html_string'
+        - $ref: '#/components/schemas/tmpl_id'
+        - $ref: '#/components/schemas/remote_file_url'
+        - type: string
+          pattern: ^(?!https://)[a-zA-Z0-9@:%._+~#=/]{1,256}.(html?|pdf)$
     return_envelope_user_provided:
       oneOf:
         - type: boolean
@@ -8727,8 +8759,8 @@ components:
         width:
           type: string
           description: >-
-            The size(in inches) of the QR code. All QR codes are generated as a
-            square.
+            The size(in inches) of the QR code with a minimum of .25 inches. All
+            QR codes are generated as a square.
         pages:
           type: string
           description: >-
@@ -8749,7 +8781,7 @@ components:
             - color
           properties:
             file:
-              $ref: '#/components/schemas/file'
+              $ref: '#/components/schemas/file-2'
             extra_service:
               $ref: '#/components/schemas/extra_service'
             cards:
@@ -8894,6 +8926,52 @@ components:
           oneOf:
             - $ref: '#/components/schemas/adr_id'
             - $ref: '#/components/schemas/inline_address_us'
+    front-2:
+      description: >
+        The artwork to use as the front of your postcard.
+
+
+        Notes:
+
+        - HTML merge variables should not include delimiting whitespace.
+
+        - PDF, PNG, and JPGs must be sized at 4.25"x6.25", 6.25"x9.25", or
+        6.25"x11.25" at 300 DPI, while supplied HTML will be rendered to the
+        specified `size`.
+
+
+        See [here](#section/HTML-Examples) for HTML examples.
+      oneOf:
+        - $ref: '#/components/schemas/html_string'
+        - $ref: '#/components/schemas/tmpl_id'
+        - $ref: '#/components/schemas/remote_file_url'
+        - $ref: '#/components/schemas/local_file_path'
+    back-2:
+      description: >
+        The artwork to use as the back of your postcard.
+
+
+        Notes:
+
+        - HTML merge variables should not include delimiting whitespace.
+
+        - PDF, PNG, and JPGs must be sized at 4.25"x6.25", 6.25"x9.25", or
+        6.25"x11.25" at 300 DPI, while supplied HTML will be rendered to the
+        specified `size`.
+
+        - Be sure to leave room for address and postage information by following
+        the templates provided here:
+          - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/postcards/4x6_postcard.pdf" target="_blank">4x6 template</a>
+          - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/postcards/6x9_postcard.pdf" target="_blank">6x9 template</a>
+          - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/postcards/6x11_postcard.pdf" target="_blank">6x11 template</a>
+
+
+        See [here](#section/HTML-Examples) for HTML examples.
+      oneOf:
+        - $ref: '#/components/schemas/html_string'
+        - $ref: '#/components/schemas/tmpl_id'
+        - $ref: '#/components/schemas/remote_file_url'
+        - $ref: '#/components/schemas/local_file_path'
     postcard_editable:
       allOf:
         - $ref: '#/components/schemas/postcard_base'
@@ -8906,9 +8984,9 @@ components:
             - back
           properties:
             front:
-              $ref: '#/components/schemas/front'
+              $ref: '#/components/schemas/front-2'
             back:
-              $ref: '#/components/schemas/back'
+              $ref: '#/components/schemas/back-2'
             billing_group_id:
               $ref: '#/components/schemas/billing_group_id'
             qr_code:

--- a/dist/lob-api-postman.json
+++ b/dist/lob-api-postman.json
@@ -1,7 +1,7 @@
 {
     "item": [
         {
-            "id": "0ef02378-c4e2-4452-93d4-ba5b6185b342",
+            "id": "aff5f34a-a6f3-437e-9be1-1e6438f8efb0",
             "name": "Addresses",
             "description": {
                 "content": "To add an address to your address book, you create a new address object. You can retrieve and delete individual\naddresses as well as get a list of addresses. Addresses are identified by a unique random ID.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -9,7 +9,7 @@
             },
             "item": [
                 {
-                    "id": "15dd95f8-ea3e-4509-9709-61b03c214344",
+                    "id": "244369b3-0a84-4718-b915-f5126615c8a8",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -57,7 +57,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -75,7 +81,7 @@
                     },
                     "response": [
                         {
-                            "id": "18e24003-dac8-4602-8eca-0ea80ddcbc2a",
+                            "id": "0c969059-8a93-42d1-b3eb-1290f24dfe4c",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -107,7 +113,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -139,7 +145,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "48202b01-2e9a-4a20-a028-ae7a131e6d13",
+                            "id": "9e311b6e-ce2e-4d3a-a1d5-21b1c6d4b640",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -171,7 +177,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -206,7 +212,7 @@
                     "event": []
                 },
                 {
-                    "id": "0df7890c-5a87-4239-a9e1-15e85721fcdb",
+                    "id": "50c80c85-f89a-4f98-91f5-46c5b9302434",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -269,7 +275,7 @@
                     },
                     "response": [
                         {
-                            "id": "2333082f-9faf-4377-8836-42d6df23dcc4",
+                            "id": "f3259252-5132-48f9-8632-530507c6351a",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -385,7 +391,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d28c56d8-ef38-4458-afc9-04ddf4419930",
+                            "id": "b55ed74f-a2c3-419a-9983-27e6df745b8e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -489,7 +495,7 @@
                     }
                 },
                 {
-                    "id": "5bba6b58-d457-4a89-b15d-0ba9f14c7d6f",
+                    "id": "3255b3bf-b9aa-4eb2-9c8d-7bd48367b1b0",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -527,7 +533,7 @@
                     },
                     "response": [
                         {
-                            "id": "f9c95a3d-acc7-4d0c-886e-671e296b1387",
+                            "id": "dc442e30-33f4-4967-89cc-b6a5a0f4ef6a",
                             "name": "Returns an address object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -575,7 +581,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8afe0ccb-64d7-47e3-96df-8153af314601",
+                            "id": "92dd5c46-08a2-4766-9537-f6650cd10852",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -626,7 +632,7 @@
                     "event": []
                 },
                 {
-                    "id": "99624f1a-25fd-42e6-8c1f-7325b3d62ad6",
+                    "id": "49f6d335-7227-473b-bb4b-70b5d7efe855",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -664,7 +670,7 @@
                     },
                     "response": [
                         {
-                            "id": "26b34fca-cdda-4cc3-9453-77477d1b4fd8",
+                            "id": "63ac4ee0-560e-4abf-a6f7-83785c8874a3",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -712,7 +718,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "33f84867-39cb-4808-aba9-b19b9270edde",
+                            "id": "8db88cfd-1400-4285-915e-98e8b7d7b21c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -766,7 +772,7 @@
             "event": []
         },
         {
-            "id": "2d1368f5-d7fa-46e8-87bd-f0e3200c9dfe",
+            "id": "9566b7a3-18ff-466e-aa74-2a78e5d72b31",
             "name": "Authentication",
             "description": {
                 "content": "Requests made to the API are protected with <a href=\"https://en.wikipedia.org/wiki/Basic_access_authentication\" target=\"_blank\">HTTP Basic authentication</a>.\nIn order to properly authenticate with the API you must use your API key as the username\nwhile leaving the password blank. Requests not properly authenticated will return a `401`\n[error code](#tag/Errors). You can find your account's API keys\nin your <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Dashboard Settings</a>.\n### Example Request\ncurl uses the -u flag to pass basic auth credentials (adding a colon after your API key will prevent it from asking you for a\npassword). One of our test API keys has been filled into all the examples on the page, so you can test out any example right away.\n```bash\ncurl https://api.lob.com/v1/addresses \\\n  -u test_0dc8dXXXXXXXXXXXXXXXXXXXXXX5b0cc:\n```\n## API Keys\n  Lob authenticates your API requests using your account's API keys.\n  If you do not include your key when making an API request, or use\n  one that is incorrect or outdated, Lob returns an error with a `401`\n  HTTP response code. You can find all API keys in your dashboard\n  under <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Settings</a>.\n  There are two types of API keys: *secret* and *publishable*.\n  - **Secret API keys** should be kept confidential and only stored on your own servers.\n  Your account's secret API key can perform any API request to Lob without restriction.\n  - **Publishable API keys** are limited to US verifications, international verifications,\n  and US autocomplete requests. While we encourage you to use a secret key for maximum\n  security, you can publish these keys to JavaScript code or in an Android or iPhone app\n  without exposing print and mail services or your secret key. Publishable keys are always\n  prefixed with `[environment]_pub`.\n  Every type comes with a pair of keys: one for the testing environment and one for the\n  live environment. We recommend reading [Test and Live Environments](#tag/Test-and-Live-Environments)\n  for more information.\n  <br><br>\n  <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -776,7 +782,7 @@
             "event": []
         },
         {
-            "id": "40c141bb-55f6-4dec-a1dd-bff35d94fced",
+            "id": "334433f1-2bed-456d-ae10-3a02bb579c42",
             "name": "Bank Accounts",
             "description": {
                 "content": "Bank Accounts allow you to store your bank account securely in our system. The API provides\nendpoints for creating bank accounts, deleting bank accounts, verifying bank accounts,\nretrieving individual bank accounts, and retrieving a list of bank accounts.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -784,7 +790,7 @@
             },
             "item": [
                 {
-                    "id": "3fdd234f-9c23-4fc1-84a4-586d6c27f67e",
+                    "id": "ee17a41a-0df6-49f9-a2ab-928aa82c72ca",
                     "name": "Verify",
                     "request": {
                         "name": "Verify",
@@ -844,7 +850,7 @@
                     },
                     "response": [
                         {
-                            "id": "76555af5-0df9-416e-89d7-4b068c0b594e",
+                            "id": "fe0faeab-6c0c-460a-9e41-9b100c6fd351",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -933,7 +939,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f7fc9f07-5dde-4256-a056-1d936794d42f",
+                            "id": "6ca6b43b-01fe-4306-876a-a10a35797bee",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1010,7 +1016,7 @@
                     }
                 },
                 {
-                    "id": "ef0af055-6e4b-4104-a283-77c31d1473b4",
+                    "id": "d7272667-3678-45c5-9fda-838d56a2d522",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -1048,7 +1054,7 @@
                     },
                     "response": [
                         {
-                            "id": "e1472744-efc2-4c67-8959-9bac68a72e6c",
+                            "id": "4d494e5f-3608-4c08-82b0-fbe3a76f9db9",
                             "name": "Returns a bank account object",
                             "originalRequest": {
                                 "url": {
@@ -1096,7 +1102,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7684d915-2254-41a9-8652-af3698c819b3",
+                            "id": "458dfdcd-61ec-4034-a719-ca5ddaa6f752",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1147,7 +1153,7 @@
                     "event": []
                 },
                 {
-                    "id": "b2e77864-c873-499f-a2a0-e411d1264352",
+                    "id": "863a2b08-bc3d-47c6-90e4-2dc12a673418",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -1185,7 +1191,7 @@
                     },
                     "response": [
                         {
-                            "id": "dc11a5a5-0d47-4667-811d-0536ef83f520",
+                            "id": "5d8925d1-873f-4a22-8dc2-c246ae6fc12c",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -1233,7 +1239,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0f0069c7-59e5-442f-a76f-e91413722b86",
+                            "id": "daa570cf-bacc-4a22-8e36-803387015400",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1284,7 +1290,7 @@
                     "event": []
                 },
                 {
-                    "id": "3f3c0a71-7ac2-404f-9a71-9c6d718329b0",
+                    "id": "70800418-c199-4640-924f-57aeaf697628",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -1332,7 +1338,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -1350,7 +1362,7 @@
                     },
                     "response": [
                         {
-                            "id": "859ff234-d4e7-4243-aec0-0eee22477860",
+                            "id": "58eaba37-03e6-4c69-a4fc-e1c73385b9d6",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -1382,7 +1394,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -1414,7 +1426,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "aae3bd65-21db-43cc-8f0e-9ec08f47d70d",
+                            "id": "506b38ad-97db-4777-98ad-af3273a00c17",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1446,7 +1458,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -1481,7 +1493,7 @@
                     "event": []
                 },
                 {
-                    "id": "85f027d9-cdac-48f1-9577-b0f2c5aaa0d7",
+                    "id": "90c0e8d6-419b-4cf9-ac67-efbb1875c5c6",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -1548,7 +1560,7 @@
                     },
                     "response": [
                         {
-                            "id": "a46cbf36-a271-4f97-98df-47e7727f36ce",
+                            "id": "82474cd3-449a-42ac-88d8-3b903b5ae187",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1655,7 +1667,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fad5df48-dcd8-4d7f-8bd5-e82bd8f8ab32",
+                            "id": "6d142ed5-8c54-4dd3-a83f-e8ff32dafb6c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1753,7 +1765,7 @@
             "event": []
         },
         {
-            "id": "109c9fdc-4c26-4f37-a09f-8cfda208599a",
+            "id": "1120526d-d86f-4c3e-ab27-3a186f3d7090",
             "name": "Beta Program",
             "description": {
                 "content": "At Lob, we pride ourselves on building high quality platform capabilities rapidly\nand iteratively, so we can constantly be delivering additional value to our customers.\nWhen evaluating a new product or feature from Lob, you may see that it has been released in Beta.\n\nTypically, something in Beta means that the feature is early in its lifecycle here at\nLob. While we fully stand behind the quality of everything we release in Beta, we do\nanticipate receiving a higher level of customer feedback on Beta features, as well as a\nfaster pace of changes from our engineering team in response to that feedback.\n\nBy participating in a Lob Beta program, you will have the opportunity to get early access\nto a new product capability, as well as having a unique opportunity to influence the product's\ndirection with your feedback.\n\nYou should also anticipate that features in Beta may have functional or design limitations,\nand might change rapidly as we receive customer feedback and make improvements. In particular,\nnew APIs in Beta may also go through more frequent versioning and version deprecation cycles\nthan our more mature APIs.\n\nIf you are participating in a Beta program and want to provide feedback, please feel free to\n<a href=\"https://lob.com/support#contact\" target=\"_blank\">contact us</a>!\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -1763,7 +1775,7 @@
             "event": []
         },
         {
-            "id": "c555a485-ad6c-459a-b62b-f6537913b69c",
+            "id": "2512c52f-e1a4-42a7-89f6-43fe10561611",
             "name": "Billing Groups",
             "description": {
                 "content": "The Billing Groups API allows you to create and view labels that can be attached to certain consumption-based\nusages of Letters, Checks, Postcards and Self-Mailers to customize your bill. Please check each\nresource API section to learn more about how to access the Billing Groups API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -1771,7 +1783,7 @@
             },
             "item": [
                 {
-                    "id": "a3efd255-3c3f-4a88-af4b-de95941efb81",
+                    "id": "9b2344d4-e199-4796-aa0f-e6a339aa1571",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -1809,7 +1821,7 @@
                     },
                     "response": [
                         {
-                            "id": "14a00b4d-6d15-4b92-bccf-45ccc546e956",
+                            "id": "ec23139d-4511-4dcc-98b2-4e82c97df5b1",
                             "name": "Returns a billing_group object.",
                             "originalRequest": {
                                 "url": {
@@ -1857,7 +1869,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3f25ab3f-9d0f-4f7a-bcd5-f9e46c18e4e3",
+                            "id": "52a74d40-15e9-45eb-ab7c-27ed498dca95",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1908,7 +1920,7 @@
                     "event": []
                 },
                 {
-                    "id": "360ed08e-5d30-41f7-a1b9-d2ba9e2433e7",
+                    "id": "dfd5c255-5cfb-407f-af29-78cd70ba89aa",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -1965,7 +1977,7 @@
                     },
                     "response": [
                         {
-                            "id": "e38d3a98-eb7f-415b-8b81-5e85d4275fcf",
+                            "id": "0ec4b249-e6fe-41b9-90dd-d80fe7a288f5",
                             "name": "Returns a billing group object",
                             "originalRequest": {
                                 "url": {
@@ -2045,7 +2057,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2cc5f703-42b7-4e7a-b4dc-77fbfe593908",
+                            "id": "d6e2aea9-b2d7-4caa-ba1d-3bd955e54400",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2113,7 +2125,7 @@
                     }
                 },
                 {
-                    "id": "de58ab95-ac4f-43a4-b317-ad316d432f5b",
+                    "id": "d7b1047b-9f1d-44fa-bebe-e5c21598f24f",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -2155,13 +2167,25 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_modified[id812]",
+                                    "key": "date_created[laboruma]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_modified[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_modified[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -2191,7 +2215,7 @@
                     },
                     "response": [
                         {
-                            "id": "6954a075-1251-4ef3-9445-0bbdfef9f176",
+                            "id": "ed14182b-f846-4e08-a733-f906207202fd",
                             "name": "Returns a list of billing_groups.",
                             "originalRequest": {
                                 "url": {
@@ -2219,11 +2243,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_modified[id7c8]",
+                                            "key": "date_modified[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -2263,7 +2287,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9f753863-4c25-4e18-bf58-7ae409a7273c",
+                            "id": "6ebff44d-294f-4d06-885f-b3422b8f407e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2291,11 +2315,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_modified[id7c8]",
+                                            "key": "date_modified[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -2338,7 +2362,7 @@
                     "event": []
                 },
                 {
-                    "id": "41642a98-1e4a-47af-b654-9552a973a0a5",
+                    "id": "a31c833b-5b02-4851-ac13-fe66841d5ea9",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -2386,7 +2410,7 @@
                     },
                     "response": [
                         {
-                            "id": "c1984ea5-5d65-4dd2-92b0-50fe3c5d0ebb",
+                            "id": "217b6507-e9ba-4428-88aa-a1e219974187",
                             "name": "Returns a billing group object",
                             "originalRequest": {
                                 "url": {
@@ -2457,7 +2481,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "67a586fb-a02f-4f72-8d68-dadd60dcc4e6",
+                            "id": "014584c4-2e8f-42b6-9005-2462b20624ca",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2519,7 +2543,7 @@
             "event": []
         },
         {
-            "id": "5dbb8369-8453-48f5-935e-e35a386227f8",
+            "id": "8dec926d-5d85-4683-a6a3-0030b7af7257",
             "name": "Buckslip Orders",
             "description": {
                 "content": "The Buckslip Orders endpoint allows you to easily create buckslip orders for existing buckslips.\nThe API provides endpoints for creating buckslip orders and listing buckslip orders for a given buckslip.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -2527,7 +2551,7 @@
             },
             "item": [
                 {
-                    "id": "5c4c6ed2-1a30-4b9b-bb03-0808a061e07b",
+                    "id": "0f7d7169-2af2-4373-99b6-6d08b3bfb395",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -2579,7 +2603,7 @@
                     },
                     "response": [
                         {
-                            "id": "762c1b69-a418-41d7-9d7e-2158215d9fa0",
+                            "id": "1090871c-81cb-4256-87cc-865622e6d986",
                             "name": "Returns the buckslip orders associated with the given buckslip id",
                             "originalRequest": {
                                 "url": {
@@ -2637,7 +2661,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "be128df2-f4b8-4b6d-a74d-030b09ff7712",
+                            "id": "40e0dd94-a006-4128-bedd-3452219145b7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2698,7 +2722,7 @@
                     "event": []
                 },
                 {
-                    "id": "ab5fbbb0-649a-4f2e-9e9f-91b31f9da2aa",
+                    "id": "09fd34dd-fde4-4bd6-bd8e-0e9ee81ae62b",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -2752,7 +2776,7 @@
                     },
                     "response": [
                         {
-                            "id": "11248745-ed91-47a9-91a0-136327a4aa1c",
+                            "id": "423e9446-d320-4149-8423-4e706734aa1b",
                             "name": "Buckslip order created successfully",
                             "originalRequest": {
                                 "url": {
@@ -2814,7 +2838,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b61838b7-8cf7-4c0d-9671-9b8d37cc58cb",
+                            "id": "49f968c5-d892-4192-80fd-cefceb518605",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2885,7 +2909,7 @@
             "event": []
         },
         {
-            "id": "1369884f-c826-460b-bf12-4fb146dc7c20",
+            "id": "6c7f0160-ddbb-4387-9b4f-e0378e93351c",
             "name": "Buckslips",
             "description": {
                 "content": "The Buckslips endpoint allows you to easily create buckslips that can later be used as add-ons for Letters Campaigns. Note that a Letter Campaign with Buckslip add-on requires a minimum send quantity of 5,000 letters.\nThe API provides endpoints for creating buckslips, retrieving individual buckslips, creating buckslip orders, and retrieving a list of buckslips.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -2893,7 +2917,7 @@
             },
             "item": [
                 {
-                    "id": "95bed6bc-4ddb-4c48-b240-0c12a74bd84d",
+                    "id": "9fc831a9-50e7-4d7e-9a1b-2ecb152f600b",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -2953,7 +2977,7 @@
                     },
                     "response": [
                         {
-                            "id": "f1555386-03f9-4942-ab15-1f28d72ea86f",
+                            "id": "20fd60e7-fed3-49ab-bc5c-da7cf3de1f64",
                             "name": "Returns a list of buckslip objects",
                             "originalRequest": {
                                 "url": {
@@ -3013,7 +3037,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e0b86167-eb26-4f6c-9181-8cabb55b0bde",
+                            "id": "bae98f08-c903-4d07-b2f2-f3a3e5c16abe",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3076,7 +3100,7 @@
                     "event": []
                 },
                 {
-                    "id": "7fb6866c-d54b-45b0-9743-e1898830d49a",
+                    "id": "37099163-dc28-4251-bc7f-ab9bf78f0b2a",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -3134,7 +3158,7 @@
                     },
                     "response": [
                         {
-                            "id": "5ce3da96-a7b7-4f47-b1bd-d786807d3224",
+                            "id": "bf8fb895-406e-4201-b1f7-ca09f08a565a",
                             "name": "Buckslip created successfully",
                             "originalRequest": {
                                 "url": {
@@ -3192,7 +3216,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7c719787-85ae-430f-ae1a-2d2ba8dd6cd3",
+                            "id": "2f42fc2c-a884-4402-b8af-250189e56e77",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3256,7 +3280,7 @@
                     }
                 },
                 {
-                    "id": "446a5d82-38e7-497f-a6f0-783963e882f2",
+                    "id": "c9488e8c-27cd-4426-a43e-122c909efe98",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -3294,7 +3318,7 @@
                     },
                     "response": [
                         {
-                            "id": "a4ee3b18-4244-4a84-ab86-f5e5fbdf7d2e",
+                            "id": "f185ea18-86e6-4977-83f8-55a05d5d8ad4",
                             "name": "Returns a buckslip object",
                             "originalRequest": {
                                 "url": {
@@ -3342,7 +3366,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5c048269-cb45-420a-b880-c7322f1b04c9",
+                            "id": "99792764-85fb-4350-87b9-4ee58c8060d6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3393,7 +3417,7 @@
                     "event": []
                 },
                 {
-                    "id": "244182ea-99ae-47e6-80af-6c6df9450143",
+                    "id": "abc04498-96fe-4be5-be72-99ebf3d3c81b",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -3457,7 +3481,7 @@
                     },
                     "response": [
                         {
-                            "id": "5c7df0e6-e469-4f30-82c5-111f47865272",
+                            "id": "28c916cf-e42e-4d47-bf7a-72f42f213359",
                             "name": "Returns a buckslip object",
                             "originalRequest": {
                                 "url": {
@@ -3523,7 +3547,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "86e339fb-dc9d-4fda-a29f-4d4eb5ffe51d",
+                            "id": "421d3795-e37d-4178-9bc1-c8ed7cc9884f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3595,7 +3619,7 @@
                     }
                 },
                 {
-                    "id": "8958abf6-bfcc-48ce-bd74-6a750bdc86c7",
+                    "id": "e1ccbdef-ede5-414e-8847-d38370ae25b4",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -3633,7 +3657,7 @@
                     },
                     "response": [
                         {
-                            "id": "2d03ea27-2dc3-49d6-9aff-03e055ae9a73",
+                            "id": "63a8390a-25e1-4403-908b-136e9e4c8478",
                             "name": "Deleted the buckslip",
                             "originalRequest": {
                                 "url": {
@@ -3681,7 +3705,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "44f6b655-01b7-489d-9f45-a8ef178526b5",
+                            "id": "864a7614-40d9-458f-80a5-19d67929c86d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3735,7 +3759,7 @@
             "event": []
         },
         {
-            "id": "88ca1c15-e730-4ccc-b23b-220312e001df",
+            "id": "9ff31d9f-b3e2-40f1-b826-2e9a283b14a9",
             "name": "Bulk Intl Verifications",
             "description": {
                 "content": "Verify a list of non-US addresses.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -3745,7 +3769,7 @@
             "event": []
         },
         {
-            "id": "1ab205a6-e340-455f-8f92-09351a0e053c",
+            "id": "1016568d-2068-4fb2-ae7f-e575d0750706",
             "name": "Bulk US Verifications",
             "description": {
                 "content": "Verify a list of US addresses.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -3755,7 +3779,7 @@
             "event": []
         },
         {
-            "id": "2e4cb165-d581-4d8c-8426-9f2464b9b904",
+            "id": "e47e21f7-ee93-4a0f-b9d4-25248190ec4a",
             "name": "Campaigns",
             "description": {
                 "content": "The campaigns endpoint allows you to create and view campaigns that can be used to send multiple letters or postcards.\nThe API provides endpoints for creating campaigns, updating campaigns, retrieving individual campaigns, listing campaigns, and deleting\ncampaigns.\n",
@@ -3763,7 +3787,7 @@
             },
             "item": [
                 {
-                    "id": "6c882092-7342-4f75-8576-b6caf86a0f3a",
+                    "id": "679cf537-2ef9-4bce-abf5-181e884d26fb",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -3823,7 +3847,7 @@
                     },
                     "response": [
                         {
-                            "id": "6928c7a8-d9d7-4412-8065-a5f050cafce3",
+                            "id": "c6149734-ca96-41c5-b82a-d7c9e90a3f24",
                             "name": "A dictionary with a data property that contains an array of up to `limit` campaigns. Each entry in the array is a separate campaign. The previous and next page of campaigns can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more campaigns are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3886,7 +3910,7 @@
                     "event": []
                 },
                 {
-                    "id": "1f59a4dc-8aa9-4ba0-82bd-24e1937007b2",
+                    "id": "5313beef-0ef9-443a-80d0-421cdec7e0ca",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -3969,7 +3993,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "P1zj'Rzp'%k~8@BsToP#Y$|0v3 IjYPH?u(NrLsL mPxGPi.awT}%SurY.3ZO`E1'dJkq^b#{V?]9a''0pp5G5|nGm&%SSg-G:I~uOOam'l2xh%{-7CjZ7B-&]zCXVTi{+$lSpfJTT[}O.Auxdnp of11XGvsC9=ww8kz+L_1:"
+                                    "value": "u!<S<84l+b<=u3E%VEn7`a]DLk?)]12+-Rm+j'%g~$V_YMh)v(>H/utFk($O%(775DIa Mo.lTc'WD~J|vB04u-zpk1Kr:+4BHM!{S@VZ<T{.3U,N}s{~!95g3F6'ZE KJ8F.F3X&^TA?~gn`4.gIH`bCP+nL<9@IxkfZ`iy%@;nfOLt_nwkv@I7)d'l+*:pYag6X6pfx4;H3vTo?_#7W$7)})u0xc*<{y;{PS=xqCu^te@d)s1SRyw.%Wm@XcC<G;-|fqA*=#7*9I3/hh&@8@/PVsAhjK^U~YMWTU[)@[,|;<C})|qxh(Gvgfi.bAn=|F2003cJ05_bSyee]-{TB @!KW[W<Qsr;KUNQ>_D^F~1}ou+2pL^7^mT_WC&$ Y;$*M'Hb8zl;]W/T!S0(e_sXD~KPnKbGxH>|`NYone@8vhv`7(Vx}/0[m:st#<F4xP^tqVGELwD`Z@tc|!wX6+D{a&nZ1+R@T0FW~<Okk'*/>r`GN"
                                 },
                                 {
                                     "disabled": false,
@@ -3987,7 +4011,7 @@
                     },
                     "response": [
                         {
-                            "id": "3a0261b6-ffb3-44ce-9f20-4ca72d7994fb",
+                            "id": "87c57642-8a00-4af9-bbf1-cb132e35d5c8",
                             "name": "Campaign created successfully",
                             "originalRequest": {
                                 "url": {
@@ -4059,7 +4083,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e6c31a8a-9be5-4a32-90b8-3e14022b9031",
+                            "id": "952cb17b-0aab-4fd9-90d0-2c58c91f0513",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4137,7 +4161,7 @@
                     }
                 },
                 {
-                    "id": "60712922-34f5-418e-9ac3-10d1680badc3",
+                    "id": "3a90cf00-5223-4b41-a679-f1761e30d4eb",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -4175,7 +4199,7 @@
                     },
                     "response": [
                         {
-                            "id": "fa63b469-03d1-4e97-b082-249468a7bde9",
+                            "id": "62dad811-b38d-40e7-a191-49404b78d60c",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4223,7 +4247,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9c25a427-11f4-41c1-aaa0-9b6f1743ebb5",
+                            "id": "6768994e-5c4f-4033-b63c-032e2cb5f2c8",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4274,7 +4298,7 @@
                     "event": []
                 },
                 {
-                    "id": "b5ea75f9-0bc6-4cb8-8192-c45c71cb870f",
+                    "id": "4611b5fc-1aa8-488b-b6e0-b1345554dbad",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -4352,7 +4376,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "d:&zyr7A?Yf)I8S_(>X6(y$hmNy:MCduN/#4',h,<,x,RCn~!A8H0^US_xIYQ}5%#4HMJ{+Id2]b,2[U=@iqlQ72`Mc@nbe^a}pX:)Z`v6}Qo_@<F^@cPo4so%Wdjn<%e}cc@Z6f@!'0s_<(2`A~V_VssF3K0M*[:!`$f!,4z:ERqF&B/Bqy17fY,FS+l,^%I|kZ~aXOs6%aAOh;9GJ=2l^QWYswpB}IhtC?=#:S/5Q'FWr+gz)eiOFr_y2L0OPLhz++EWS=ky7Djt(5h'A"
+                                    "value": "Z^Zm 4b:1pxX+oKV,^xljO$A~T5swC$otkKw:j}|CSU:ifqu(iMk1b>]Vr>tXc]aL'q;*UPEExaYdM+*S$@U*Fs10pu|)`'yQ]'5.'xp&'e@[N^i1ZU_e#kF@E}cz-%~K$4q+3>Cc@i3LiX)--c@rBLXa]YS7$R.W1F7cL|!Ec>NnK?gxv`f HG7?hl'6rYVu<6OpV5&1LYnxv#8e:/,d$c&o%"
                                 },
                                 {
                                     "disabled": false,
@@ -4376,7 +4400,7 @@
                     },
                     "response": [
                         {
-                            "id": "29c56774-4217-442a-af68-ae063091b208",
+                            "id": "6baf7c91-8b2c-423c-a161-ecf42b0a537b",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4433,7 +4457,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0fb43a6a-c831-4e29-bbd4-7ab5449c4c0a",
+                            "id": "3a289dcc-08cc-4950-b999-2e4ede0545bb",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4496,7 +4520,7 @@
                     }
                 },
                 {
-                    "id": "d766d740-bbcb-423a-9255-835bc8875165",
+                    "id": "e9919e8e-6979-4808-aaed-4a0d184770d5",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -4534,7 +4558,7 @@
                     },
                     "response": [
                         {
-                            "id": "3f28ce0d-1ad7-4e3d-9bd7-44f882920c00",
+                            "id": "a04bcda0-96aa-4654-9f78-7a22e98755ce",
                             "name": "Deleted the campaign.",
                             "originalRequest": {
                                 "url": {
@@ -4582,7 +4606,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1bfde10d-dd32-4bf8-9f6b-09a8e198ec5e",
+                            "id": "68d4720c-ebb3-4a49-afb0-a2afee0cef30",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4633,7 +4657,7 @@
                     "event": []
                 },
                 {
-                    "id": "33c9ad2f-0bda-4c1e-9070-a5671bd661bf",
+                    "id": "60d190ca-5134-4e06-b67c-498c04460dfc",
                     "name": "Send Campaign",
                     "request": {
                         "name": "Send Campaign",
@@ -4672,7 +4696,7 @@
                     },
                     "response": [
                         {
-                            "id": "d034d4fb-9d9f-48c2-b296-77217c42a479",
+                            "id": "249f2746-4210-46b8-a936-2c6aa1c1a13b",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4721,7 +4745,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d8cebcdc-ce0c-4cbb-a60c-8394e023164e",
+                            "id": "432da5a0-01a7-4091-90b2-90fb73d53cf0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4776,7 +4800,7 @@
             "event": []
         },
         {
-            "id": "7d533cf3-2b03-4615-a1cd-a38a1974ed32",
+            "id": "089aac23-4356-4a44-9242-d02d8b19d9a2",
             "name": "Card Orders",
             "description": {
                 "content": "The card orders endpoint allows you to easily create card orders for existing cards.\nThe API provides endpoints for creating card orders and listing card orders for a given card.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -4784,7 +4808,7 @@
             },
             "item": [
                 {
-                    "id": "6fe53d9c-9b72-4300-85f6-bfdb5428ea64",
+                    "id": "b55991e1-6687-42f1-bc54-74a78064c4c9",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -4836,7 +4860,7 @@
                     },
                     "response": [
                         {
-                            "id": "b91c97b3-78f5-4e94-abc9-9875055e3c2f",
+                            "id": "4490af89-41cb-48eb-979c-193a10110dce",
                             "name": "Returns the card orders associated with the given card id",
                             "originalRequest": {
                                 "url": {
@@ -4894,7 +4918,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "96c27beb-3141-4b27-954a-194562d78c16",
+                            "id": "935b0e7e-ca54-41de-a52c-6bc0e22c7938",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4955,7 +4979,7 @@
                     "event": []
                 },
                 {
-                    "id": "f50f26d1-4259-4f5f-8270-6768c378811b",
+                    "id": "4645e328-0905-48ca-a2e8-37419b0459d9",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -5009,7 +5033,7 @@
                     },
                     "response": [
                         {
-                            "id": "f490ecb4-9412-4fe9-bb43-a59aa185f2bc",
+                            "id": "fd6f7e41-0573-4462-9c18-cd22bbaf2bcc",
                             "name": "Card order created successfully",
                             "originalRequest": {
                                 "url": {
@@ -5071,7 +5095,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4c7d6cfd-3529-4315-9287-0e84e8b323b5",
+                            "id": "61c56dbc-4756-43e4-b0dc-83c969fdfeb9",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5142,7 +5166,7 @@
             "event": []
         },
         {
-            "id": "e26a1b97-3f7d-4f19-8bfb-cfbe0201b831",
+            "id": "73e113c8-6343-4386-8c48-d3a7780de9aa",
             "name": "Cards",
             "description": {
                 "content": "The cards endpoint allows you to easily create cards that can later be affixed to Letters.\nThe API provides endpoints for creating cards, retrieving individual cards, creating card orders, and retrieving a list of cards.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -5150,7 +5174,7 @@
             },
             "item": [
                 {
-                    "id": "16269c29-51ef-4a94-b5ed-b89934561245",
+                    "id": "4b6bca58-7333-43f8-990b-c3d31d56950e",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -5210,7 +5234,7 @@
                     },
                     "response": [
                         {
-                            "id": "3c2bd0b2-b0ae-4694-8577-eff070455559",
+                            "id": "5c9d1572-fdb3-4f08-85a7-4969dc3fc60a",
                             "name": "Returns a list of card objects",
                             "originalRequest": {
                                 "url": {
@@ -5270,7 +5294,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b4fccfce-fe58-479c-b593-89e58d7563f2",
+                            "id": "505ac0cb-f51e-4cfd-af65-2ea0cbad0a64",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5333,7 +5357,7 @@
                     "event": []
                 },
                 {
-                    "id": "e5f2b84a-033b-41e0-a959-391707dbc87a",
+                    "id": "84240970-1edf-4062-ba6e-855dc6ac136e",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -5391,7 +5415,7 @@
                     },
                     "response": [
                         {
-                            "id": "d7c9cc25-f074-43f1-b770-fa5192ea5663",
+                            "id": "2702ecb3-1f08-4e9c-8f52-79a81ecf5e83",
                             "name": "Card created successfully",
                             "originalRequest": {
                                 "url": {
@@ -5454,7 +5478,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0a880a7a-c523-4ba8-bcc5-220b262baf23",
+                            "id": "3aa4ddc6-1a75-4b0e-bfc7-0d3c2d4bb6d3",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5523,7 +5547,7 @@
                     }
                 },
                 {
-                    "id": "c1b21822-6c74-4638-8820-513ded963494",
+                    "id": "ffd1a5da-f73f-46ce-9286-ea9b353c91ca",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -5561,7 +5585,7 @@
                     },
                     "response": [
                         {
-                            "id": "f485eebe-1968-42cd-9d25-72803461909d",
+                            "id": "068857e1-bf3d-4cec-96f6-7a0d75597341",
                             "name": "Returns a card object",
                             "originalRequest": {
                                 "url": {
@@ -5609,7 +5633,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cf0e4794-e317-4580-b8fa-bcdb96cf368e",
+                            "id": "d7c54dd2-0805-459b-b95e-f828869955bb",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5660,7 +5684,7 @@
                     "event": []
                 },
                 {
-                    "id": "daef0be7-9416-455e-b857-5fd6c049b6b3",
+                    "id": "7235722e-2483-4002-9a71-e2546f0e3225",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -5724,7 +5748,7 @@
                     },
                     "response": [
                         {
-                            "id": "833794a7-de38-4f59-8ff8-92147a166582",
+                            "id": "801780c5-abd3-4f9e-b35a-2200bc72f31d",
                             "name": "Returns a card object",
                             "originalRequest": {
                                 "url": {
@@ -5790,7 +5814,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "322cc046-0bec-42b4-8973-2421198df103",
+                            "id": "163d4b36-a2e5-4cee-bbd7-8560efb946bd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5862,7 +5886,7 @@
                     }
                 },
                 {
-                    "id": "510e95e6-2791-4f8f-9b62-dcc011a181a3",
+                    "id": "5ca16a4d-a978-4116-afa0-8214da5c7517",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -5900,7 +5924,7 @@
                     },
                     "response": [
                         {
-                            "id": "f7431f62-6d4f-4983-a34c-a884c48deb79",
+                            "id": "fb94fc07-2c53-42cf-8500-c3b3ef2bc9e0",
                             "name": "Deleted the card",
                             "originalRequest": {
                                 "url": {
@@ -5948,7 +5972,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4bf24ee2-3e62-4abf-abc6-af4a66d07377",
+                            "id": "c27ab25b-10fa-484c-baea-d4ab9851496a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6002,7 +6026,7 @@
             "event": []
         },
         {
-            "id": "bbdd079e-4076-4a13-ad53-40726c0a3918",
+            "id": "57cb2621-a275-43c6-adde-44e8100c881d",
             "name": "Checks",
             "description": {
                 "content": "Checks allow you to send payments via physical checks. The API provides endpoints\nfor creating checks, retrieving individual checks, canceling checks, and retrieving a list of checks.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -6010,7 +6034,7 @@
             },
             "item": [
                 {
-                    "id": "089458b0-b7d7-4e8b-9dc7-f371c386a6d8",
+                    "id": "d9460995-6d43-466a-9cbf-f94910532065",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -6058,7 +6082,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -6100,7 +6130,7 @@
                     },
                     "response": [
                         {
-                            "id": "27557726-b011-4139-895f-e7dcdbc26607",
+                            "id": "c0053bef-e2ab-44bb-babe-c3d0f82ab62b",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -6132,7 +6162,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -6180,7 +6210,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "192e3bb8-0388-441a-baae-5e356ddd4757",
+                            "id": "e1fa665a-cc08-4231-8d6e-4826f6d315da",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6212,7 +6242,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -6263,7 +6293,7 @@
                     "event": []
                 },
                 {
-                    "id": "41cc37b3-7607-46f1-a1bf-7e81d66048a6",
+                    "id": "526a2648-8cf2-45a7-9243-2dfbcd80df96",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -6349,7 +6379,7 @@
                     },
                     "response": [
                         {
-                            "id": "8d4e57dc-2dd1-419b-808b-71c4723598ac",
+                            "id": "cf7073b4-e311-4a07-9d9e-7b5810c63dbe",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -6566,7 +6596,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cc78ef37-1def-4270-86f8-592e0f603b6f",
+                            "id": "b273aa5b-556c-4bca-b30e-51838a0c66e6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6771,7 +6801,7 @@
                     }
                 },
                 {
-                    "id": "b2b81956-ced6-4b09-9cd6-f04041c9214c",
+                    "id": "a730da45-e41c-466e-84d8-935e718a2e70",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -6809,7 +6839,7 @@
                     },
                     "response": [
                         {
-                            "id": "72d52fb0-9f91-4c7f-a0fc-8def19399e43",
+                            "id": "6faf099f-d488-479f-8b1f-d14eea60ac53",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -6857,7 +6887,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5406a1fe-2107-45f4-a821-3ca50325aac6",
+                            "id": "63739213-24ea-42b3-ba68-f3cc50eac981",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6908,7 +6938,7 @@
                     "event": []
                 },
                 {
-                    "id": "79f336ec-2595-44ab-bfa1-ed42cc110aba",
+                    "id": "b9919bb6-2589-451b-871a-1b48bede3c4c",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -6946,7 +6976,7 @@
                     },
                     "response": [
                         {
-                            "id": "a0759138-72e6-434a-a10d-6d8ab022ae9d",
+                            "id": "2954fad7-e247-4af0-89a4-2d2ead5d47d2",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -6994,7 +7024,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "187d1ad1-7332-44bd-b1c1-31a7e06e5555",
+                            "id": "9b4b9ec2-2f7e-441a-a292-53a7b9c2952b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7048,7 +7078,7 @@
             "event": []
         },
         {
-            "id": "b32241c4-e5fc-4c59-8046-65b17adb53ca",
+            "id": "88fff5d4-e96c-4664-8f5e-bbbd14d062df",
             "name": "Creatives",
             "description": {
                 "content": "The creatives endpoint allows you to create and view creatives. Creatives are used to create\nreusable letter and postcard templates. The API provides endpoints for creating creatives, updating creatives,\nretrieving individual creatives, and deleting creatives.\n",
@@ -7056,7 +7086,7 @@
             },
             "item": [
                 {
-                    "id": "4e65e47c-6d83-48b1-a3e8-e45958a03eda",
+                    "id": "e1e8c0e2-5134-4a29-bac1-9ab8d2f2b87e",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -7145,7 +7175,7 @@
                     },
                     "response": [
                         {
-                            "id": "2f1c81da-ce99-4a98-aa19-a3bc7da202c2",
+                            "id": "59528506-e5a4-4fd2-a0bf-8a563b83561b",
                             "name": "Creative created successfully",
                             "originalRequest": {
                                 "url": {
@@ -7209,7 +7239,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "891898fd-5052-47b2-92c7-81092f6f0b48",
+                            "id": "afd77a89-099a-45b6-bf8a-32cb4d31f5df",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7279,7 +7309,7 @@
                     }
                 },
                 {
-                    "id": "637f00cc-fed4-4ba9-82dc-6c9687ecb1c3",
+                    "id": "04aa8d5d-b67a-4620-9356-a916256181e3",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -7317,7 +7347,7 @@
                     },
                     "response": [
                         {
-                            "id": "efcb97f0-3d9a-4b7b-9eda-6b00ab240584",
+                            "id": "6412cd44-e25c-4942-bd5b-363851cf336a",
                             "name": "Returns a creative object",
                             "originalRequest": {
                                 "url": {
@@ -7365,7 +7395,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9680779f-0e05-4a2f-bc34-87d87d8eefad",
+                            "id": "41779e0e-c7c6-4730-afba-c090d9f4ea74",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7416,7 +7446,7 @@
                     "event": []
                 },
                 {
-                    "id": "576e6f46-0590-440b-b1ef-b0fd7897377e",
+                    "id": "56fbd522-abbd-4d51-bb84-18b36520afd9",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -7471,14 +7501,14 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "tPRc{eAMpOV[NZMk*5(f8]lPKNgom5lGBN{I~#zn5j)NtSzY)kOM)'>rLFF`xMyb.7M5JBpP8u:JDe H7pYJsz0gI7vP;~cB6?kIIWyS2B@M}s,2lB9/KnNvs<oh~5msTg<!fR&= ba1<$n:Q,iCVNd7=MtU'+#?Ksc+]ZLQ-{R2p38=kmOG%aEC[f"
+                                    "value": " a!8[lZvOW}2M1}yg_`Se^Ot)!-7~!Jlto,2)63` a#T_LLJCYH`0}`Yvv,QI|3-]95bgaf`q1+k=;+0|25*r)..|26oyX3CsoPv@ePPrz4V_|#SUTf7~@ ^zhM2ux]kX;5G;Z&/2$oE>{^Bn_TXg~WfyA<RXk6uJELqY,ADa`=T{6:c=cK7i<1dYp^wO:vlW+3>:W@lu?rBC,|K;wZ2y+6-90Ig0 2|]1DL"
                                 }
                             ]
                         }
                     },
                     "response": [
                         {
-                            "id": "5a0cb868-cf17-481c-a192-cba6088a7621",
+                            "id": "9757dbcb-a043-41b9-9c07-2c30bdec0067",
                             "name": "Returns a creative object",
                             "originalRequest": {
                                 "url": {
@@ -7535,7 +7565,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a38df436-e7bf-4bca-b16c-1ab878d5efaa",
+                            "id": "f59d5843-0e12-40ad-a3a9-104a15dd16ca",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7601,7 +7631,7 @@
             "event": []
         },
         {
-            "id": "5da6db4c-9e2f-43f1-9090-ed20efd59f37",
+            "id": "ba6e9062-ebfc-4bff-82b5-a3c59b780d67",
             "name": "Errors",
             "description": {
                 "content": "Lob uses RESTful HTTP response codes to indicate success or failure of an API request - read below for more information. In general, 2xx indicates success, 4xx indicate an input error, and 5xx indicates an error on Lob's end.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">ATTRIBUTE</th>\n    <th style=\"white-space: nowrap\">DESCRIPTION</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>code</code></td>\n    <td style=\"white-space: nowrap\">A consistent machine-keyable string identifying the error</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>status_code</code></td>\n    <td style=\"white-space: nowrap\">A conventional HTTP status code</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>message</code></td>\n    <td style=\"white-space: nowrap\">A human-readable, subject-to-change message with more details about the error</td>\n  </tr>\n</table>\n\n### HTTP Status Code Summary\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>200</code></td>\n    <td style=\"white-space: nowrap\">SUCCESS</td>\n    <td style=\"white-space: nowrap\">Successful API request</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED</td>\n    <td style=\"white-space: nowrap\">Authorization error with your API key or account</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">FORBIDDEN</td>\n    <td style=\"white-space: nowrap\">Forbidden error with your API key or account</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">NOT FOUND</td>\n    <td style=\"white-space: nowrap\">The requested item does not exist</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BAD REQUEST</td>\n    <td style=\"white-space: nowrap\">The query or body parameters did not pass validation</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>429</code></td>\n    <td style=\"white-space: nowrap\">TOO MANY REQUESTS</td>\n    <td style=\"white-space: nowrap\">Too many requests have been sent with an API key in a given amount of time</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>500</code></td>\n    <td style=\"white-space: nowrap\">SERVER ERROR</td>\n    <td style=\"white-space: nowrap\">An internal server error occurred, please contact support@lob.com</td>\n  </tr>\n</table>\n\n### Error Codes - Generic\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BAD_REQUEST</td>\n    <td style=\"white-space: nowrap\">An invalid request was made. See error message for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>409/422</code></td>\n    <td style=\"white-space: nowrap\">CONFLICT</td>\n    <td style=\"white-space: nowrap\">This operation would leave data in a conflicted state.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">FEATURE_LIMIT_REACHED</td>\n    <td style=\"white-space: nowrap\">The account has reached its resource limit and requires upgrading to add more.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>500</code></td>\n    <td style=\"white-space: nowrap\">INTERNAL_SERVER_ERROR</td>\n    <td style=\"white-space: nowrap\">An error has occured on Lob's servers. Please try request again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID</td>\n    <td style=\"white-space: nowrap\">An invalid request was made. See error message for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">NOT_DELETABLE</td>\n    <td style=\"white-space: nowrap\">An attempt was made to delete a resource, but the resource cannot be deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">NOT_FOUND</td>\n    <td style=\"white-space: nowrap\">The requested resource was not found.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>408</code></td>\n    <td style=\"white-space: nowrap\">REQUEST_TIMEOUT</td>\n    <td style=\"white-space: nowrap\">The request took too long. Please try again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>503</code></td>\n    <td style=\"white-space: nowrap\">SERVICE_UNAVAILABLE</td>\n    <td style=\"white-space: nowrap\">The Lob servers are temporarily unavailable. Please try again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">UNRECOGNIZED_ENDPOINT</td>\n    <td style=\"white-space: nowrap\">The requested endpoint doesn't exist.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">UNSUPPORTED_LOB_VERSION</td>\n    <td style=\"white-space: nowrap\">An unsupported Lob API version was requested.</td>\n  </tr>\n</table>\n\n### Error Codes - Authentication\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">EMAIL_REQUIRED</td>\n    <td style=\"white-space: nowrap\">Account must have a verified email address before creating live resources.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED</td>\n    <td style=\"white-space: nowrap\">The request isn't authorized.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED_TOKEN</td>\n    <td style=\"white-space: nowrap\">Token isn't authorized.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401/403</code></td>\n    <td style=\"white-space: nowrap\">INVALID_API_KEY</td>\n    <td style=\"white-space: nowrap\">The API key is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">PUBLISHABLE_KEY_NOT_ALLOWED</td>\n    <td style=\"white-space: nowrap\">The requested operation needs a secret key, not a publishable key. See [API Keys](#tag/API-Keys) for more information.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>429</code></td>\n    <td style=\"white-space: nowrap\">RATE_LIMIT_EXCEEDED</td>\n    <td style=\"white-space: nowrap\">Requests were sent too quickly and must be slowed down.</td>\n  </tr>\n</table>\n\n ### Error Codes - Advanced\n\n <table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">PAYMENT_METHOD_UNVERIFIED</td>\n    <td style=\"white-space: nowrap\">You must have a verified bank account or credit card to submit live requests.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">DELETED_BANK_ACCOUNT</td>\n    <td style=\"white-space: nowrap\">Checks cannot be created with a deleted bank account.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">ADDRESS_LENGTH_EXCEEDS_LIMIT</td>\n    <td style=\"white-space: nowrap\">The sum of to.address_line1 and to.address_line2 cannot surpass 50 characters.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BANK_ACCOUNT_ALREADY_VERIFIED</td>\n    <td style=\"white-space: nowrap\">The bank account has already been verified.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BANK_ERROR</td>\n    <td style=\"white-space: nowrap\">There's an issue with the bank account.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">CUSTOM_ENVELOPE_INVENTORY_DEPLETED</td>\n    <td style=\"white-space: nowrap\">Custom envelope inventory is depleted, and more will need to be ordered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FAILED_DELIVERABILITY_STRICTNESS</td>\n    <td style=\"white-space: nowrap\">The to address doesn't meet strictness requirements.\n    See <a href=\"https://dashboard.lob.com/#/settings/account\" target=\"_blank\">Account Settings</a> to configure strictness.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_PAGES_BELOW_MIN</td>\n    <td style=\"white-space: nowrap\">Not enough pages.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_PAGES_EXCEED_MAX</td>\n    <td style=\"white-space: nowrap\">Too many pages.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_SIZE_EXCEEDS_LIMIT</td>\n    <td style=\"white-space: nowrap\">The file size is too large. See description for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FOREIGN_RETURN_ADDRESS</td>\n    <td style=\"white-space: nowrap\">The 'from' address must be a US address.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INCONSISTENT_PAGE_DIMENSIONS</td>\n    <td style=\"white-space: nowrap\">All pages of the input file must have the same dimensions.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_BANK_ACCOUNT</td>\n    <td style=\"white-space: nowrap\">The provided bank routing number is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_BANK_ACCOUNT_VERIFICATION</td>\n    <td style=\"white-space: nowrap\">Verification amounts do not match.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_CHECK_INTERNATIONAL</td>\n    <td style=\"white-space: nowrap\">Checks cannot be sent internationally.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_COUNTRY_COVID</td>\n    <td style=\"white-space: nowrap\">The postal service in the specified country is currently unable to process the request due to COVID-19 restrictions.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE</td>\n    <td style=\"white-space: nowrap\">The file is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_DIMENSIONS</td>\n    <td style=\"white-space: nowrap\">File dimensions are incorrect for the selected mail type.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_DOWNLOAD_TIME</td>\n    <td style=\"white-space: nowrap\">File download from remote server took too long.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_URL</td>\n    <td style=\"white-space: nowrap\">The file URL when creating a resource is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_IMAGE_DPI</td>\n    <td style=\"white-space: nowrap\">DPI must be at least 300.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_INTERNATIONAL_FEATURE</td>\n    <td style=\"white-space: nowrap\">The specified product cannot be sent to the destination.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_PERFORATION_RETURN_ENVELOPE</td>\n    <td style=\"white-space: nowrap\">Both `return_envelope` and `perforation` must be used together.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_TEMPLATE_HTML</td>\n    <td style=\"white-space: nowrap\">The provided HTML is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MERGE_VARIABLE_REQUIRED</td>\n    <td style=\"white-space: nowrap\">A required merge variable is missing.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MERGE_VARIABLE_WHITESPACE</td>\n    <td style=\"white-space: nowrap\">Merge variable names cannot contain whitespace.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">PDF_ENCRYPTED</td>\n    <td style=\"white-space: nowrap\">An encrypted PDF was provided.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">SPECIAL_CHARACTERS_RESTRICTED</td>\n    <td style=\"white-space: nowrap\">Cannot use special characters for merge variable names.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">UNEMBEDDED_FONTS</td>\n    <td style=\"white-space: nowrap\">The provided PDF contains non-standard unembedded fonts. See description for details.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7611,7 +7641,7 @@
             "event": []
         },
         {
-            "id": "e783780c-1097-4e52-bd9e-51b4eff27bfc",
+            "id": "f677d47e-7228-4976-aeb6-7c74a4d5c2b5",
             "name": "Events",
             "description": {
                 "content": "When various notable things happen within the Lob architecture, Events will be created. To get these events sent to your server\nautomatically when they occur, you can set up [Webhooks](#tag/Webhooks).\n\n<h3>Postcards</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n</table>\n\n<h3>Self Mailers</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Letters</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.pickup_available</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Pickup Available\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.issue</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"Issue\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A return envelope is created (occurs simultaneously with letter creation).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Checks</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Addresses</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully deleted.</td>\n  </tr>\n</table>\n\n<h3>Bank Accounts</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.verified</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully verified.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7621,7 +7651,7 @@
             "event": []
         },
         {
-            "id": "dde81aea-27c1-481c-ba56-140b378ac005",
+            "id": "af54f8dd-2834-402b-8e2c-ce920af138a5",
             "name": "Getting Started",
             "description": {
                 "content": "### 1. Get Setup\n* Create an account at <a href=\"https://dashboard.lob.com/#/register\" target=\"_blank\">Lob.com</a>\n* Obtain your API keys in the Lob dashboard <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">settings</a>\n* You'll use the format, `test_*.` for your Test API key and `live_*.` for your Live API key.\n\n### 2. Explore\n* Try out in Postman:\n<div class=\"postman-run-button\"\ndata-postman-action=\"collection/fork\"\ndata-postman-var-1=\"16169677-975ecb9f-ea22-4d8f-a4f9-53a42f2aee03\"\ndata-postman-collection-url=\"entityId=16169677-975ecb9f-ea22-4d8f-a4f9-53a42f2aee03&entityType=collection&workspaceId=5404d3a5-5a84-4df6-b078-a1547e1a68a7\"\nstyle=\"background:#0099d7;color: white;display: flex;justify-content: center;align-items: center;\">\n  Run in Postman\n</div>\n<script type=\"text/javascript\">\n  (function (p,o,s,t,m,a,n) {\n    !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });\n    !o.getElementById(s+t) && o.getElementsByTagName(\"head\")[0].appendChild((\n      (n = o.createElement(\"script\")),\n      (n.id = s+t), (n.async = 1), (n.src = m), n\n    ));\n  }(window, document, \"_pm\", \"PostmanRunObject\", \"https://run.pstmn.io/button.js\"));\n</script>\n* Launch your terminal and copy/paste a CURL command.\n```bash\ncurl https://api.lob.com/v1/addresses \\\n  -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc:\n```\n* Download a [Lob SDK](#tag/SDKs-and-Tools) into your favorite IDE (integrated development environment)\n\n### 3. Learn more\nTry our quick start (TypeScript, Python, PHP, Java or Ruby):\n* <a href=\"https://help.lob.com/developer-docs/quickstart-guide\" target=\"_blank\">Send your first Postcards</a>\n\nUse Case guides\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/mass-deletion-setup\" target=\"_blank\">Mass Deletion Setup</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/ncoa-restrictions\" target=\"_blank\">NCOA Restrictions</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/override-cancellation-window\" target=\"_blank\">Override Cancellation Window</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/visibility-of-address-changes\" target=\"_blank\">Visibility of Address Changes</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/ingesting-tracking-events-with-webhooks\" target=\"_blank\">Ingesting Tracking Events with Webhooks</a>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7631,7 +7661,7 @@
             "event": []
         },
         {
-            "id": "b764af56-0805-4c90-82e8-1524d2ebba71",
+            "id": "a559be10-3550-44c7-9bb2-8a0f63b6c31c",
             "name": "Identity Validation",
             "description": {
                 "content": "Validates whether a given name is associated with an address.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7639,7 +7669,7 @@
             },
             "item": [
                 {
-                    "id": "a2b9d614-fcd9-4bec-b5f4-8dde5d845805",
+                    "id": "6771aef8-9847-400d-bda0-6febe7c32ff1",
                     "name": "Identity Validation",
                     "request": {
                         "name": "Identity Validation",
@@ -7712,7 +7742,7 @@
                     },
                     "response": [
                         {
-                            "id": "b6ac3328-eabc-4ca0-952d-368c1df62b3d",
+                            "id": "2eb86f32-decf-4bd8-bfd6-2de7acb7ac91",
                             "name": "Returns the likelihood a given name is associated with an address.",
                             "originalRequest": {
                                 "url": {
@@ -7803,7 +7833,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e2eee77e-fd12-4943-9bbc-6ba48da6d1b3",
+                            "id": "98038ca5-3003-43df-955f-7802c52f2fa9",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7885,7 +7915,7 @@
             "event": []
         },
         {
-            "id": "dc11a861-79df-4a36-815c-ae5c72150d32",
+            "id": "21022e24-a013-4c62-899d-b083c2253d32",
             "name": "Intl Autocompletions",
             "description": {
                 "content": "Address autocompletion for non-US addresses. Given partial address information, this endpoint returns up to 10 address suggestions.\n## Autocompletion Test Env\nYour test API key does not autocomplete international addresses and is used to simulate\nbehavior. With your test API key, requests with specific values for `address_prefix`\nreturn predetermined values. When `address_prefix` is set to:\n- `0 suggestions` - Returns no suggestions\n- `[PRIMARY NUMBER] s[uggestion]` - Returns a maximum of ten predefined suggested addresses.\n  `[PRIMARY NUMBER]` does not have to be a valid primary number when sending a test request.\n  Each additional letter in `suggestion` reduces the number of suggestions by one (e.g.\n  `1 su` returns 9 suggested addresses). `[PRIMARY NUMBER]` does not affect the number of\n  suggestions returned.\nCountry is a required field.\nCity and state filters work as expected and filter the list of predetermined suggested addresses.\nSee the `test` request & response examples under [Autocomplete Examples](#operation/intl_autocompletions) within the \"Autocomplete\na partial address\" section in Intl Autocompletions.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7893,7 +7923,7 @@
             },
             "item": [
                 {
-                    "id": "0207b0d8-0a7d-4f42-aef9-09c7367ace3c",
+                    "id": "cdc91a28-1df9-49f2-b9e2-642deba4905b",
                     "name": "Autocomplete",
                     "request": {
                         "name": "Autocomplete",
@@ -7973,7 +8003,7 @@
                     },
                     "response": [
                         {
-                            "id": "a262405f-49eb-4785-88f3-a906928e57d3",
+                            "id": "c9f37069-aafa-45f4-b2dc-22bfb1f7a626",
                             "name": "Returns an international autocompletions object.",
                             "originalRequest": {
                                 "url": {
@@ -8094,7 +8124,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c7037f3a-a67e-4cf5-94eb-87ea08cc5f35",
+                            "id": "bd1cc816-d683-4b72-ab42-9fda9f79af57",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8206,7 +8236,7 @@
             "event": []
         },
         {
-            "id": "94344a01-b5ab-449b-8b70-ff11d02f5f9b",
+            "id": "4d1423a5-118c-40e3-9850-44e32afd1bfd",
             "name": "Intl Verifications",
             "description": {
                 "content": "Address verification for non-US addresses\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Intl Verifications Test Env\n\nWhen verifying international addresses, you'll likely want to test against\na wide array of addresses to ensure you're handling responses correctly.\nWith your test API key, requests that use specific values for `primary_line`\nlet you explore the responses to many types of addresses:\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">DELIVERABILITY OF SAMPLE RESPONSE</th>\n    <th style=\"white-space: nowrap\">SET <code>primary_line</code> TO</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\">deliverable</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>deliverable_missing_info</code></td>\n    <td style=\"white-space: nowrap\">deliverable missing info</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\">undeliverable</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>no_match</code></td>\n    <td style=\"white-space: nowrap\">no match</td>\n  </tr>\n</table>\n\nSee the `test` request & response examples under [Intl Verification Examples](#operation/intl_verification) within the\n\"Verify an international address section\" in Intl Verifications.\n\nYou can rely on the response from these examples generally matching the response\nyou'd see in the live environment with an address of that type (excluding the `recipient` field).\n\nThe test API key does not perform any verification, automatic correction, or standardization\nfor addresses. If you wish to try these features out, use our <a href=\"https://lob.com/address-verification\" target=\"_blank\">live demo</a>\nor the free plan (see <a href=\"https://lob.com/pricing/address-verification\" target=\"_blank\">our pricing</a> for details).\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -8214,7 +8244,7 @@
             },
             "item": [
                 {
-                    "id": "8705c8fd-21d4-4f69-9d9c-25a2bf9fb3c0",
+                    "id": "6bf8eea9-065d-455c-afed-877e36c7e292",
                     "name": "Bulk Verify",
                     "request": {
                         "name": "Bulk Verify",
@@ -8259,7 +8289,7 @@
                     },
                     "response": [
                         {
-                            "id": "396975ef-b610-4e94-9ca9-0465a7864437",
+                            "id": "ad7d626b-ae7a-4ff1-8e0b-9d9fede277a6",
                             "name": "Returns an array of international verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -8330,7 +8360,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7f7e738b-3d2c-4f62-a515-a1a83fb722df",
+                            "id": "7f82991f-82ab-42e2-bf3c-404bfc324a53",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8389,7 +8419,7 @@
                     }
                 },
                 {
-                    "id": "3d34e667-ddee-489f-88a5-036384a9b547",
+                    "id": "44a52596-221f-4bd3-b157-ef74377c448a",
                     "name": "Single Verify",
                     "request": {
                         "name": "Single Verify",
@@ -8468,7 +8498,7 @@
                     },
                     "response": [
                         {
-                            "id": "158e00f6-b1c6-4012-a577-827613bcd924",
+                            "id": "7fabc832-b6d5-4064-ac63-f4c52da1ddbd",
                             "name": "Returns an international verification object.",
                             "originalRequest": {
                                 "url": {
@@ -8570,7 +8600,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "57fb9636-727b-4115-a44d-098d62d4e76a",
+                            "id": "25a0680e-5a89-4ce7-9e4b-4b034dd4f6e0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8663,7 +8693,7 @@
             "event": []
         },
         {
-            "id": "34add319-d2ed-49bd-98d9-55ce52dc6d79",
+            "id": "c90f17d1-402d-434c-9660-f7aa4962354e",
             "name": "Introduction",
             "description": {
                 "content": "Lob’s Print & Mail and Address Verification APIs help companies transform outdated,\nmanual print-and-mail processes; save 1,000s of hours in processing time by sending mail much more\nquickly; and increase ROI on offline communications.\n\nAutomate direct mail by triggering on-demand postcards, letters, and checks directly from your\nCRM or customer data systems.\n\nAddress Verification corrects, standardizes, and cleanses address data for assured delivery with\ninstant verification across 240+ countries and territories.\n\nLob's print delivery network eliminates the hassle of vendor management with automated\nproduction and postage across a global network of vetted commercial printers.\n\nTracking & Analytics gives you complete visibility of production and delivery for each piece of\nmail you send to meet compliance requirements and measure campaign performance.\n",
@@ -8673,7 +8703,7 @@
             "event": []
         },
         {
-            "id": "cd2417db-fea1-49bb-87c0-5201c382f7e1",
+            "id": "0bab8ae5-455f-4093-8846-5238f931320c",
             "name": "Letters",
             "description": {
                 "content": "The letters endpoint allows you to easily print and mail letters. The API provides endpoints for\ncreating letters, retrieving individual letters, canceling letters, and retrieving a list of letters.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -8681,7 +8711,7 @@
             },
             "item": [
                 {
-                    "id": "1d395caa-4741-4071-a625-b1b8b8e33676",
+                    "id": "97effd2b-bddd-44ca-8c89-da87272e7734",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -8719,7 +8749,7 @@
                     },
                     "response": [
                         {
-                            "id": "321fc3bc-2714-4cc5-8127-7b04c60cb2e3",
+                            "id": "834bf15e-632f-4758-b41b-2902f241fdca",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -8767,7 +8797,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b066c2e1-8be8-40ef-bbc0-6bb5416a06c6",
+                            "id": "04b23d97-fe5c-4894-b3e2-66025105fe61",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8818,7 +8848,7 @@
                     "event": []
                 },
                 {
-                    "id": "85d6f5a8-e18c-4798-bd4e-216bcdcd8c8f",
+                    "id": "3fb7f721-e1be-425c-9497-a67a34a7c5a2",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -8856,7 +8886,7 @@
                     },
                     "response": [
                         {
-                            "id": "ddc8fe71-6e6a-4e83-8943-0d194dbe383c",
+                            "id": "bfd55c32-1ec4-43be-aaa0-1623825bcaa9",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -8904,7 +8934,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6a2f8881-df83-45db-9b9e-f7e8f0068cb3",
+                            "id": "adace7b0-bd1d-4a8f-8eb2-ca93a4ce5a7a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8955,7 +8985,7 @@
                     "event": []
                 },
                 {
-                    "id": "d0dba67c-b598-4ab4-b58a-633ca2f18082",
+                    "id": "09ddce1c-a930-45e1-a4bb-3224bdff57d5",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -9003,7 +9033,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -9051,7 +9087,7 @@
                     },
                     "response": [
                         {
-                            "id": "a522e8cd-e6be-4603-97e4-2e3d31e73492",
+                            "id": "1087c536-7310-423d-a519-9fc5f26780fc",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -9083,7 +9119,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -9135,7 +9171,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8935f408-a110-4fc0-b21e-ebdabc064ae3",
+                            "id": "03e2a867-e668-42d0-bcfe-e030ff5eaa84",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9167,7 +9203,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -9222,7 +9258,7 @@
                     "event": []
                 },
                 {
-                    "id": "be79b456-41c6-4498-951c-495af7df119a",
+                    "id": "e597d092-7e84-4015-b42a-09e5fe1959bc",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -9388,7 +9424,7 @@
                     },
                     "response": [
                         {
-                            "id": "392b9330-4d0f-4ec1-b811-7e026a1bc669",
+                            "id": "c49264c6-ee11-44ec-96c4-fc6fa4e7ce9c",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -9640,7 +9676,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9116adf6-7cac-45cc-8ae0-3f1d0edcc5bd",
+                            "id": "766555aa-bfea-4622-b55e-5253944ab022",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9883,7 +9919,7 @@
             "event": []
         },
         {
-            "id": "846542e3-d3e7-42ba-9375-847dc72a11c8",
+            "id": "b57e1052-ae69-466a-b4de-93f55423f40c",
             "name": "Manage Mail",
             "description": {
                 "content": "## Cancellation Windows\n\nBy default, all new accounts have a 5 minute cancellation window for postcards,\nself mailers, letters, and checks. Within that timeframe, you can cancel\nmailings from production, free of charge. Once the window has passed for a\npostcard, self mailer, letter, or check, the mailing is no longer cancelable.\nIn addition, certain customers can customize their cancellation windows by\nproduct in their <a href=\"https://dashboard.lob.com/#\" target=\"_blank\">Dashboard Settings</a>. Upgrade to\nthe appropriate <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>\nto automatically gain access to this ability. For more details on this feature,\ncheck out our <a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#cancellation-windows-4\" target=\"_blank\">Cancellation Guide</a>.\n\nIf you schedule a postcard, self mailer, letter, or check for up to 180 days\nin the future by supplying the `send_date` parameter, that will override any\ncancellation window you may have for that product.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Scheduled Mailings\n\nPostcards, self mailers, letters, and checks can be scheduled to be sent up\nto 180 days in advance. You can use this feature to:\n- Create automated drip campaigns (e.g. send a postcard at 15, 30, and 60\ndays)\n- Schedule recurring sends\n- Plan your mailing schedule ahead of time\n\nUp until the time a mailing is scheduled for, it can also be canceled.\nIf you use this feature in conjunction with [a cancellation window](\nindex.html#section/Cancellation-Windows), the `send_date` parameter will always\ntake precedence.\n\nFor implementation details, see documentation below for each respective\nendpoint. For more help, see our <a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/choosing-a-delivery-strategy#scheduled-mailings-15\" target=\"_blank\">Scheduled Mailings Guide</a>.\n\nThis feature is exclusive to certain customers. Upgrade to the appropriate\n<a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a> to\ngain access.\n\n### Example Create Request using Send Date\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Future Postcard\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    -d \"front=tmpl_b846a20859ae11a\" \\\n    -d \"back=tmpl_01b0d396a10c268\" \\\n    -d \"merge_variables[name]=Harry\" \\\n    -d \"send_date=2021-07-26\"\n```\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -9893,7 +9929,7 @@
             "event": []
         },
         {
-            "id": "2a7ad85a-7e46-4921-8fa1-5405d392d4d8",
+            "id": "108cb06b-1729-4ea3-8ccc-be34f053929e",
             "name": "National Change of Address",
             "description": {
                 "content": "National Change of Address Linkage (NCOALink) is a service offered by the USPS, which allows individuals\nor businesses who have recently moved to have any mail forwarded from their previous address\nto their new address.\n\nAs a CASS-certified Address Verification Provider, Lob also offers NCOALink\nfunctionality to our Print & Mail customers. With the Lob NCOALink feature enabled, Postcards,\nLetters, Checks and Addresses can automatically be corrected to reflect an individual's or business's\nnew address in the case that they have moved (only if they have registered for NCOALink with the USPS).\n\nDue to privacy concerns and USPS constraints, for customers with NCOALink enabled, our API responses\nfor a limited set of endpoints differ slightly in the case when an address has been changed through NCOALink.\n\n**NOTE**: This feature is exclusive to certain customers. Upgrade to the appropriate <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a> to gain access.\n\nFor more information, see our <a href=\"https://help.lob.com/print-and-mail/all-about-addresses#national-change-of-address-ncoa-7\" target=\"_blank\">NCOALink guide</a>.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## NCOALink Live Environment\nThough there are no changes to API requests, there are significant changes to our API responses, but\nonly in the event that an address has been changed through NCOALink. If an address has not been changed\nthrough NCOALink, the response would be identical to our standard responses, except the addition of a\n`recipient_moved` field, which is `false` for unchanged addresses.\n\nIf an address has been changed through NCOALink, we are required to suppress the following response\nfields for that address:\n- `address_line1`\n- `address_line2`\n- The +4 portion of the ZIP+4 (5-digit ZIP code will still be present)\n\nSee the `ncoa_us_live` example under [Response samples](#operation/address_create) within the \"Create an Address\" section in Addresses\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## NCOALink Test Environment\n\nIn addition to sending live requests, you may also want to simulate what an NCOALink response might\nlook like so that you can ensure your application behaves as expected. The behavior of NCOALink in\nLob's Test Environment is very similar to our [US Verifications Test Mode](#section/US-Verifications-Test-Env).\n\nTo simulate an NCOALink request, send a POST request to any of the four endpoints below with an `address_line1` field equal to `NCOA`:\n- `POST /v1/addresses`\n- `POST /v1/checks`\n- `POST /v1/letters`\n- `POST /v1/postcards`\n- `POST /v1/self_mailers`\n\nA static address will always be returned, as documented in the `ncoa_us_test` example under [Response samples](#operation/address_create) within the \"Create an Address\"\nsection in Addresses (along with the corresponding request under \"Request samples\").\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -9903,7 +9939,7 @@
             "event": []
         },
         {
-            "id": "d2267da2-4ac6-4de5-9c99-1b49dce1ab27",
+            "id": "e8c43815-18c7-48e0-abb5-990855d6d2e6",
             "name": "Postcards",
             "description": {
                 "content": "The postcards endpoint allows you to easily print and mail postcards. The API provides endpoints for creating postcards,\nretrieving individual postcards, canceling postcards, and retrieving a list of postcards.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -9911,7 +9947,7 @@
             },
             "item": [
                 {
-                    "id": "c04031fa-dce1-4799-8fa2-b432fd2de2a4",
+                    "id": "fddd84ad-b19a-4fd1-beb7-600437904334",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -9949,7 +9985,7 @@
                     },
                     "response": [
                         {
-                            "id": "b278d34b-f158-4863-ae08-f3515e78f9ad",
+                            "id": "09aa5da0-f1a3-4c45-88c5-53c0c68b3d46",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -9997,7 +10033,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1b2af123-fd0a-4b84-9672-f7f86511b226",
+                            "id": "d6c41834-3a2d-44a4-a1c0-a0b3c4b8f32d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10048,7 +10084,7 @@
                     "event": []
                 },
                 {
-                    "id": "043f04f3-0b61-479a-9bb4-68d3c8002962",
+                    "id": "ae80f168-6d4c-4322-8996-63624a3019a4",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -10086,7 +10122,7 @@
                     },
                     "response": [
                         {
-                            "id": "7da26ef3-7dca-466b-92d1-ae1f8098327a",
+                            "id": "ae21d57e-be98-4942-a9bc-af269f6d08df",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -10134,7 +10170,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "36c0f73c-7dbc-4a23-b16f-e82e79819744",
+                            "id": "2308aacf-d429-49b0-a558-5c540ae1b7c0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10185,7 +10221,7 @@
                     "event": []
                 },
                 {
-                    "id": "2915715e-2cc3-447d-b27f-862d90ec1f6b",
+                    "id": "ae78b29a-4313-46c4-a3aa-3482a19aa522",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -10233,7 +10269,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -10287,7 +10329,7 @@
                     },
                     "response": [
                         {
-                            "id": "7b2d7fe9-c346-48aa-8746-2ae402a33870",
+                            "id": "1b9a07d7-139a-421a-a6c2-0e249d642fc2",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -10319,7 +10361,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -10375,7 +10417,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "692047b4-506f-4c8c-9eae-633d454697a2",
+                            "id": "9ad0e9aa-d4c8-486c-922e-a4a2682b017a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10407,7 +10449,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -10466,7 +10508,7 @@
                     "event": []
                 },
                 {
-                    "id": "39d3ad31-64a0-49a0-bcb7-c32f8bd81f8c",
+                    "id": "4b7ed28a-40ed-4027-befa-e5792291370a",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -10612,7 +10654,7 @@
                     },
                     "response": [
                         {
-                            "id": "ffc9671a-afa4-4405-9315-b98035c7b81a",
+                            "id": "cbff3d28-007f-4942-b717-5e969f341dea",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -10864,7 +10906,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b80d7c26-338f-4cae-9268-111399fc9391",
+                            "id": "d4192bfb-62f1-4ff9-9e44-b3efe01caa13",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11107,7 +11149,7 @@
             "event": []
         },
         {
-            "id": "b7b45452-890f-4fe6-ae6d-1bbb890b56e9",
+            "id": "b8c7ceed-0bbd-44cd-b85f-78cecd6b6aa9",
             "name": "QR Codes",
             "description": {
                 "content": "\nLob QR codes allow you to generate a QR code that is unique to each mailpiece, thereby allowing each and every customers to receive a personalized link. See the Create endpoint for <a href=\"#tag/Letters/operation/letter_create\">Letters</a> or <a href=\"#tag/Postcards/operation/postcard_create\">Postcards</a> to learn how to embed a QR code into your mail piece.\n\nWebhooks can be used to integrate Lob QR code scans into your omni channel marketing strategy. See the <a href=\"#tag/Webhooks\">Webhooks</a> section of our documentation to learn how to enable the `letter.viewed` and `postcard.viewed` event notifications for your mail pieces.\n\nFurthermore, our QR code Analytics endpoint can be used to track the impact and engagement rate of your mail sends. Lob can tell you exactly which recipients opened your mailpiece. Our Analytics endpoint allows you to see exactly which recipient scanned a mailpiece, when they scanned it, and more!\n\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11115,7 +11157,7 @@
             },
             "item": [
                 {
-                    "id": "cd5736f5-3250-4563-8652-de14019ffcc0",
+                    "id": "2768675d-70fc-45f0-bd2f-57ccc7481a9a",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -11157,7 +11199,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -11181,7 +11229,7 @@
                     },
                     "response": [
                         {
-                            "id": "8d7e9af0-1c27-45a8-86a1-1924502e56b8",
+                            "id": "832a9f3e-4f4b-4991-a36e-4c47250ed414",
                             "name": "Returns a list of QR Codes and their analytics.",
                             "originalRequest": {
                                 "url": {
@@ -11209,7 +11257,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -11251,7 +11299,7 @@
             "event": []
         },
         {
-            "id": "5d013f92-a6ea-4b18-8024-1bf11fdf1fc8",
+            "id": "f5299eb8-745d-46b2-9db9-dbdeb17c315f",
             "name": "Rate Limiting",
             "description": {
                 "content": "To prevent misuse, we enforce a rate limit on an API Key and endpoint basis, similar to the way many other APIs enforce rate limits. By default, all accounts and their corresponding Test and Live API Keys have a rate limit of 150 requests per 5 seconds per endpoint. The `POST /v1/us_verifications` and `POST /v1/us_autocompletions` endpoints have a limit of 300 requests per 5 seconds for all accounts.\n\nWhen your application exceeds the rate limit for a given API endpoint, the Lob API will return an HTTP 429 \"Too Many Requests\" response code instead of the variety of codes you would find across the other API endpoints.\n\n**HTTP Headers**\n\nHTTP headers are returned on each request to a rate limited endpoint. Ensure that you inspect these headers during your requests as they provide relevant data on how many more requests your application is allowed to make for the endpoint you just utilized.\n\nWhile the headers are documented here in titlecase, HTTP headers are case insensitive and certain libraries may transform them to lowercase. Please inspect your headers carefully to see how they will be represented in your chosen development scenario.\n<table>\n  <tbody>\n    <tr>\n      <td>X-Rate-Limit-Limit:</td>\n      <td>the rate limit ceiling for a given request</td>\n    </tr>\n    <tr>\n      <td>X-Rate-Limit-Remaining:</td>\n      <td>the number of requests remaining in this window</td>\n    </tr>\n    <tr>\n      <td>X-Rate-Limit-Reset:</td>\n      <td>the time at which the rate limit window resets (in <a  href=\"https://en.wikipedia.org/wiki/Unix_time\"  target=\"_blank\">UTC epoch seconds</a>)\n    </td>\n    </tr>\n  </tbody>\n</table>\n\n### Example HTTP Headers\n\n```bash\n  X-Rate-Limit-Limit:150\n  X-Rate-Limit-Remaining:100\n  X-Rate-Limit-Reset:1528749846\n```\n\n### Example Response\n\nIf you hit the rate limit on a given endpoint, this is the body of the HTTP 429 message that you will see:\n\n```javascript\n  {\n    \"error\": {\n      \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n      \"code\": \"rate_limit_exceeded\",\n      \"status_code\": 429\n    }\n  }\n``` <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>",
@@ -11261,7 +11309,7 @@
             "event": []
         },
         {
-            "id": "5708791a-1430-400b-b3e3-0634ca740d43",
+            "id": "105fb33f-8703-4af0-9981-a8e7fadadc01",
             "name": "Requests and Responses",
             "description": {
                 "content": "## Asset URLs\n\nAll asset URLs returned by the Lob API (postcards, letters, thumbnails,\netc) are signed links served over HTTPS. All links returned will expire in\n30 days to prevent mis-sharing. Each time a GET request is initiated, a\nnew signed URL will be generated.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Query Parameters\n\nQuery parameters which consist of lists of strings require that all elements of\nthe list be double-quoted, as per query filter standards.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Idempotent Requests\n\nLob supports idempotency for safely retrying `POST` requests to create\npostcards, self mailers, letters, and checks without accidentally creating\nduplicates.\n\nFor example, if a request to create a check fails due to a network error,\nyou can safely retry the same request with the same idempotency key and\nguarantee that only one check will ultimately be created and sent. When a\nrequest is sent with an idempotency key for an already created resource,\nthe response object for the existing resource will be returned.\n\nTo perform an idempotent `POST` request to one of the mailpiece product\nendpoints, provide an additional `Idempotency-Key` header or an `idempotency_key`\nquery parameter to the request. If multiple idempotency keys are provided,\nthe request will fail. How you create unique keys is up to you, but we\nsuggest using random values, such as V4 UUIDs. Idempotency keys are intended\nto prevent issues over a short periods of time, therefore keys expire after\n24 hours. Keys are unique by mode (Test vs. Live) as well as by resource\n(postcard vs. letter, etc.).\n\nBy default, all `GET` and `DELETE` requests are idempotent by nature, so\nthey do not require an additional idempotency key.\n\nFor more help integrating idempotency keys, refer to our\n<a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#idempotent-requests-12\" target=\"_blank\">implementation guide</a>.\n\n**Headers**\n<table>\n  <tbody>\n    <tr>\n      <td>Idempotency-Key:</td>\n      <td>\n        optional\n        <p style=\"color:#888;margin-top:0px;\">\n          <font size=\"-1\">\n            A string of no longer than 256 characters\n            that uniquely identifies this resource.\n          </font>\n        </p>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n**Query Parameters**\n<table>\n  <tbody>\n    <tr>\n      <td>idempotency-key:</td>\n      <td>\n        optional\n        <p style=\"color:#888;margin-top:0px;\">\n          <font size=\"-1\">\n            A string of no longer than 256 characters\n            that uniquely identifies this resource.\n          </font>\n        </p>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n### Example Request\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -H \"Idempotency-Key: 026e7634-24d7-486c-a0bb-4a17fd0eebc5\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    --data-urlencode \"front=<html style='margin: 130px; font-size: 50;'>Front HTML for {{name}}</html>\" \\\n    --data-urlencode \"back=<html style='margin: 130px; font-size: 50;'>Back HTML</html>\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Metadata\n\nWhen creating any Lob object, you can include a metadata object with up to 20 key-value pairs of\ncustom data. You can use metadata to store information like `metadata[customer_id] = \"987654\"` or\n`metadata[campaign] = \"NEWYORK2015\"`. This is especially useful for filtering and matching to internal\nsystems.\n\nEach metadata key must be less than 40 characters long and values must be less than 500 characters.\nMetadata does not support nested objects.\n\n### Example Create Request with Metadata\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Postcard job\" \\\n    -d \"metadata[campaign]=NEWYORK2015\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    --data-urlencode \"front=<html style='margin: 130px; font-size: 50;'>Front HTML for {{name}}</html>\" \\\n    --data-urlencode \"back=<html style='margin: 130px; font-size: 50;'>Back HTML</html>\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n\n### Example List Request with Metadata Filter\n\n```bash\n  curl -g \"https://api.lob.com/v1/postcards?metadata[campaign]=NEWYORK2015&limit=2\" \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc:\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n\n## Request Body\n\nWhen manually sending a POST HTTP request directly to the Lob API, without\nthe use of a library, you may represent the body as either a Form URL\nEncoded request, a JSON document, or a Multipart Form Data request.\n\nHowever, if you're using one of our [SDKs](#tag/SDKs-and-Tools),\nthe generation of the request bodies is done for you automatically and you don't\nneed to worry about the format.\n\n### Form URL Encoded\n\nThis request body encoding is accompanied with the\n`Content-Type: application/x-www-form-urlencoded` header. The content is an\nexample of what the [Verify a US address](index.html#operation/us_verification)\nendpoint accepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  primary_line=210 King Street&city=San Francisco&state=CA&zip_code=94107\n```\n\n### JSON\n\nThis request body encoding is accompanied with the `Content-Type: application/json` header.\nThe content is an example of what the [Verify a US address endpoint](index.html#operation/us_verification)\naccepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  {\n    \"primary_line\": \"210 King Street\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"zip_code\": \"94107\"\n  }\n```\n\n### Multipart Form Data\n\nThis request body encoding is accompanied with the `Content-Type: multipart/form-data`\nheader. This is the only format that can be used for uploading a file to the API. The\ncontent is an example of what the [Create a check](index.html#operation/check_create)\nendpoint accepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"description\"\n\n  Demo Letter\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"to\"\n\n  adr_bae820679f3f536b\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"from\"\n\n  adr_210a8d4b0b76d77b\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"file\"; filename=\"file.pdf\"\n  Content-Type: application/pdf\n\n  <FILE CONTENT>\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"color\"\n\n  true\n  --------------------------7015ebe79c0a5f8c--\n```\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11271,7 +11319,7 @@
             "event": []
         },
         {
-            "id": "d85036d6-8515-4ec6-802d-e1d9e39376c5",
+            "id": "5b79b60a-0023-46a0-a177-765f17817099",
             "name": "Reverse Geocode Lookups",
             "description": {
                 "content": "Find a list of zip codes associated with a valid US location via latitude and longitude. <br> <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11279,7 +11327,7 @@
             },
             "item": [
                 {
-                    "id": "4eec7c42-4ed0-4990-be55-c00d6419b551",
+                    "id": "cd8e887d-4b6c-49f8-a343-90ce7eca25bb",
                     "name": "Reverse Geocode Lookup",
                     "request": {
                         "name": "Reverse Geocode Lookup",
@@ -11336,7 +11384,7 @@
                     },
                     "response": [
                         {
-                            "id": "eae33302-2a1f-48a2-987a-6614dfa8076f",
+                            "id": "89d32fef-c5ba-4c96-a1ea-bf3ad911aa14",
                             "name": "Returns a zip lookup object if a valid zip was provided.",
                             "originalRequest": {
                                 "url": {
@@ -11420,7 +11468,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a1341baf-6714-40de-9131-5b52ea05a0e3",
+                            "id": "eebe4213-bb0f-474c-a2f8-16c538500d98",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11495,7 +11543,7 @@
             "event": []
         },
         {
-            "id": "accbab48-da68-45c1-b469-2cf7bc9b1d66",
+            "id": "1cd50a9d-fd97-49ae-9d77-ca0295110e3f",
             "name": "SDKs and Tools",
             "description": {
                 "content": "Please visit our <a href=\"https://www.github.com/lob\" target=\"_blank\">Github</a> for a list of our supported libraries.\n- <a href=\"https://github.com/lob/lob-typescript-sdk\" target=\"_blank\">Typescript</a>\n- <a href=\"https://github.com/lob/lob-php\" target=\"_blank\">PHP</a>\n- <a href=\"https://github.com/lob/lob-python\" target=\"_blank\">Python</a>\n- <a href=\"https://github.com/lob/lob-java\" target=\"_blank\">Java</a>\n- <a href=\"https://github.com/lob/lob-ruby\" target=\"_blank\">Ruby</a>\n- <a href=\"https://github.com/lob/lob-dotnet\" target=\"_blank\">CSharp</a>\n- <a href=\"https://github.com/lob/lob-elixir\" target=\"_blank\">Elixir</a>\n- <a href=\"https://github.com/lob/lob-node\" target=\"_blank\">Node.js (legacy)</a>\n- <a href=\"https://github.com/lob/lob-java/tree/12.3.7-Legacy\" target=\"_blank\">Java (legacy)</a>\n- <a href=\"https://github.com/lob/lob-php/tree/v3-legacy\" target=\"_blank\">PHP (legacy)</a>\n- <a href=\"https://github.com/lob/lob-python/tree/legacy_v4\" target=\"_blank\">Python (Legacy)</a>\n\n<br><br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11505,7 +11553,7 @@
             "event": []
         },
         {
-            "id": "9363f499-027d-4307-95a6-7f70e4a38098",
+            "id": "a8f6e968-aab2-4604-aaf8-8b8b7ef80277",
             "name": "Self Mailers",
             "description": {
                 "content": "The self mailer endpoint allows you to easily print and mail self mailers. The API provides endpoints\nfor creating self mailers, retrieving individual self mailers, canceling self mailers, and retrieving a list of self mailers.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11513,7 +11561,7 @@
             },
             "item": [
                 {
-                    "id": "257b921d-7ed1-4e07-b384-fe97e1895245",
+                    "id": "496d3666-0dc6-4333-a87b-56730f1937c8",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -11551,7 +11599,7 @@
                     },
                     "response": [
                         {
-                            "id": "8033c03d-6536-4724-84d8-1e0068d378fb",
+                            "id": "80edbb27-58ea-4c38-ac8b-fa53408c3a4b",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -11599,7 +11647,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0fb7927a-76e4-41b9-88bd-7d3a88fa60ed",
+                            "id": "aa56f38c-1c70-4aca-b384-2720a6ecf6eb",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11650,7 +11698,7 @@
                     "event": []
                 },
                 {
-                    "id": "b558c38a-dd6e-465d-92cd-478c97535c22",
+                    "id": "e6b80514-b607-4551-ac33-c8a503db7bb3",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -11688,7 +11736,7 @@
                     },
                     "response": [
                         {
-                            "id": "2d5c2698-6ecc-4535-be0a-4e8c4b569c97",
+                            "id": "d4be1109-395c-4374-90e6-3c8bc314649d",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -11736,7 +11784,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8c59eab3-abf9-4d74-a4d6-cdbff4d9939e",
+                            "id": "52243bb5-12d5-4f9b-b397-ffcaa82cc8f4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11787,7 +11835,7 @@
                     "event": []
                 },
                 {
-                    "id": "02b07448-2f05-47a8-971c-d177f2888cad",
+                    "id": "5273621c-8f2a-4585-b119-e4c8acc2f55f",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -11835,7 +11883,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -11889,7 +11943,7 @@
                     },
                     "response": [
                         {
-                            "id": "577eaf4c-bbf6-4453-863d-3d9e3fbf7a08",
+                            "id": "e66782c9-9e14-48bc-a744-3a17334d4c78",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -11921,7 +11975,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -11977,7 +12031,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ab6a4408-9c03-48d4-8cf0-231a8edba531",
+                            "id": "d73ec502-a8a0-4dcf-b7b6-e90deb09c807",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12009,7 +12063,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         },
                                         {
@@ -12068,7 +12122,7 @@
                     "event": []
                 },
                 {
-                    "id": "a99946a4-7823-4a8d-a8d9-15df174356a7",
+                    "id": "6971c6cf-9b2a-4bf0-b2e5-56f2af4141f6",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -12174,7 +12228,7 @@
                     },
                     "response": [
                         {
-                            "id": "98ae70dc-01c3-4a7f-8391-6d30d0100329",
+                            "id": "d2bca681-d880-4639-8dd5-c4d602035067",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -12296,7 +12350,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3a2a6a9c-a27f-4bb3-9d7f-8a4096e76e4f",
+                            "id": "308ac2f5-eca7-4c2f-9ded-bb28802212b1",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12409,7 +12463,7 @@
             "event": []
         },
         {
-            "id": "47bb0a8f-8a60-4848-b228-2d7ae1e7e742",
+            "id": "1fb9f8ec-40d4-4053-85af-05a2dc5dc4ea",
             "name": "Template Design",
             "description": {
                 "content": "## HTML Templates\nYou can save commonly used HTML as templates within Lob to more easily manage them. You can reference\nyour saved templates in postcard, letter, and check requests instead of having to pass a long HTML\nstring on each request. Additionally, you can make changes to your HTML templates and update them\nindependently, without having to touch your API integration. Templates can be created, edited,\nand viewed on your <a href=\"https://dashboard.lob.com/#/templates\" target=\"_blank\">Dashboard</a>. To use a template in a postcard,\nletter, or check, see the documentation for each endpoint below. For help using templates, check out our\n<a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/dynamic-personalization#html-templates-1\" target=\"_blank\">HTML Templates Guide</a> or get started with a\n<a href=\"https://lob.com/template-gallery\" target=\"_blank\">pre-designed template from our gallery</a>. In Live mode, you can only have\nas many templates as allotted in your current\n<a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>. There is no limit in Test mode.\n\nIf you'd like to interact with templates programmatically, check out our Beta Program for API access\nto the [HTML Templates Endpoints](#tag/Templates).\n\n### Example Create Request using HTML Templates\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Postcard job\" \\\n    -d \"to=adr_78c304d54912c502\" \\\n    -d \"from=adr_61a0865c8c573139\" \\\n    -d \"front=tmpl_b846a20859ae11a\" \\\n    -d \"back=tmpl_01b0d396a10c268\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## HTML Examples\nUse a pre-designed template from our <a href=\"https://lob.com/resources/template-gallery\" target=\"_blank\">gallery</a> or follow these\nbasic <a href=\"https://github.com/lob/examples\" target=\"_blank\">guidelines</a> as starting points for creating custom Postcards,\nSelf Mailers, Letters, and Checks.\n\nPlease follow the standards used in these templates, such as:\n- For any linked assets, you must use a performant file hosting provider with no rate limits such as Amazon\nS3.\n- Use inline styles or an internal stylesheet, do not link to external stylesheets.\n- Link to images that are 300DPI and sized at the final desired size on the physical mailing. For example,\nfor a photo that is desired to be 1in x 1in on the final postcard, the image asset should be sized at 1in\nx 1in at 300DPI (which equates to 300px by 300px).\n- The sum of all linked assets should not exceed 5MB in file size.\n- Use `-webkit` prefixes for CSS properties when recommended <a href=\"http://shouldiprefix.com/\" target=\"_blank\">here</a>.\n\nBecause different browsers have varying user-agent styles, the HTML you see in your browser will not\nalways look identical to what is produced through the API. It is **strongly** recommended that you test all\nHTML requests by reviewing the final PDF files in your Test Environment, as these are the files that will be\nprinted.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Image Prepping\nCurrently we support the following file types for all endpoints:\n- PDF\n- PNG\n- JPEG\n\n**Templates**\n\nYou can find pre-made templates that already adhere to all of these guidelines here:\n- [Postcards](#tag/Postcards)\n- [Letters](#tag/Letters)\n- [Checks](#tag/Checks)\n- [Self Mailers](#tag/Self-Mailers)\n\n**Prepping All Images**\n\nThe following guidelines apply to image types:\n- Images should be 300 dpi or higher - PNG/JPEG files with less than 300 dpi will be rejected.\n- Your artwork should include a 1/8\" border around the final trim size. This means your final file size will be a total of 0.25\" larger than your expected printed piece (ie, a 4\"x6\" postcard should be submitted as 4.25\"x6.25\"). There is no need to include crop marks in your submitted content.\n- Include a safe zone – make sure no critical elements are within 1/8\" from the edge of the final size.\n- Do not include any additional postage marks or indicia.\n- File sizes should be no larger than 5MB.\n\n**Prepping PDFs**\n\nTo ensure that you are producing PDF's correctly please follow the guidelines below:\n- [Make sure all non-standard fonts are embedded.](#section/Standard-PDF-Fonts)\n- Generated PDF's need to be be PDF/A compliant.\n\n**Prepping PNGs/JPEGs**\n\nTo ensure that you are producing PNG's/JPEG's correctly please follow the guidelines below:\n\n- Minimum 300 dpi. The dpi is calculated as (width of image in pixels) / (width of product in inches) and (length of image in pixels) / (length of product in inches). For Example: 1275px x 1875px image used to create a 4.25\" x 6.25\" postcard has a dpi of 300.\n- Submitted images must have the same length to width ratio as the chosen product. Images will not be cropped or stretched by the API.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Standard PDF Fonts\nIdeally, all fonts in provided PDFs should be embedded. Embedding a font in a PDF ensures that the final\nprinted product will look as it was designed. Fonts can vary greatly in size and shape, even within the\nsame family. If the exact font that was used to design the artwork is not used to print, the look and\nplacement of the text is not guaranteed to be the same.\n\nIn general, requests that provide PDFs with un-embedded fonts will be rejected. We make an exception for\n\"standard fonts\", a set of fonts that we have identified as being common. PDFs that contain un-embedded\nfonts that are found in the list, and match the accepted <a href=\"https://en.wikipedia.org/wiki/Category:Font_formats\" target=\"_blank\">font type</a>\nwill be accepted. Otherwise, the request will be rejected.\n\nFont embedding is an essential part of standard PDF workflows. Fonts should be embedded automatically by\nPDF editing software that are compliant with PDF standards.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">FONT NAME</th>\n    <th style=\"white-space: nowrap\">TYPES</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,BoldItalic</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-BoldItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialNarrow</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialNarrow-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri-Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-Oblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-BoldOblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPSMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPS-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPS-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-BoldOblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-Oblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>LucidaConsole</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>MsSansSerif</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>MsSansSerif,Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Symbol</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Tahoma</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Tahoma-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-BoldItalic</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Italic</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Roman</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-BoldItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPSMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPSMT,Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana,Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ZapfDingbats</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12419,7 +12473,7 @@
             "event": []
         },
         {
-            "id": "d8113146-eb8f-407c-952e-aa7203b0f2d8",
+            "id": "b596d33b-4789-4ffc-9434-7083e8b853ad",
             "name": "Template Versions",
             "description": {
                 "content": "These API endpoints allow you to create, retrieve, update and delete versions of reusable HTML templates for use with the Print & Mail API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12427,7 +12481,7 @@
             },
             "item": [
                 {
-                    "id": "59616659-8f4c-4e8e-9bfa-0200510b3a51",
+                    "id": "70e91f72-bd97-4026-8531-0f80f5443a0e",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -12474,7 +12528,7 @@
                     },
                     "response": [
                         {
-                            "id": "209a7bd3-29b2-4abf-933a-e6653e4cffc8",
+                            "id": "144d9d39-6e11-4e7e-bcfe-84c2dec99b86",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -12531,7 +12585,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1c57ad19-a2c5-45d2-9a53-a650581a8c08",
+                            "id": "ccb3c800-d018-43d4-a8fd-d65402142df5",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12591,7 +12645,7 @@
                     "event": []
                 },
                 {
-                    "id": "e70889b3-9632-4fe3-9e4e-b31d5cc2258e",
+                    "id": "a305f949-0845-451a-b785-3b00c3a41ac0",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -12657,7 +12711,7 @@
                     },
                     "response": [
                         {
-                            "id": "539f20b3-6a51-4dc6-82ca-d151da1ef5e5",
+                            "id": "d0f3bce0-4bb6-4ac6-a9cc-419b8abdf87e",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -12741,7 +12795,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1ac682ac-3476-4944-bfb5-96e94ee3c8d2",
+                            "id": "85cac575-c5da-42c9-9a03-e8486189e237",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12813,7 +12867,7 @@
                     }
                 },
                 {
-                    "id": "3d26ef66-6271-416d-9c52-b25cc6a8d60b",
+                    "id": "52feac88-403b-45af-9fed-698211381f09",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -12860,7 +12914,7 @@
                     },
                     "response": [
                         {
-                            "id": "8645b889-59b1-450b-9cc5-5581a6a1948d",
+                            "id": "4f180558-5faa-4eef-a679-ed90705d533b",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -12917,7 +12971,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e5adbeff-930f-404e-b1e9-a3dddee794e7",
+                            "id": "8ab0cba9-71b0-4cd7-a79d-f42ac9dfc8f2",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12977,7 +13031,7 @@
                     "event": []
                 },
                 {
-                    "id": "bde47046-6e34-4fab-94ea-068bdc7f4a17",
+                    "id": "e616da70-66aa-4c16-a2ba-22da33a6f3a9",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -13027,7 +13081,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -13053,7 +13113,7 @@
                     },
                     "response": [
                         {
-                            "id": "4c5caf5b-740c-46ce-bf0b-7a48c46444f6",
+                            "id": "551bac23-3338-4a58-a72d-19c2dff8f93c",
                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -13087,7 +13147,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -13127,7 +13187,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "aaf3226a-b394-409e-bb32-3e1d7a77ad57",
+                            "id": "7c5988be-4ff7-49e6-b448-fab13bf77ac8",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13161,7 +13221,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -13204,7 +13264,7 @@
                     "event": []
                 },
                 {
-                    "id": "756d0d03-3085-4002-8031-e2085d14e763",
+                    "id": "d1a2b985-0bd9-49af-a2c4-b82b8800e013",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -13268,7 +13328,7 @@
                     },
                     "response": [
                         {
-                            "id": "8a654e4a-fc17-4b05-be3a-6816640c4374",
+                            "id": "edda4c96-3d5a-4d3f-9d54-8fcbb8568154",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -13353,7 +13413,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a048475f-ff6f-4d6a-a17e-9f69c5534422",
+                            "id": "683ae32b-4796-4ab7-a857-c05fefbc2e6e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13429,7 +13489,7 @@
             "event": []
         },
         {
-            "id": "a7234250-4b6e-437e-9d4e-9aa3f058e6d4",
+            "id": "dca3ff53-b559-4606-9eaf-c91128b5094e",
             "name": "Templates",
             "description": {
                 "content": "These API endpoints allow you to create, retrieve, update and delete reusable HTML templates for use with the Print & Mail API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -13437,7 +13497,7 @@
             },
             "item": [
                 {
-                    "id": "f3f4e843-ee2d-49a6-91ef-ac7ffeb89b35",
+                    "id": "408abe5e-28d3-4bd3-9bc8-4f720a307a79",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -13475,7 +13535,7 @@
                     },
                     "response": [
                         {
-                            "id": "1d083d21-c7f5-4266-a41f-e6f63c9831b0",
+                            "id": "cb35e0bc-638b-4388-9ca6-c282e7042e94",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -13523,7 +13583,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8f277de6-2446-4b8d-b3dc-27cfbf5cc107",
+                            "id": "881ba9a7-c6b9-4a6a-a608-0f23959be105",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13574,7 +13634,7 @@
                     "event": []
                 },
                 {
-                    "id": "9039c64f-d203-452e-aa13-8bfddf93bdf4",
+                    "id": "cf4d98e4-554a-4c1e-aeac-1b97d9e02f9e",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -13631,7 +13691,7 @@
                     },
                     "response": [
                         {
-                            "id": "615efd47-9ea8-4e0a-b8b0-4335fac63448",
+                            "id": "734cac16-1315-4f83-8fef-ce4002a2e3dc",
                             "name": "Returns the updated template object",
                             "originalRequest": {
                                 "url": {
@@ -13711,7 +13771,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d48840a2-b312-4d16-b5d5-5280af0065f6",
+                            "id": "0d3f7211-1ef4-411c-9c6c-44c87cea5148",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13779,7 +13839,7 @@
                     }
                 },
                 {
-                    "id": "56e53cb0-f3ca-4973-bd26-c58e9f19106c",
+                    "id": "a939ed36-c6d4-44c9-b61a-577b36c202bf",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -13817,7 +13877,7 @@
                     },
                     "response": [
                         {
-                            "id": "89473b16-8502-436b-9c12-ed88c9c42f63",
+                            "id": "e4f6e6a2-fd98-4c5b-a027-6776163ddabf",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -13865,7 +13925,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "77d4b26b-7a72-4bdd-8e1c-c7ef4663880a",
+                            "id": "f7d0f1a9-1104-4ba6-aa17-5ecf178baa9e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13916,7 +13976,7 @@
                     "event": []
                 },
                 {
-                    "id": "8bd9e43d-cfa4-4017-9f58-bb9ee1839eb9",
+                    "id": "1a1e242b-2acb-4ee7-943d-df0ec950cbb0",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -13964,7 +14024,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[id812]",
+                                    "key": "date_created[voluptate_f6]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[laboruma]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -13982,7 +14048,7 @@
                     },
                     "response": [
                         {
-                            "id": "51092d93-3d89-496f-812b-acf3748b1190",
+                            "id": "0f0ae731-e6cb-456f-9609-15c1ea28bf20",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -14014,7 +14080,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -14046,7 +14112,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9f3ca9a5-1e6a-4b9b-bd00-c894b29f93a2",
+                            "id": "0711e393-b9e3-4b54-9cdf-65beeed38d30",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14078,7 +14144,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[id7c8]",
+                                            "key": "date_created[tempor_1f]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -14113,7 +14179,7 @@
                     "event": []
                 },
                 {
-                    "id": "22e837cc-281e-4ff1-ae9f-d5c55a40b8f5",
+                    "id": "591539a5-b0cf-4f59-83fb-7d605ca9cefd",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -14160,7 +14226,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "}Syjx:_6sWIet.~QyNpef6KGR S/z6R0l,B+k/Js;@EgSHT*|p<{o!i(d(r*j(N}1&u9zH0U,TnOEPQn`;!;NIG[vxZy1*X{%'pXaZjU[i)s"
+                                    "value": "24Akz&J>H-Mj$zrpmyTF!RwJ;&.w4 [X.oaBN_YwP6Oy'DmG7k hmDzTZO3&l3RV/zMGg`Isdh]k#BcwzR$Ld-5,)q-mlG--S7XW<Yv]6sIYgice_-1M>**dcm+i'a^M>_49zWcMXeM7kkF}AU9:J(MsC%5t,8!`_A|s;^ghz=h!c%4R)vl-#eIGH ; (T*`HO?w_oTAg;KD{R] =}l~*D?Rg*jLa{Q@M1#8e@^g:rqkw-,P-y=5WTd`PJZg;E0v0Y@6BtM^dJdXXu!J/iDjh3($wV`|.>5/( Z:Oy~3^,vmEX!MLmhbu96/Y-*4UPXSya?] [Zo<7Zovfx'"
                                 },
                                 {
                                     "disabled": false,
@@ -14172,7 +14238,7 @@
                     },
                     "response": [
                         {
-                            "id": "7e5f4c97-e665-4e0d-b84e-c40ec4f8a3f2",
+                            "id": "6a9534fb-d712-479b-a0a2-ddd8fa191ec6",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -14257,7 +14323,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d5863f92-69e4-431c-8712-1f8c29775ce8",
+                            "id": "61dae556-65f2-4944-8042-c7a391fe08fe",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14333,7 +14399,7 @@
             "event": []
         },
         {
-            "id": "41722b73-7766-4a39-bcc0-e6e3a29a93a9",
+            "id": "0c02c0bf-0606-437f-ab1f-c1880dcf9a36",
             "name": "Test and Live Environments",
             "description": {
                 "content": "To make the API as explorable as possible, accounts have test and live\nenvironment API keys. You're not charged any fees in the test environment,\nso we encourage you to use it to try out services, perform quality\nassurance, and run automated testing. Objects―addresses, letters, checks,\netc―in one environment cannot be manipulated by objects in the other.\n\nIn general, a payment method (either credit card or ACH account) must be\nadded to your account to make live API requests. However, a payment method\nis not required for the first 300 live requests per month to the\n`/v1/us_verifications` endpoint. After the first 300 requests, you will\nbegin receiving errors with status code `403`.\n\nRequests made in the test environment always validate request arguments,\nsimulate live environment behavior, and enforce rate limits. _They never\nprint, mail nor, for verification services, verify addresses._ The US &\nInternational verification services trigger behavior with specific\nargument values, and, if you plan on using those, we recommend reading\n[US Verification Test Environment](#tag/US-Verifications-Test-Environment)\nand [Intl Verification Test Environment](#tag/Intl-Verifications-Test-Environment).\n\nTo switch between environments, use the appropriate key for that\nenvironment when performing a request. You can find each environment's API\nkey in your dashboard under Settings; test API keys are always prefixed\nwith `test_` and production API keys with `live_`.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -14343,7 +14409,7 @@
             "event": []
         },
         {
-            "id": "a1b7c71f-8f5f-407d-a879-69efd8690a4f",
+            "id": "584dda71-630a-4eb3-bb40-a0c8d3ebf564",
             "name": "Tracking Events",
             "description": {
                 "content": "As mailpieces travel through the mail stream, USPS scans their unique barcodes, and Lob processes these mail scans to generate tracking events.\n\n<h3>Certified Tracking Event Details</h3>\n\nLetters sent with USPS Certified Mail are fully tracked by USPS, and\ntherefore their [tracking events](#operation/tracking_event) have an\nadditional `details` object with more detailed information about the\ntracking event. The following table shows the potential values for\nthe fields in the `details` object mapped to the tracking event `name`.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">NAME</th>\n    <th style=\"white-space: nowrap\">EVENT</th>\n    <th style=\"white-space: nowrap\">DESCRIPTION</th>\n    <th style=\"white-space: nowrap\">ACTION REQUIRED</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Mailed</td>\n    <td style=\"white-space: nowrap\"><code>package_accepted</code></td>\n    <td>Package has been accepted into the carrier network for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_arrived</code></td>\n    <td>Package has arrived at an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_departed</code></td>\n    <td>Package has departed from an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_processing</code></td>\n    <td>Package is processing at an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_processed</code></td>\n    <td>Package has been processed at an intermediate location.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Local Area</td>\n    <td style=\"white-space: nowrap\"><code>package_in_local_area</code></td>\n    <td>Package is at a location near the end destination.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Processed For Delivery</td>\n    <td style=\"white-space: nowrap\"><code>delivery_scheduled</code></td>\n    <td>Package is scheduled for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Processed For Delivery</td>\n    <td style=\"white-space: nowrap\"><code>out_for_delivery</code></td>\n    <td>Package is out for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Pickup Available</td>\n    <td style=\"white-space: nowrap\"><code>pickup_available</code></td>\n    <td>Package is available for pickup at carrier location.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Delivered</td>\n    <td style=\"white-space: nowrap\"><code>delivered</code></td>\n    <td>Package has been delivered.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Re-Routed</td>\n    <td style=\"white-space: nowrap\"><code>package_forwarded</code></td>\n    <td>Package has been forwarded.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Returned to Sender</td>\n    <td style=\"white-space: nowrap\"><code>returned_to_sender</code></td>\n    <td>Package is to be returned to sender.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>address_issue</code></td>\n    <td>Address information is incorrect. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>contact_carrier</code></td>\n    <td>Contact the carrier for more information.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delayed</code></td>\n    <td>Delivery of package is delayed.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delivery_attempted</code></td>\n    <td>Delivery of package has been attempted. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delivery_rescheduled</code></td>\n    <td>Delivery of package has been rescheduled.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>location_inaccessible</code></td>\n    <td>Delivery location inaccessible to carrier. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>notice_left</code></td>\n    <td>Carrier left notice during attempted delivery. Follow carrier instructions on notice.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_damaged</code></td>\n    <td>Package has been damaged. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_disposed</code></td>\n    <td>Package has been disposed.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_held</code></td>\n    <td>Package held at carrier location. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_lost</code></td>\n    <td>Package has been lost. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_unclaimed</code></td>\n    <td>Package is unclaimed.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_undeliverable</code></td>\n    <td>Package is not able to be delivered.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>reschedule_delivery</code></td>\n    <td>Contact carrier to reschedule delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>other</code></td>\n    <td>Unrecognized carrier status.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -14353,7 +14419,7 @@
             "event": []
         },
         {
-            "id": "0c93c7e2-26b4-4257-986a-6ceb17357534",
+            "id": "75395e26-509c-4bbc-a844-70f7f45b35af",
             "name": "Uploads",
             "description": {
                 "content": "The uploads endpoint allows you to upload audience files that are then associated with a given campaign.\nAt this time, only CSV files are allowed. The API provides endpoints for creating uploads, uploading audience files,\nand marking uploaded files as ready for processing. The API also provides endpoints for downloading files that\ndescribe the results, both successful and not, of the processing.\n",
@@ -14361,7 +14427,7 @@
             },
             "item": [
                 {
-                    "id": "5a8f24d3-ca95-4d3e-b4a9-1f565af89e37",
+                    "id": "fe3260f4-1c13-42a5-87b3-82b2f3a886d3",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -14397,7 +14463,7 @@
                     },
                     "response": [
                         {
-                            "id": "8c64b363-5068-4296-927b-ed7a66c325d7",
+                            "id": "9b871b7f-b42f-4708-b363-a80023216971",
                             "name": "An array of matching uploads. Each entry in the array is a separate upload.",
                             "originalRequest": {
                                 "url": {
@@ -14444,7 +14510,7 @@
                     "event": []
                 },
                 {
-                    "id": "1b2f9851-740d-49e6-ae43-aa142231b482",
+                    "id": "02dff6e2-74f3-43f1-bf82-acd2178b591c",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -14486,7 +14552,7 @@
                     },
                     "response": [
                         {
-                            "id": "cdd7930d-e0e1-433a-92ac-185f28c18cbd",
+                            "id": "f1101883-a759-4941-b7ad-f0b0fd4cd0c9",
                             "name": "Upload created successfully",
                             "originalRequest": {
                                 "url": {
@@ -14533,7 +14599,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3819eee8-65e8-4b9f-b9d3-51901998e527",
+                            "id": "fab2b2ba-12d3-4229-afda-327d83997b6a",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -14575,7 +14641,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"sunt magna sint mollit\",\n        \"est dolore\"\n      ],\n      \"msg\": \"nulla fugiat laborum ut commodo\",\n      \"type\": \"veniam esse quis\"\n    },\n    {\n      \"loc\": [\n        \"Lorem ut sit\",\n        \"minim esse\"\n      ],\n      \"msg\": \"id dolore\",\n      \"type\": \"tempor\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"est consequat Ut eu\",\n        \"voluptate laborum\"\n      ],\n      \"msg\": \"eu\",\n      \"type\": \"magna est adipisicing ipsum\"\n    },\n    {\n      \"loc\": [\n        \"sit consequat\",\n        \"irure\"\n      ],\n      \"msg\": \"aliquip officia laborum nulla\",\n      \"type\": \"Lorem aliqua ea\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -14586,7 +14652,7 @@
                     }
                 },
                 {
-                    "id": "38cd6b6a-b492-4567-aae6-a1282024df78",
+                    "id": "fbb13160-d111-4536-961e-7eb33fed34b8",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -14624,7 +14690,7 @@
                     },
                     "response": [
                         {
-                            "id": "d8e58b8b-5e0a-4d64-9f9d-e257a26b6508",
+                            "id": "6b6ae257-439d-43c0-b295-f3de25eb6c78",
                             "name": "Returns an upload object",
                             "originalRequest": {
                                 "url": {
@@ -14672,7 +14738,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a58be58a-6937-4170-985f-ddca552a99df",
+                            "id": "f38dfcf8-dfda-4ba2-96fa-8c164c41f0ca",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -14720,7 +14786,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5795f872-78fa-4ca8-a6d4-0c807e90b830",
+                            "id": "e4e62806-9272-4653-b778-8d8971f40416",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -14763,7 +14829,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"velit ut\",\n        \"est dolor cupidatat laborum ex\"\n      ],\n      \"msg\": \"dolor esse\",\n      \"type\": \"Lorem in\"\n    },\n    {\n      \"loc\": [\n        \"proident quis\",\n        \"laborum sint\"\n      ],\n      \"msg\": \"eiusmod\",\n      \"type\": \"eiusmod\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"enim velit\",\n        \"commod\"\n      ],\n      \"msg\": \"sed in nisi irure Lorem\",\n      \"type\": \"ex do sit\"\n    },\n    {\n      \"loc\": [\n        \"labore minim incididunt elit\",\n        \"veniam\"\n      ],\n      \"msg\": \"consectetur ipsum sed nisi\",\n      \"type\": \"consectetur et\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -14771,7 +14837,7 @@
                     "event": []
                 },
                 {
-                    "id": "66815d8d-9a72-40a6-bf55-70f31be9ad6a",
+                    "id": "992dc310-2a7f-4548-8a75-00ab7b98b094",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -14822,7 +14888,7 @@
                     },
                     "response": [
                         {
-                            "id": "d1e03378-6080-42f2-80d1-d8336b527010",
+                            "id": "d7c10db5-e8db-4395-b0a6-64a135381aba",
                             "name": "Returns an upload object",
                             "originalRequest": {
                                 "url": {
@@ -14878,7 +14944,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5771ffa7-ad9c-4d50-a314-38b5653294ea",
+                            "id": "16bc1afe-ef3c-4ef1-b4a1-3828460061ba",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -14934,7 +15000,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9e1a2609-b3c2-4bc8-bfb5-dda206ed799e",
+                            "id": "64015643-c4ea-48c6-8050-9c146976e894",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -14985,7 +15051,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"velit ut\",\n        \"est dolor cupidatat laborum ex\"\n      ],\n      \"msg\": \"dolor esse\",\n      \"type\": \"Lorem in\"\n    },\n    {\n      \"loc\": [\n        \"proident quis\",\n        \"laborum sint\"\n      ],\n      \"msg\": \"eiusmod\",\n      \"type\": \"eiusmod\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"enim velit\",\n        \"commod\"\n      ],\n      \"msg\": \"sed in nisi irure Lorem\",\n      \"type\": \"ex do sit\"\n    },\n    {\n      \"loc\": [\n        \"labore minim incididunt elit\",\n        \"veniam\"\n      ],\n      \"msg\": \"consectetur ipsum sed nisi\",\n      \"type\": \"consectetur et\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -14996,7 +15062,7 @@
                     }
                 },
                 {
-                    "id": "23d1799f-3b24-4e41-a813-7bea772ea2b1",
+                    "id": "1e4ff87b-6b86-480c-96d7-5feb2c0c4e08",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -15028,7 +15094,7 @@
                     },
                     "response": [
                         {
-                            "id": "c51c895f-6528-4a22-80f2-dff453b090b4",
+                            "id": "dfd200f6-1356-4c68-98cc-7a69a95dd346",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -15079,7 +15145,7 @@
                     "event": []
                 },
                 {
-                    "id": "e980d6a8-9cf1-4a8a-acba-57de199e12d5",
+                    "id": "5f8d5399-44a3-4dd1-a710-c85703fa0d1f",
                     "name": "Upload file",
                     "request": {
                         "name": "Upload file",
@@ -15132,7 +15198,7 @@
                     },
                     "response": [
                         {
-                            "id": "7f372251-0c5a-41a3-8915-822ca4aeab39",
+                            "id": "347d7d44-e049-4412-a3e4-6ab5f042e77a",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -15189,12 +15255,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"message\": \"File uploaded successfully\",\n  \"filename\": \"nulla ad eu ullamco \"\n}",
+                            "body": "{\n  \"message\": \"File uploaded successfully\",\n  \"filename\": \"in ut Lorem ex\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c243cbfb-82b9-4798-b3f7-43532645d41c",
+                            "id": "a4dd667e-7b59-4fb1-a517-fb7384832c82",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15251,7 +15317,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"velit ut\",\n        \"est dolor cupidatat laborum ex\"\n      ],\n      \"msg\": \"dolor esse\",\n      \"type\": \"Lorem in\"\n    },\n    {\n      \"loc\": [\n        \"proident quis\",\n        \"laborum sint\"\n      ],\n      \"msg\": \"eiusmod\",\n      \"type\": \"eiusmod\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"enim velit\",\n        \"commod\"\n      ],\n      \"msg\": \"sed in nisi irure Lorem\",\n      \"type\": \"ex do sit\"\n    },\n    {\n      \"loc\": [\n        \"labore minim incididunt elit\",\n        \"veniam\"\n      ],\n      \"msg\": \"consectetur ipsum sed nisi\",\n      \"type\": \"consectetur et\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15262,7 +15328,7 @@
                     }
                 },
                 {
-                    "id": "1f7dc10d-c002-43e5-a08c-ea80332230cc",
+                    "id": "d800409b-aa9d-4fe6-8109-7d0c9e195228",
                     "name": "Create Export",
                     "request": {
                         "name": "Create Export",
@@ -15314,7 +15380,7 @@
                     },
                     "response": [
                         {
-                            "id": "d042ba62-f7a3-46bc-8238-935163f3429c",
+                            "id": "089964df-a624-4244-98c5-b0b3837b1bab",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -15371,7 +15437,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5543c132-d09e-41b3-950a-f143f984e086",
+                            "id": "34093a61-081f-4d66-a289-4e818368f8ef",
                             "name": "Create Export Error",
                             "originalRequest": {
                                 "url": {
@@ -15434,7 +15500,7 @@
                     }
                 },
                 {
-                    "id": "ecca9159-66c3-4105-b82c-131e9943809b",
+                    "id": "ed954ea7-b003-426c-b4eb-f980e0edf832",
                     "name": "Retrieve Export",
                     "request": {
                         "name": "Retrieve Export",
@@ -15481,7 +15547,7 @@
                     },
                     "response": [
                         {
-                            "id": "4947d1c0-c496-469f-b1b3-7b3c7e75684f",
+                            "id": "075d9b9e-1cc7-4bd1-bfb3-ba4719adf5e3",
                             "name": "Returns an export object",
                             "originalRequest": {
                                 "url": {
@@ -15544,7 +15610,7 @@
             "event": []
         },
         {
-            "id": "2ce2646e-a122-44c6-a020-c1a0808bf278",
+            "id": "99e1bd45-9a3f-422c-8608-cc441547fb64",
             "name": "US Autocompletions",
             "description": {
                 "content": "Given partial address information, this endpoint returns up to 10 address suggestions. <br> <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n## Autocompletion Test Env\nYour test API key does not autocomplete US addresses and is used to simulate behavior. With your test API key, requests with specific values for `address_prefix` return predetermined values. When `address_prefix` is set to:\n- `0 suggestions` - Returns no suggestions - `[PRIMARY NUMBER] s[uggestion]` - Returns a maximum of ten predefined suggested addresses.\n  `[PRIMARY NUMBER]` does not have to be a valid primary number when sending a test request.\n  Each additional letter in `suggestion` reduces the number of suggestions by one (e.g.\n  `1 su` returns 9 suggested addresses). `[PRIMARY NUMBER]` does not affect the number of\n  suggestions returned.\n\nCity and state filters work as expected and filter the list of predetermined suggested addresses.\nSee the `test` request & response examples under [Autocomplete Examples](#operation/autocompletion) within the \"Autocomplete a partial address\" section in US Autocompletions. <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -15552,7 +15618,7 @@
             },
             "item": [
                 {
-                    "id": "d5ccf806-1bfb-4c1c-98bc-916180ad0565",
+                    "id": "f01d0645-a81f-482b-9181-fdfb37f3ab9d",
                     "name": "Autocomplete",
                     "request": {
                         "name": "Autocomplete",
@@ -15633,7 +15699,7 @@
                     },
                     "response": [
                         {
-                            "id": "ff77c7c5-c1e5-4152-a636-bc4ddf4bada9",
+                            "id": "5c8ee3b0-f62d-4e79-9b61-c63a4bd05b2d",
                             "name": "Returns a US autocompletion object.",
                             "originalRequest": {
                                 "url": {
@@ -15748,7 +15814,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "13ecac53-f779-4406-adfe-1fdd107dbc77",
+                            "id": "cd64594a-7742-44df-9116-8372fd7e80cf",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -15854,7 +15920,7 @@
             "event": []
         },
         {
-            "id": "39838de5-830c-49ad-be1a-e15f238ffb6f",
+            "id": "34ca4499-da66-4615-bb08-b02932905914",
             "name": "US Verification Types",
             "description": {
                 "content": "These are detailed definitions for various fields in the [US verification object](#operation/us_verification).\n\n<h3>ZIP Code Types - <code>components[zip_code_type]</code></h3>\n\n<table>\n  <tbody>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>standard</code></td>\n      <td>The default ZIP code type. Used when none of the other types apply.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The ZIP code contains only PO Boxes.</td>\n    </tr>\n    <tr>\n      <td><code>unique</code></td>\n      <td>The ZIP code is uniquely assigned to a single organization (such as a government agency) that receives a large volume of mail.</td>\n    </tr>\n    <tr>\n      <td><code>military</code></td>\n      <td>The ZIP code contains military addresses.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>Record Types - <code>components[record_type]</code></h3>\n\n<table>\n  <tbody>\n    <tr>\n      <td><code>street</code></td>\n      <td>The default address type.</td>\n    </tr>\n    <tr>\n      <td><code>highrise</code></td>\n      <td>The address is a commercial building, apartment complex, highrise, etc.</td>\n    </tr>\n    <tr>\n      <td><code>firm</code></td>\n      <td>The address is of an organizational entity which receives a minimum number of mailpieces per day.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The address is a PO Box.</td>\n    </tr>\n    <tr>\n      <td><code>rural_route</code></td>\n      <td>The address exists on a Rural Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>general_delivery</code></td>\n      <td>The address is part of the USPS General Delivery service, which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>Carrier Route Types - <code>components[carrier_route_type]</code></h3>\n\n<table class=\"table-docs table-docs-code\">\n  <tbody>\n    <tr>\n      <td><code>city_delivery</code></td>\n      <td>The default carrier route type. Used when none of the other types apply.</td>\n    </tr>\n    <tr>\n      <td><code>rural_route</code></td>\n      <td>The carrier route is a Rural Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td><code>highway_contract</code></td>\n      <td>The carrier route is a Highway Contract Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The carrier route consists of PO Boxes.</td>\n    </tr>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>general_delivery</code></td>\n      <td>The carrier route is part of the USPS General Delivery service, which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>DPV Footnotes - <code>deliverability_analysis[dpv_footnotes]</code></h3>\n\n<table class=\"table-docs table-docs-code\">\n  <tbody>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>AA</code></td>\n      <td>Some parts of the address (such as the street and ZIP code) are valid.</td>\n    </tr>\n    <tr>\n      <td><code>A1</code></td>\n      <td>The address is invalid based on given inputs.</td>\n    </tr>\n    <tr>\n      <td><code>BB</code></td>\n      <td>The address is deliverable.</td>\n    </tr>\n    <tr>\n      <td><code>CC</code></td>\n      <td>The address is deliverable by removing the provided secondary unit designator.</td>\n    </tr>\n    <tr>\n      <td><code>N1</code></td>\n      <td>The address is deliverable but is missing a secondary information (apartment, unit, etc).</td>\n    </tr>\n    <tr>\n      <td><code>F1</code></td>\n      <td>The address is a deliverable military address.</td>\n    </tr>\n    <tr>\n      <td><code>G1</code></td>\n      <td>The address is a deliverable General Delivery address. General Delivery is a USPS service which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><code>U1</code></td>\n      <td>The address is a deliverable unique address. A unique ZIP code is assigned to a single organization (such as a government agency) that receives a large volume of mail.</td>\n    </tr>\n    <tr>\n      <td><code>M1</code></td>\n      <td>The primary number is missing.</td>\n    </tr>\n    <tr>\n      <td><code>M3</code></td>\n      <td>The primary number is invalid.</td>\n    </tr>\n    <tr>\n      <td><code>P1</code></td>\n      <td>PO Box, Rural Route, or Highway Contract box number is missing.</td>\n    </tr>\n    <tr>\n      <td><code>P3</code></td>\n      <td>PO Box, Rural Route, or Highway Contract box number is invalid.</td>\n    </tr>\n    <tr>\n      <td><code>R1</code></td>\n      <td>The address matched to a <a href=\"https://en.wikipedia.org/wiki/Commercial_mail_receiving_agency\" target=\"_blank\">CMRA</a> and private mailbox information is not present.</td>\n    </tr>\n    <tr>\n      <td><code>R7</code></td>\n      <td>The address matched to a Phantom Carrier Route (<code>carrier_route</code> of <code>R777</code>), which corresponds to physical addresses that are not eligible for delivery.</td>\n    </tr>\n    <tr>\n      <td><code>RR</code></td>\n      <td>The address matched to a <a href=\"https://en.wikipedia.org/wiki/Commercial_mail_receiving_agency\" target=\"_blank\">CMRA</a> and private mailbox information is present.</td>\n    </tr>\n  </tbody>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -15864,7 +15930,7 @@
             "event": []
         },
         {
-            "id": "dcc57ce3-6f11-4e3b-9f6a-2c1d50878311",
+            "id": "376ca465-9ebd-4717-a634-718e09b58924",
             "name": "US Verifications",
             "description": {
                 "content": "Validate, automatically correct, and standardize the addresses in your\naddress book based on USPS's <a href=\"https://postalpro.usps.com/certifications/cass\" target=\"_blank\">Coding Accuracy Support System (CASS)</a>.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## US Verifications Test Env\n\nWhen verifying US addresses, you'll likely want to test against a wide array of addresses to\nensure you're handling responses correctly. With your test API key, requests that use specific\nvalues for `address` or `primary_line` and (if using `primary_line`) an arbitrary five digit\nnumber for `zip_code` (e.g. \"11111\") let you explore the responses to many types of addresses:\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">ADDRESS TYPE FOR SAMPLE RESPONSE</th>\n    <th style=\"white-space: nowrap\">DELIVERABILITY</th>\n    <th style=\"white-space: nowrap\">SET <code>primary_line</code> OR <code>address</code> TO</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Commercial highrise</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>commercial highrise</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential highrise</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>residential highrise</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential house</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>residential house</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">PO Box</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>po box</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Rural route</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>rural route</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Puerty Rico address w/ urbanization</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>puerto rico</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Military address</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>military</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Department of state</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>department of state</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Generic deliverable</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Missing a suite number</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_missing_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>missing unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Suite number doesn't exist</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_incorrect_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>incorrect unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential house with unnecessary suite number</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_unnecessary_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>unnecessary unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Undeliverable and block matched</td>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>undeliverable block match</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Undeliverable and no block matched</td>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>undeliverable no match</code></td>\n  </tr>\n</table>\n\nSee the `test` request & response examples under [US Verification Examples](#operation/us_verification) within the\n\"Verify a US or US territory address\" section in US Verifications.\n\nYou can rely on the response from these examples generally matching the response you'd see in the live environment with an\naddress of that type (excluding the `recipient` field).\n\nThe test API key does not perform any verification, automatic correction, or standardization for addresses. If you wish to\ntry these features out, use our <a href=\"https://lob.com/address-verification\" target=\"_blank\">live demo</a> or the free plan (see <a href=\"https://lob.com/pricing/address-verification\" target=\"_blank\">our pricing</a> for details).\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -15872,7 +15938,7 @@
             },
             "item": [
                 {
-                    "id": "378a64c2-5416-4fd1-8893-3d07d4ab9bb3",
+                    "id": "fa8e84cc-4b97-47f9-83b4-51a54fbdd205",
                     "name": "Bulk Verify",
                     "request": {
                         "name": "Bulk Verify",
@@ -15924,7 +15990,7 @@
                     },
                     "response": [
                         {
-                            "id": "700d4969-0073-46be-b6f4-339d2738a9fa",
+                            "id": "4297534e-b101-46c8-8692-a1f538c0d219",
                             "name": "Returns a list of US verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -16009,7 +16075,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5c84e8b6-fbba-4d9e-aff2-f76acc4fca33",
+                            "id": "a5dc118f-6142-4aae-b5bd-c24267eef5da",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16082,7 +16148,7 @@
                     }
                 },
                 {
-                    "id": "dd0cf1d5-b6f4-4991-8318-ce740535fe53",
+                    "id": "eca344d5-7869-4f04-8747-7ee44c589816",
                     "name": "Single Verify",
                     "request": {
                         "name": "Single Verify",
@@ -16162,7 +16228,7 @@
                     },
                     "response": [
                         {
-                            "id": "ec35bef6-31a3-431f-94da-bdba0c33deac",
+                            "id": "52bdde58-79ea-4101-9c71-3a7c90a5567a",
                             "name": "Returns a US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -16248,7 +16314,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ce46b942-d70b-41dc-a0f6-1ce7a1c21c34",
+                            "id": "93b4fbb4-071b-4efa-bbe5-5e8a4b93bde6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16325,7 +16391,7 @@
             "event": []
         },
         {
-            "id": "bfc69aa3-d92b-4c99-bd35-6474fd09e42d",
+            "id": "7918bad8-8934-4f5f-81ec-1df8ed74bc49",
             "name": "Versioning and Changelog",
             "description": {
                 "content": "### API Versioning\n\nWhen backwards-incompatible changes are made to the API, a new dated version\nis released. The latest version of the API is version **2020-02-11**. You can\nview your version and upgrade to the latest version in your\n<a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Dashboard Settings</a>. You will\nonly need to specify a version if you would like to test a newer version of\nthe API without doing a full upgrade. The API will return an error if a\nversion older than your current one is passed in. See\n[API Changelog](#tag/Versioning-and-Changelog) for a full list of breaking changes.\n\n### Example Request\n\n```bash\n  curl https://api.lob.com/v1/addresses \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -H \"Lob-Version: 2020-02-11\"\n```\n\n### Specification Versioning\nYou might be wondering why our API and specification use different versioning schemes.\nLob's API predates our specification and follows the <a href=\"https://stripe.com/blog/api-versioning\" target=\"_blank\">Stripe versioning</a>\napproach. This works well to manage backwards-incompatible changes to our API.\n\nFor our API specification (used to create this documentation), we've chosen <a href=\"https://semver.org/\" target=\"_blank\">semantic\nversioning</a>. This versioning reflects the backward-compatible\nchanges that do not require a versioning of Lob's API.\n\nLob's API specification will be used to generate artifacts like documentation, client SDKs,\nand other developer tooling. Semantic versioning of our specification will inform how we\nversion those artifacts like SDKs. It is helpful to know the version of a specification\nused to produce an artifact in order reference the specification release notes.\n\n\n### Changelog\n\n**2020-02-11**\n- renders merge_variables into HTML with syntax that supports objects, conditionals, and loops\n\n**2019-06-01** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- changed pagination model of GET endpoints for postcards, letters, checks, addresses, bank accounts, templates, and template versions to a cursor-based model\n- offset parameter on these endpoints has been removed\n- previous_url and next_url response fields have been added\n\n**2018-06-05** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- remove rate-limit headers\n\n**2018-03-30** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- updated letter template which includes a white box behind the address block area to ensure deliverability\n\n**2018-03-01** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- US verification deliverability value no_match deprecated and merged into undeliverable\n- US verification deliverability value deliverable_extra_secondary is split into deliverable_unnecessary_unit and deliverable_incorrect_unit\n- US verification deliverability value deliverable_missing_secondary renamed to deliverable_missing_unit\n- US verifications zip_code special values deprecated in favor of more comprehensive primary_line special values\n\n**2018-02-08** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- enforce 50 character limit on the sum of address_line1 and address_line2 for check recipients\n\n**2017-11-08** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- split extra_secondary_information into extra_secondary_designator and extra_secondary_number for /v1/us_verifications\n\n**2017-10-17** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- remove support for the /v1/states endpoint\n- remove support for the /v1/countries endpoint\n- remove support for the message field from the POST /v1/postcards endpoint\n\n**2017-09-08** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- renames input parameters and restructures response object for /v1/intl_verifications\n\n**2017-08-14** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- automatically standardizes and corrects US addresses created via POST /v1/addresses. non-US addresses will be standardized into uppercase only.\n- automatically standardizes and corrects inline US addresses used in POST /v1/postcards, POST /v1/letters, and POST /v1/checks. non-US addresses will be standardized into uppercase only.\n- enforce 40 character limit on name and company for all addresses\n- enforce 64 character limit on address_line1 and address_line2 for US addresses\n\n**2017-06-16** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- enforce 10,000 character limit on HTML strings\n- rename data parameter for all products to merge_variables\n\n**2017-05-17** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- discontinues the /v1/verify endpoint - please use /v1/us_verifications or /v1/intl_verifications instead\n\n**2016-06-30** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- unnest tracking object from postcard, letter, and check response objects\n\n**2016-05-02** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- adds address_placement parameter to letters that defaults to top_first_page, template is no longer allowed\n\n**2016-03-21** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- removes tracking numbers that do not provide any consumer-facing tracking information\n- removes link from tracking responses\n- requires account_type when creating a bank account\n\n**2016-01-19** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- renames the count parameter to limit for all list endpoints\n- removes the next_url and previous_url from list responses\n\n**2015-12-22** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- adds size parameter to postcards that defaults to 4x6, setting is no longer allowed\n\n**2015-11-23** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- remove price from letters\n- remove pages from letters\n- remove price from postcards\n- renamed file parameter to check_bottom for checks\n\n**2015-11-06** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- remove bank_address from bank_accounts\n- remove account_address from bank_accounts and add from to checks\n- remove price from checks\n\n**2015-10-21** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- use the new HTML renderer for all products\n\n**2015-06-25** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- remove the status field from all endpoints\n\n**2015-04-11** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- errors on all endpoints are now single objects instead of arrays\n- full_bleed is no longer allowed for postcards, objects, and area mails - all products are now full_bleed by default\n- template is no longer allowed for postcards - all postcards must adhere to the template\n- name is no longer allowed for area mails, bank accounts, checks, jobs, objects, and postcards - it has been replaced by description\n- setting ID's 100 and 101 are no longer supported for objects - please use the Simple Letter Service instead\n- service is no longer supported for jobs\n- all boolean parameters now return true/false instead of 1/0\n- double_sided is no longer allowed for objects - all products are default double sided if more than one page is allowed\n- template is no longer allowed for objects\n\n**2014-12-18** <span style=\"background: #ebf2fb;color: #1878e0;text-transform: none;letter-spacing: 1px;font-weight: 500;border-radius: 100px;padding: 6px 16px;font-size: 14px;\">Sunsetted</span>\n- removed concept of packaging\n- signatory is now a required field when creating a bank account\n- bank_code is no longer an allowed field when creating a bank account\n- service_id parameter replaced by service parameter in /jobs\n- setting_id parameter replaced by setting parameter in /objects\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -16335,7 +16401,7 @@
             "event": []
         },
         {
-            "id": "2ee12787-5d9b-433a-ad2a-316467fcc3a7",
+            "id": "b626c2fa-4a1e-4b2f-ae77-15aec3642c3f",
             "name": "Webhooks",
             "description": {
                 "content": "Webhooks are an easy way to get notifications on events happening asynchronously\nwithin Lob's architecture. For example, when a postcard gets a \"Processed For\nDelivery\" tracking event, an event object of type `postcard.processed_for_delivery`\nwill be created. If you are subscribed to that event type in that Environment\n(Test vs. Live), Lob will send that event to any URLs you've specified via an\nHTTP POST request. In Live mode, you can only have as many webhooks as allotted\nin your current <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>.\nThere is no limit in Test mode.\nYou can view and create <a href=\"https://dashboard.lob.com/#/webhooks\" target=\"_blank\">webhooks</a> on the\nLob Dashboard, as well as view your <a href=\"https://dashboard.lob.com/#/events\" target=\"_blank\">events</a>.\nSee our <a href=\"https://help.lob.com/print-and-mail/getting-data-and-results/using-webhooks\" target=\"_blank\">Webhooks Integration Guide</a> for more\ndetails on how to integrate. Please see the full list of event types available for\nsubscription here.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -16345,7 +16411,7 @@
             "event": []
         },
         {
-            "id": "4a9dab6c-1c48-4353-aad7-3e38ca390add",
+            "id": "10585473-0ebe-4e65-9edf-f45ee68948ca",
             "name": "Zip Lookups",
             "description": {
                 "content": "Find a list of cities, states and associated information about a US ZIP code. <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -16353,7 +16419,7 @@
             },
             "item": [
                 {
-                    "id": "65388823-f6fa-4539-9a66-e956dcbc6bb7",
+                    "id": "e5de2a31-f177-4fce-a9cb-09dc601d8642",
                     "name": "Lookups",
                     "request": {
                         "name": "Lookups",
@@ -16397,7 +16463,7 @@
                     },
                     "response": [
                         {
-                            "id": "c243249c-634e-4d8d-9fea-f4abdc731581",
+                            "id": "f8285dab-fade-4445-9819-20c7c0b5f940",
                             "name": "Returns a zip lookup object if a valid zip was provided.",
                             "originalRequest": {
                                 "url": {
@@ -16467,7 +16533,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5ca2700d-7729-48b7-9939-d1ded741656c",
+                            "id": "c42e236a-dfcd-41a9-9e39-51bffa2c8ff8",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16550,7 +16616,7 @@
         ]
     },
     "info": {
-        "_postman_id": "7218979a-e443-4bd6-a3ea-c90a44e3372e",
+        "_postman_id": "ec934d21-79ec-4267-8e44-96f02cc3ba0f",
         "name": "Lob",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/resources/creatives/attributes/back.yml
+++ b/resources/creatives/attributes/back.yml
@@ -1,0 +1,23 @@
+description: >
+  The artwork to use as the back of your postcard creative.
+
+
+  Notes:
+
+  - HTML merge variables should not include delimiting whitespace.
+
+  - PDF, PNG, and JPGs must be sized at 4.25"x6.25", 6.25"x9.25", or
+  6.25"x11.25" at 300 DPI, while supplied HTML template will be rendered to the
+  specified `size`.
+
+  - Be sure to leave room for address and postage information by following the
+  templates provided here:
+    - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/postcards/4x6_postcard.pdf" target="_blank">4x6 template</a>
+    - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/postcards/6x9_postcard.pdf" target="_blank">6x9 template</a>
+    - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/postcards/6x11_postcard.pdf" target="_blank">6x11 template</a>
+
+
+  See [here](#section/HTML-Examples) for HTML examples.
+oneOf:
+  - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+  - $ref: "../../../shared/attributes/local_file_path.yml"

--- a/resources/creatives/attributes/file.yml
+++ b/resources/creatives/attributes/file.yml
@@ -1,0 +1,32 @@
+description: >-
+  Notes:
+
+  - HTML merge variables should not include delimiting whitespace.
+
+  - All pages of a supplied PDF file must be sized at 8.5"x11",
+  while supplied HTML will be rendered and trimmed to as many 8.5"x11" pages
+  as necessary.
+
+  - For design specifications, please see our
+  <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_template.pdf" target="_blank">PDF</a>
+  and [HTML](#section/HTML-Examples) templates.
+
+  - If a `custom_envelope` is used, follow
+  <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_custom_envelope.pdf" target="_blank">this template</a>.
+
+  - For domestic destinations, the file limit is 60 pages single-sided or 120
+  pages double-sided. For international destinations, the file limit is 6
+  pages single-sided or 12 pages double-sided. PDFs that surpass the file
+  limit will error, while HTML that renders more pages than the file limit
+  will be trimmed.
+
+  - Any letters over 6
+  pages single-sided or 12 pages double-sided will be placed in a
+  <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_flat_template.pdf" target="_blank">flat envelope</a> instead of the standard double window envelope.
+
+
+  See <a href="https://lob.com/pricing/print-mail#compare" target="_blank">pricing</a> for extra costs incurred.
+
+oneOf:
+  - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+  - $ref: "../../../shared/attributes/local_file_path.yml"

--- a/resources/creatives/attributes/front.yml
+++ b/resources/creatives/attributes/front.yml
@@ -1,0 +1,17 @@
+description: >
+  The artwork to use as the front of your postcard.
+
+
+  Notes:
+
+  - HTML merge variables should not include delimiting whitespace.
+
+  - PDF, PNG, and JPGs must be sized at 4.25"x6.25", 6.25"x9.25", or
+  6.25"x11.25" at 300 DPI, while supplied HTML template will be rendered to the
+  specified `size`.
+
+
+  See [here](#section/HTML-Examples) for HTML examples.
+oneOf:
+  - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+  - $ref: "../../../shared/attributes/local_file_path.yml"

--- a/resources/creatives/models/creative_writable.yml
+++ b/resources/creatives/models/creative_writable.yml
@@ -18,10 +18,10 @@ oneOf:
             $ref: "../../campaigns/attributes/cmp_id.yml"
 
           front:
-            $ref: "../../postcards/attributes/front.yml"
+            $ref: "../attributes/front.yml"
 
           back:
-            $ref: "../../postcards/attributes/back.yml"
+            $ref: "../attributes/back.yml"
 
           details:
             $ref: "postcard_details.yml#/writable"
@@ -46,5 +46,5 @@ oneOf:
           details:
             $ref: "letter_details.yml#/writable"
           file:
-            $ref: "../../letters/attributes/file.yml"
+            $ref: "../attributes/file.yml"
       - $ref: "creative_base.yml"


### PR DESCRIPTION
Fixes [#2194](https://lobsters.atlassian.net/browse/PMAPI-2194)

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [x] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect

## Changes
Update the attributes for creative artwork assets (front, back, file) to specify that only html template ID and local file path are valid methods of "uploading" artwork for a creative.

## Areas of Concern (optional)
