### PR TITLE
GC-1466/adds self mailer qr codes documentation

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -6075,7 +6075,9 @@ components:
         international destinations.
       default: 4x6
     returned:
-      description: Properties that the postcards in your Creative should have.
+      description: >-
+        Properties that the postcards in your Creative should have. Check within
+        in order to add a QR code to your creative.
       properties:
         mail_type:
           $ref: '#/components/schemas/mail_type'
@@ -6195,7 +6197,9 @@ components:
           * `registered` - provides tracking and confirmation for international addresses
       nullable: true
     letter_details_returned:
-      description: Properties that the letters in your Creative should have.
+      description: >-
+        Properties that the letters in your Creative should have. Check within
+        in order to add a QR code to your creative.
       properties:
         address_placement:
           $ref: '#/components/schemas/address_placement'
@@ -6232,6 +6236,38 @@ components:
           type: string
         mail_type:
           $ref: '#/components/schemas/mail_type'
+    self_mailer_size:
+      type: string
+      enum:
+        - 6x18_bifold
+        - 11x9_bifold
+        - 12x9_bifold
+        - 17.75x9_trifold
+      description: >-
+        Specifies the size of the self mailer. The `17.75x9_trifold` size is in
+        beta. Contact support@lob.com or your account contact to learn more.
+      default: 6x18_bifold
+    self_mailer_details_returned:
+      description: >-
+        Properties that the self mailers in your Creative should have. Check
+        within in order to add a QR code to your creative.
+      properties:
+        mail_type:
+          $ref: '#/components/schemas/mail_type'
+        size:
+          $ref: '#/components/schemas/self_mailer_size'
+        inside_original_url:
+          description: The original URL of the `inside` template.
+          maxLength: 2083
+          minLength: 1
+          type: string
+          format: uri
+        outside_original_url:
+          description: The original URL of the `outside` template.
+          maxLength: 2083
+          minLength: 1
+          type: string
+          format: uri
     returned_resource:
       oneOf:
         - allOf:
@@ -6262,6 +6298,20 @@ components:
                     - letter
                 details:
                   $ref: '#/components/schemas/letter_details_returned'
+            - $ref: '#/components/schemas/creative_base'
+        - allOf:
+            - title: Self Mailer Creative
+              required:
+                - resource_type
+                - details
+              properties:
+                resource_type:
+                  type: string
+                  description: Mailpiece type for the creative
+                  enum:
+                    - self_mailer
+                details:
+                  $ref: '#/components/schemas/self_mailer_details_returned'
             - $ref: '#/components/schemas/creative_base'
     crv_id:
       type: string
@@ -7713,7 +7763,7 @@ components:
     qr_code_campaigns:
       type: object
       description: >-
-        Customize and place a QR code on all the postcards, letters or self mailers in a
+        Customize and place a QR code on all the postcards and letters in a
         campaign. Redirect URLs can either be unique for each recipient, or a
         single link can be used for the whole campaign. See `redirect_url`
         attribute below for more details.
@@ -7724,8 +7774,11 @@ components:
         position:
           type: string
           enum:
-            - relative
-          description: Sets how a QR code is being positioned in the document.
+            - relative, fixed
+          description: >-
+            Sets how a QR code is being positioned in the document. When using
+            position 'relative', you should provide one of 'top' or 'bottom',
+            and one of 'left' or 'right'.
         top:
           type: string
           description: Vertical distance (in inches) to place QR code from the top.
@@ -7757,17 +7810,25 @@ components:
         width:
           type: string
           description: >-
-            The size(in inches) of the QR code with a minimum of 1 inch. All QR
+            The size (in inches) of the QR code with a minimum of 1 inch. All QR
             codes are generated as a square.
         pages:
           type: string
           description: >-
             Specify the pages where the QR code should be stamped in a comma
-            separated format. For postcards, the values should be either
-            `front`, `back`, or `front,back`. For letters, the values can be
-            specific page numbers or page number ranges.
+            separated format. Your QR code can be printed in the same position
+            on multiple pages. For postcards, the values should either be
+            "front", "back" (for either front or back) or "front,back" (for the
+            QR code to be printed on both sides). For self-mailers, the values
+            should either be "inside", "outside" (for either inside or outside)
+            or "inside,outside" (for the QR code to be printed on both sides).
+            For letters, the values can be specific page numbers ("1", "3"),
+            page number ranges such as "1-3", or a comma separated combination
+            of both ("1,3,5-7").
     writable:
-      description: Properties that the postcards in your Creative should have.
+      description: >-
+        Properties that the postcards in your Creative should have. Check within
+        in order to add a QR code to your creative.
       required:
         - color
       properties:
@@ -7797,7 +7858,9 @@ components:
       nullable: true
       pattern: ^env_[a-zA-Z0-9]+$
     letter_details_writable:
-      description: Properties that the letters in your Creative should have.
+      description: >-
+        Properties that the letters in your Creative should have. Check within
+        in order to add a QR code to your creative.
       required:
         - color
       properties:
@@ -8920,19 +8983,22 @@ components:
           type: string
           enum:
             - relative
-          description: Sets how a QR code is being positioned in the document.
+          description: >-
+            Sets how a QR code is being positioned in the document. When using
+            position 'relative', you should provide one of 'top' or 'bottom',
+            and one of 'left' or 'right'.
         top:
           type: string
-          description: Vertical distance(in inches) to place QR code from the top.
+          description: Vertical distance (in inches) to place QR code from the top.
         right:
           type: string
-          description: Horizonal distance(in inches) to place QR code from the right.
+          description: Horizonal distance (in inches) to place QR code from the right.
         left:
           type: string
           description: Horizonal distance(in inches) to place QR code from the left.
         bottom:
           type: string
-          description: Vertical distance(in inches) to place QR code from the bottom.
+          description: Vertical distance (in inches) to place QR code from the bottom.
         redirect_url:
           type: string
           description: >-
@@ -8941,16 +9007,21 @@ components:
         width:
           type: string
           description: >-
-            The size(in inches) of the QR code with a minimum of 1 inch. All QR
+            The size (in inches) of the QR code with a minimum of 1 inch. All QR
             codes are generated as a square.
         pages:
           type: string
           description: >-
             Specify the pages where the QR code should be stamped in a comma
-            separated format. For postcards, the values should be either
-            `front`, `back`, or `front,back`. For letters, the values can be
-            specific page numbers or page number ranges. For selfmailers, the
-            values should be either `inside`, `outside`, or `inside,outside`.
+            separated format. Your QR code can be printed in the same position
+            on multiple pages. For postcards, the values should either be
+            "front", "back" (for either front or back) or "front,back" (for the
+            QR code to be printed on both sides). For self-mailers, the values
+            should either be "inside", "outside" (for either inside or outside)
+            or "inside,outside" (for the QR code to be printed on both sides).
+            For letters, the values can be specific page numbers ("1", "3"),
+            page number ranges such as "1-3", or a comma separated combination
+            of both ("1,3,5-7").
     letter_editable:
       allOf:
         - $ref: '#/components/schemas/input_to'
@@ -9359,17 +9430,6 @@ components:
       type: string
       description: Unique identifier prefixed with `sfm_`.
       pattern: ^sfm_[a-zA-Z0-9]+$
-    self_mailer_size:
-      type: string
-      enum:
-        - 6x18_bifold
-        - 11x9_bifold
-        - 12x9_bifold
-        - 17.75x9_trifold
-      description: >-
-        Specifies the size of the self mailer. The `17.75x9_trifold` size is in
-        beta. Contact support@lob.com or your account contact to learn more.
-      default: 6x18_bifold
     self_mailer_base:
       allOf:
         - $ref: '#/components/schemas/editable'

--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -7763,7 +7763,7 @@ components:
     qr_code_campaigns:
       type: object
       description: >-
-        Customize and place a QR code on all the postcards and letters in a
+        Customize and place a QR code on all the postcards, letters or self mailers in a
         campaign. Redirect URLs can either be unique for each recipient, or a
         single link can be used for the whole campaign. See `redirect_url`
         attribute below for more details.

--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -7713,7 +7713,7 @@ components:
     qr_code_campaigns:
       type: object
       description: >-
-        Customize and place a QR code on all the postcards and letters in a
+        Customize and place a QR code on all the postcards, letters or self mailers in a
         campaign. Redirect URLs can either be unique for each recipient, or a
         single link can be used for the whole campaign. See `redirect_url`
         attribute below for more details.

--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -7714,7 +7714,7 @@ components:
       type: object
       description: >-
         Customize and place a QR code on all the postcards and letters in a
-        campaign. Redirect URLs can either be unqiue for each recipient, or a
+        campaign. Redirect URLs can either be unique for each recipient, or a
         single link can be used for the whole campaign. See `redirect_url`
         attribute below for more details.
       required:
@@ -7728,16 +7728,16 @@ components:
           description: Sets how a QR code is being positioned in the document.
         top:
           type: string
-          description: Vertical distance(in inches) to place QR code from the top.
+          description: Vertical distance (in inches) to place QR code from the top.
         right:
           type: string
-          description: Horizonal distance(in inches) to place QR code from the right.
+          description: Horizonal distance (in inches) to place QR code from the right.
         left:
           type: string
-          description: Horizonal distance(in inches) to place QR code from the left.
+          description: Horizonal distance (in inches) to place QR code from the left.
         bottom:
           type: string
-          description: Vertical distance(in inches) to place QR code from the bottom.
+          description: Vertical distance (in inches) to place QR code from the bottom.
         redirect_url:
           description: >
             Redirect all mail receipients to either a single URL or a custom

--- a/dist/lob-api-postman.json
+++ b/dist/lob-api-postman.json
@@ -1,7 +1,7 @@
 {
     "item": [
         {
-            "id": "2f15b3bf-72aa-4a55-ade9-4070efc4cd1a",
+            "id": "7e2d576a-db6a-4eb8-a852-ed1e053c1ce2",
             "name": "Addresses",
             "description": {
                 "content": "To add an address to your address book, you create a new address object. You can retrieve and delete individual\naddresses as well as get a list of addresses. Addresses are identified by a unique random ID.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -9,7 +9,7 @@
             },
             "item": [
                 {
-                    "id": "6ec8a541-6414-4409-a6cc-65ff026df4f2",
+                    "id": "17604674-b7d8-46c9-8c20-af2ef1d13078",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -57,19 +57,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -87,7 +99,7 @@
                     },
                     "response": [
                         {
-                            "id": "a4b869c9-51fa-4a45-92e6-1baa00d84766",
+                            "id": "539b1b13-2036-4ad4-9597-a9e0661faddf",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -119,11 +131,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -155,7 +163,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fed42960-c3d8-490c-aefd-843afe0149ac",
+                            "id": "2d2bfb76-b3c9-414b-be37-3bb2dcabecb5",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -187,11 +195,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -226,7 +230,7 @@
                     "event": []
                 },
                 {
-                    "id": "c2803e1f-f5bd-45b4-87b2-3e5406ccd447",
+                    "id": "10355eb9-f938-40d1-8662-7dc329031f91",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -289,7 +293,7 @@
                     },
                     "response": [
                         {
-                            "id": "be727ded-163e-4aff-86d3-fc27bd4801b3",
+                            "id": "b8bc98c2-8eb3-4f26-8a9e-58caa5255e4f",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -405,7 +409,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3903ed02-0db4-489f-8538-0091abca5804",
+                            "id": "41ef4b53-dc03-4a27-80b5-93f6168c3dad",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -509,7 +513,7 @@
                     }
                 },
                 {
-                    "id": "cd2d956a-0fa7-4bd4-96b8-1af97786ddcd",
+                    "id": "83a6b258-25b2-44ef-9afa-3252d323711e",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -547,7 +551,7 @@
                     },
                     "response": [
                         {
-                            "id": "a029cdc7-7bb9-491f-a404-6f8551700798",
+                            "id": "b9d980d5-2773-476d-b065-be95aa15c025",
                             "name": "Returns an address object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -595,7 +599,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1dae0b2e-75ef-4f2f-a365-15d0557b0dde",
+                            "id": "670ce562-177a-4fbf-9d78-b939ae223c79",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -646,7 +650,7 @@
                     "event": []
                 },
                 {
-                    "id": "d9df20e9-b663-47b6-adb2-21d6014401e7",
+                    "id": "0df4ec4b-7d9c-4961-bf4c-e9b0f725b895",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -684,7 +688,7 @@
                     },
                     "response": [
                         {
-                            "id": "10d93e2d-0201-4c26-9364-00c90ff6a7bb",
+                            "id": "2cab0147-f2f1-4441-b1df-9b295ddde5ee",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -732,7 +736,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9a6af711-94f2-4e5e-b055-84225ed4b02d",
+                            "id": "c1a78e61-1d2a-4a33-b607-385409bd54ef",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -786,7 +790,7 @@
             "event": []
         },
         {
-            "id": "77f48079-72d1-4360-8fd1-4c43a2fa62f3",
+            "id": "9c3a0872-74e3-429b-9dff-8a7c37061e49",
             "name": "Authentication",
             "description": {
                 "content": "Requests made to the API are protected with <a href=\"https://en.wikipedia.org/wiki/Basic_access_authentication\" target=\"_blank\">HTTP Basic authentication</a>.\nIn order to properly authenticate with the API you must use your API key as the username\nwhile leaving the password blank. Requests not properly authenticated will return a `401`\n[error code](#tag/Errors). You can find your account's API keys\nin your <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Dashboard Settings</a>.\n### Example Request\ncurl uses the -u flag to pass basic auth credentials (adding a colon after your API key will prevent it from asking you for a\npassword). One of our test API keys has been filled into all the examples on the page, so you can test out any example right away.\n```bash\ncurl https://api.lob.com/v1/addresses \\\n  -u test_0dc8dXXXXXXXXXXXXXXXXXXXXXX5b0cc:\n```\n## API Keys\n  Lob authenticates your API requests using your account's API keys.\n  If you do not include your key when making an API request, or use\n  one that is incorrect or outdated, Lob returns an error with a `401`\n  HTTP response code. You can find all API keys in your dashboard\n  under <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Settings</a>.\n  There are two types of API keys: *secret* and *publishable*.\n  - **Secret API keys** should be kept confidential and only stored on your own servers.\n  Your account's secret API key can perform any API request to Lob without restriction.\n  - **Publishable API keys** are limited to US verifications, international verifications,\n  and US autocomplete requests. For maximum security, we encourage you to not expose your \n  secret key. You can include the publishable keys in JavaScript code or in an Android or iPhone app\n  without exposing your Lob Print and Mail account services or your secret key. Publishable keys are always\n  prefixed with `[environment]_pub`.\n  Every type comes with a pair of keys: one for the testing environment and one for the\n  live environment. We recommend reading [Test and Live Environments](#tag/Test-and-Live-Environments)\n  for more information.\n  <br><br>\n  <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -796,7 +800,7 @@
             "event": []
         },
         {
-            "id": "d542d229-6887-45dc-81d3-0cd5d608ec25",
+            "id": "0b5a86c8-36de-4546-88b5-7849cc7635dc",
             "name": "Bank Accounts",
             "description": {
                 "content": "Bank Accounts allow you to store your bank account securely in our system. The API provides\nendpoints for creating bank accounts, deleting bank accounts, verifying bank accounts,\nretrieving individual bank accounts, and retrieving a list of bank accounts.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -804,7 +808,7 @@
             },
             "item": [
                 {
-                    "id": "dcaf56fb-a273-46fc-83b3-a1316406765f",
+                    "id": "64fea7e7-2fb0-4c3d-98b5-7767990c27b6",
                     "name": "Verify",
                     "request": {
                         "name": "Verify",
@@ -864,7 +868,7 @@
                     },
                     "response": [
                         {
-                            "id": "68c7d270-3905-40e6-990b-d2ef37f21960",
+                            "id": "0de66f1a-7b81-426b-b351-f3208f8c95c2",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -953,7 +957,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d9042bc0-3954-488c-835b-b03c84e1351f",
+                            "id": "9a537064-cdc1-4c1e-a010-a56877d346b0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1030,7 +1034,7 @@
                     }
                 },
                 {
-                    "id": "d369616e-87ca-4d07-b4f5-74715f78744a",
+                    "id": "63976248-8f44-4535-9183-edc7ef95e829",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -1068,7 +1072,7 @@
                     },
                     "response": [
                         {
-                            "id": "cb844490-43de-4fe8-9494-2574820f1fc2",
+                            "id": "592c85b2-cde4-4275-9691-79e3ceff4c27",
                             "name": "Returns a bank account object",
                             "originalRequest": {
                                 "url": {
@@ -1116,7 +1120,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "87cb5f34-d1ef-46b1-97ad-72682c145028",
+                            "id": "9b167e23-4672-4ca8-bce3-2fce58a9ea71",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1167,7 +1171,7 @@
                     "event": []
                 },
                 {
-                    "id": "183a2fd9-38f4-409b-9ccc-50a365c7f452",
+                    "id": "a1c2d71d-4838-4819-9264-095f492e2eee",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -1205,7 +1209,7 @@
                     },
                     "response": [
                         {
-                            "id": "a2dc1609-fbc9-41a3-b7bc-440f7fad8f37",
+                            "id": "62cebf18-529f-4f41-a893-c6737cd9679b",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -1253,7 +1257,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "39f93b0e-0e23-4b62-b0b1-b1cbe3267738",
+                            "id": "a8b37b88-a7ae-4727-a028-60cc45d9ddc2",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1304,7 +1308,7 @@
                     "event": []
                 },
                 {
-                    "id": "598de8f8-8ece-4728-8ac0-43510c415d97",
+                    "id": "74ba9f08-7c44-4dcc-b53b-0c42953cf5a1",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -1352,19 +1356,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -1382,7 +1398,7 @@
                     },
                     "response": [
                         {
-                            "id": "f51632f3-d60f-44ab-aca9-352ff70cca09",
+                            "id": "9e8317b8-c659-46a7-996c-1e8a8effe16f",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -1414,11 +1430,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -1450,7 +1462,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6d16b722-d19a-41ce-932d-b410f224f2c7",
+                            "id": "bb0e5ea7-f823-4af8-9eb7-5aa9d97acf15",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1482,11 +1494,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -1521,7 +1529,7 @@
                     "event": []
                 },
                 {
-                    "id": "ead29990-d7c6-40b5-8f84-c33dc1ac1b22",
+                    "id": "27899d53-b9cb-4e56-b0e4-7d4dea70ac57",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -1618,7 +1626,7 @@
                     },
                     "response": [
                         {
-                            "id": "a13547d4-f6c8-4154-bb24-a0e1340d9e72",
+                            "id": "4357b54a-72d3-42e3-9e18-7c1327930e71",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1725,7 +1733,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "228ea61f-09d9-4d92-b7ef-f1c10c35d97b",
+                            "id": "936324c9-2f6e-4785-bca1-78c4f1ffe674",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1823,7 +1831,7 @@
             "event": []
         },
         {
-            "id": "ba69a431-0d35-4465-ba02-5cc9e5fe8493",
+            "id": "6b4247ab-bc55-4994-9429-f96b0a84badc",
             "name": "Beta Program",
             "description": {
                 "content": "At Lob, we pride ourselves on building high quality platform capabilities rapidly\nand iteratively, so we can constantly be delivering additional value to our customers.\nWhen evaluating a new product or feature from Lob, you may see that it has been released in Beta.\n\nTypically, something in Beta means that the feature is early in its lifecycle here at\nLob. While we fully stand behind the quality of everything we release in Beta, we do\nanticipate receiving a higher level of customer feedback on Beta features, as well as a\nfaster pace of changes from our engineering team in response to that feedback.\n\nBy participating in a Lob Beta program, you will have the opportunity to get early access\nto a new product capability, as well as having a unique opportunity to influence the product's\ndirection with your feedback.\n\nYou should also anticipate that features in Beta may have functional or design limitations,\nand might change rapidly as we receive customer feedback and make improvements. In particular,\nnew APIs in Beta may also go through more frequent versioning and version deprecation cycles\nthan our more mature APIs.\n\nIf you are participating in a Beta program and want to provide feedback, please feel free to\n<a href=\"https://lob.com/support#contact\" target=\"_blank\">contact us</a>!\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -1833,7 +1841,7 @@
             "event": []
         },
         {
-            "id": "4c93533a-492d-4899-afa0-347864a8fd3c",
+            "id": "3c2011c7-fff7-4a60-8729-6c5d574743ca",
             "name": "Billing Groups",
             "description": {
                 "content": "The Billing Groups API allows you to create and view labels that can be attached to certain consumption-based\nusages of Letters, Checks, Postcards and Self-Mailers to customize your bill. Please check each\nresource API section to learn more about how to access the Billing Groups API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -1841,7 +1849,7 @@
             },
             "item": [
                 {
-                    "id": "15be6348-21b1-4083-8a1a-41bddd07c848",
+                    "id": "623882c6-d172-4dd3-a451-c6251664a25d",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -1879,7 +1887,7 @@
                     },
                     "response": [
                         {
-                            "id": "ea35913b-617f-42ee-a7a7-28f7e581219a",
+                            "id": "7cee0172-fe3f-49c4-8c9e-daf66dd150e6",
                             "name": "Returns a billing_group object.",
                             "originalRequest": {
                                 "url": {
@@ -1927,7 +1935,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fd3d3890-08b8-4253-8e1f-17fea9d42ee4",
+                            "id": "0cbdc369-a239-4d97-ad80-117b977f3e3a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1978,7 +1986,7 @@
                     "event": []
                 },
                 {
-                    "id": "e0319c93-90ab-4506-9000-e477dc6a5e76",
+                    "id": "ff03b945-e89d-46dc-9373-098301a9dee4",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -2035,7 +2043,7 @@
                     },
                     "response": [
                         {
-                            "id": "e71f6436-7a9d-41d6-8499-567b8e75cf29",
+                            "id": "37899d9f-d0bc-4955-956d-8c2244b23d68",
                             "name": "Returns a billing group object",
                             "originalRequest": {
                                 "url": {
@@ -2115,7 +2123,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7e3f6ba3-b25e-4393-a986-040fc02a622a",
+                            "id": "353a5fb4-de81-4323-ac1d-1b2d5096899f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2183,7 +2191,7 @@
                     }
                 },
                 {
-                    "id": "856aa115-e07d-4b1e-a2a2-a80a81bacba0",
+                    "id": "7f130042-e499-41c2-b144-2c53502ff86d",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -2225,37 +2233,61 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_modified[pariatur_3]",
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_modified[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_modified[Duisf]",
+                                    "key": "date_modified[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_modified[cillum2]",
+                                    "key": "date_modified[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_modified[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_modified[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -2285,7 +2317,7 @@
                     },
                     "response": [
                         {
-                            "id": "6793eb4d-64c4-4375-8ca4-e530e599b96a",
+                            "id": "b6fe20ed-2a07-484f-a238-068db84db7c6",
                             "name": "Returns a list of billing_groups.",
                             "originalRequest": {
                                 "url": {
@@ -2313,19 +2345,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[laborum_5]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_modified[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_modified[laborum_5]",
+                                            "key": "date_modified[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -2365,7 +2389,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fbf10dec-d937-48e3-9a10-7f9655c54388",
+                            "id": "7abd5f58-89f4-409a-ac83-b16e9b4f20e7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2393,19 +2417,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[laborum_5]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_modified[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_modified[laborum_5]",
+                                            "key": "date_modified[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -2448,7 +2464,7 @@
                     "event": []
                 },
                 {
-                    "id": "ad625f93-d070-4512-804f-97cbcabd25b0",
+                    "id": "c3fb4a0b-e637-4988-b238-dc299b915778",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -2496,7 +2512,7 @@
                     },
                     "response": [
                         {
-                            "id": "4e9e57a9-8117-4cf7-b9ab-d4c3a2272d13",
+                            "id": "edd09227-0b0b-42da-9a2c-195a9ca007c7",
                             "name": "Returns a billing group object",
                             "originalRequest": {
                                 "url": {
@@ -2567,7 +2583,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8d3bbac8-3be3-433b-8f9e-20ca4702eaff",
+                            "id": "b2aeddb5-7008-4d77-b103-b2f2cfcc31ab",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2629,7 +2645,7 @@
             "event": []
         },
         {
-            "id": "d230f450-5f14-4294-9adb-3d5f1079e8a9",
+            "id": "4e078c81-e71c-4d0c-8a1d-6eaeac9a65c2",
             "name": "Buckslip Orders",
             "description": {
                 "content": "The Buckslip Orders endpoint allows you to easily create buckslip orders for existing buckslips.\nThe API provides endpoints for creating buckslip orders and listing buckslip orders for a given buckslip.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -2637,7 +2653,7 @@
             },
             "item": [
                 {
-                    "id": "bb65de53-78b6-4aac-af93-5d822ff5b12a",
+                    "id": "e63ee860-051e-4a36-b5ec-630406d9e0fa",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -2689,7 +2705,7 @@
                     },
                     "response": [
                         {
-                            "id": "eb8570f1-0a53-4f25-8075-5c7dfb9d59d5",
+                            "id": "facfc687-16ad-47c7-8b07-c35bd12e2889",
                             "name": "Returns the buckslip orders associated with the given buckslip id",
                             "originalRequest": {
                                 "url": {
@@ -2747,7 +2763,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "54189546-7617-4e79-83cb-29dab8574502",
+                            "id": "91a808a1-9093-40db-b9df-5493df991a7c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2808,7 +2824,7 @@
                     "event": []
                 },
                 {
-                    "id": "2cb8d7c4-89a3-4399-95f8-10039284b7a1",
+                    "id": "373127e7-2996-40cf-bb04-092556b5ddb7",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -2862,7 +2878,7 @@
                     },
                     "response": [
                         {
-                            "id": "42911e9b-1cfe-48ce-99a6-13384b011899",
+                            "id": "b8ca276c-964d-4a19-963a-509830565b4f",
                             "name": "Buckslip order created successfully",
                             "originalRequest": {
                                 "url": {
@@ -2924,7 +2940,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "763d441a-159c-4e71-a657-3f7ff6f5bcd3",
+                            "id": "6d199c16-17ee-481e-9f92-213986a3bae6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2995,7 +3011,7 @@
             "event": []
         },
         {
-            "id": "c27f1661-450f-4e7e-9a1b-22260966d44b",
+            "id": "36a35ec4-8b85-4cb1-bdfc-5d42ac3ee7cb",
             "name": "Buckslips",
             "description": {
                 "content": "The Buckslips endpoint allows you to easily create buckslips that can later be used as add-ons for Letters Campaigns. Note that a Letter Campaign with Buckslip add-on requires a minimum send quantity of 5,000 letters.\nThe API provides endpoints for creating buckslips, retrieving individual buckslips, creating buckslip orders, and retrieving a list of buckslips.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -3003,7 +3019,7 @@
             },
             "item": [
                 {
-                    "id": "87982b08-d4c3-4ecc-a6af-6a475bc3da8c",
+                    "id": "be22dce3-8a30-4b28-b277-ae68068d3bac",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -3063,7 +3079,7 @@
                     },
                     "response": [
                         {
-                            "id": "d351a0a3-1b15-483a-9fc6-ddd2442ebabe",
+                            "id": "73c5a975-a2df-4d8a-b3ca-9a820a633009",
                             "name": "Returns a list of buckslip objects",
                             "originalRequest": {
                                 "url": {
@@ -3123,7 +3139,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b45c8840-b42e-4643-9135-cda02bc6a79a",
+                            "id": "8328972d-31ec-40b1-8bcf-f0031dc8e9cd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3186,7 +3202,7 @@
                     "event": []
                 },
                 {
-                    "id": "74f494ae-8a2d-4d6a-b448-01a2eb70cd52",
+                    "id": "e3394f50-0c75-4316-a6ab-39d637aeaa94",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -3244,7 +3260,7 @@
                     },
                     "response": [
                         {
-                            "id": "896f572e-3db6-439c-bceb-efe5c6a44b5d",
+                            "id": "e51ebd8a-dae7-49d1-b705-115f920b5562",
                             "name": "Buckslip created successfully",
                             "originalRequest": {
                                 "url": {
@@ -3302,7 +3318,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2993012c-89e7-408f-b4b9-007d26fe564f",
+                            "id": "2106ba46-41bb-471e-863b-0e46e1072278",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3366,7 +3382,7 @@
                     }
                 },
                 {
-                    "id": "463481e3-7a47-406b-8d35-55ff6b51e4dc",
+                    "id": "f85cd83b-bd0b-4648-8b9d-9fd7e6571cec",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -3404,7 +3420,7 @@
                     },
                     "response": [
                         {
-                            "id": "82d37287-4c63-4432-a93d-a624280c043e",
+                            "id": "f4dd27f1-5d59-4fae-883e-283a4c0ce0b6",
                             "name": "Returns a buckslip object",
                             "originalRequest": {
                                 "url": {
@@ -3452,7 +3468,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8f430ac4-ccbe-4f23-b19a-169813dc39ff",
+                            "id": "ca115f75-811a-4160-8b58-9ac91250064f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3503,7 +3519,7 @@
                     "event": []
                 },
                 {
-                    "id": "be7f7682-7fce-482a-8724-3cb29d43aa6d",
+                    "id": "742e5c41-0a55-411a-9dca-8366b9417f98",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -3567,7 +3583,7 @@
                     },
                     "response": [
                         {
-                            "id": "6dc70385-94db-462a-887f-9e9410c8b864",
+                            "id": "c81559ab-ea9c-49f3-8fe4-2ae7fae88f28",
                             "name": "Returns a buckslip object",
                             "originalRequest": {
                                 "url": {
@@ -3633,7 +3649,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4660e59b-5f44-4fd5-9dce-d9f57ff95a85",
+                            "id": "f8e7bdd4-a779-4b05-89f0-53c9627baa5b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3705,7 +3721,7 @@
                     }
                 },
                 {
-                    "id": "1a19da25-db1c-45e8-8283-ddfd39f9df40",
+                    "id": "8f3f0945-44bc-4234-b2f8-443a044404cf",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -3743,7 +3759,7 @@
                     },
                     "response": [
                         {
-                            "id": "b701e699-da4e-4d40-bb0f-086e33280150",
+                            "id": "78e805a1-b9a9-45fa-b49a-d3a4e6be3503",
                             "name": "Deleted the buckslip",
                             "originalRequest": {
                                 "url": {
@@ -3791,7 +3807,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "36e62e71-6119-44e1-a553-d316e364f954",
+                            "id": "1e05ddeb-0a30-4d41-bb84-4256cd7430bd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3845,7 +3861,7 @@
             "event": []
         },
         {
-            "id": "d11a2a22-aa05-42aa-bbcd-2443607fe46d",
+            "id": "6857975d-926d-4f35-9b71-8a2d579d7af0",
             "name": "Bulk Intl Verifications",
             "description": {
                 "content": "Verify a list of non-US addresses.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -3855,7 +3871,7 @@
             "event": []
         },
         {
-            "id": "66797dfd-8778-4861-8d17-f183cd56d758",
+            "id": "c36f522a-8fbc-4e36-ae3d-4b28d31d8b0b",
             "name": "Bulk US Verifications",
             "description": {
                 "content": "Verify a list of US addresses.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -3865,7 +3881,7 @@
             "event": []
         },
         {
-            "id": "62d80d41-b0f1-49e1-affa-79c94549478c",
+            "id": "25ea6abe-3b19-4f64-94b1-3880f67841e3",
             "name": "Campaigns",
             "description": {
                 "content": "The campaigns endpoint allows you to create and view campaigns that can be used to send multiple letters or postcards.\nThe API provides endpoints for creating campaigns, updating campaigns, retrieving individual campaigns, listing campaigns, and deleting\ncampaigns.\n",
@@ -3873,7 +3889,7 @@
             },
             "item": [
                 {
-                    "id": "720c9eb2-aab0-47b5-b624-f866dc3617e0",
+                    "id": "f07a982f-e11d-4723-8a1f-900f2434fa9c",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -3933,7 +3949,7 @@
                     },
                     "response": [
                         {
-                            "id": "d5ba01cb-29fe-4be8-9d6c-976c066f662b",
+                            "id": "e43508a4-94bd-4f50-ab8b-e30a3e983492",
                             "name": "A dictionary with a data property that contains an array of up to `limit` campaigns. Each entry in the array is a separate campaign. The previous and next page of campaigns can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more campaigns are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3996,7 +4012,7 @@
                     "event": []
                 },
                 {
-                    "id": "601d0b97-e98a-4dc2-998b-2ca61f0b4fcb",
+                    "id": "0c42b495-b338-43af-ab41-a30bcf132b4c",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -4085,7 +4101,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "2/;=<I@Q0`v`hrp:;cjU6ESnN>:EMc!:l|UnUk+]<[>m?+W0NqfeIw`[4vLDf!k-$pjAad]:HCYO/4[yTxO@THC|X)f%rsBeV%HEK4!s;l^T"
+                                    "value": "Hl^0!MS N,M_!snXfC9x~08|s?vwEmAGB''(RyauRz{+u*}Y9Ok#W]Uw'W;}6%cU!1AKV.)>a$xdL04ZV}:TJk%`HEszO0jf;5S1fq*j%QXpQV)QUw9&9t&t[.V_/hk(PuNTr5sSd6F]{('FuW.IUeU#iV[#b&=?'00sx3@I44K+k+~q`%cfF|SWY~yo}lj<RPPpkY>]r-Y'au:ry@8=~AVjza.]A__avE9nHsIjpB)E|C^V,4;cz4mD**^o.a*[z<8;TeB[g.XL8<ff=b: K;|_!_A5bEkctlM-wC>dy?o!Vy+nQ4G})i!d;)zYx4Q(Jzk05{E1F6$UW-,$_|(fdZcT`rK|$gP#iZul$sYLKO*FOvx)N!1{LcEpw*3rE<r|#}k1"
                                 },
                                 {
                                     "disabled": false,
@@ -4098,7 +4114,7 @@
                     },
                     "response": [
                         {
-                            "id": "c8e61e41-2573-4912-bec8-2f170dc7c38b",
+                            "id": "53a115e2-2b0c-4278-ae19-673eacb1b9c5",
                             "name": "Campaign created successfully",
                             "originalRequest": {
                                 "url": {
@@ -4170,7 +4186,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2206f008-3fcf-4e3a-80a3-80ab6f0036fb",
+                            "id": "ba3f2921-4f7e-4abd-8e52-93671cd47ccf",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4248,7 +4264,7 @@
                     }
                 },
                 {
-                    "id": "a25e9043-a533-4f52-bb98-2d9e406b181b",
+                    "id": "b4cdd1ae-f91c-4cbc-b509-eef0c160fc07",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -4286,7 +4302,7 @@
                     },
                     "response": [
                         {
-                            "id": "214280af-8d36-4355-9188-a9c6247de89c",
+                            "id": "71213053-0edd-4d44-9d1c-f646b0aa0418",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4334,7 +4350,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c914b173-5d15-48b6-ab98-5375a3ca6f68",
+                            "id": "a18dffbb-8af7-4a71-93c1-b970f5bc72a3",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4385,7 +4401,7 @@
                     "event": []
                 },
                 {
-                    "id": "0077762a-5f7c-44c4-a506-145bd4b88353",
+                    "id": "6c9515fd-9991-45c2-854f-183fdc16330c",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -4463,7 +4479,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "Ij<PjeJcDO(CufEsl;A{$q99IMMQ_osEF$7z[^]@M"
+                                    "value": "+d?I~"
                                 },
                                 {
                                     "disabled": false,
@@ -4487,7 +4503,7 @@
                     },
                     "response": [
                         {
-                            "id": "e210adbc-c8c7-48a7-a799-615c4c3eeb1a",
+                            "id": "a58f0915-84f3-4e70-ae98-3d40476abe24",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4544,7 +4560,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1fc426c8-bb91-4d8e-914f-6f04cafdf522",
+                            "id": "63d387c2-5faf-481b-a8d3-9187bb09eeff",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4607,7 +4623,7 @@
                     }
                 },
                 {
-                    "id": "96d3bafe-7f01-4cc8-a917-becdc88fe3bc",
+                    "id": "227ac0d8-86b1-418d-b4d9-9f801fc4a26c",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -4645,7 +4661,7 @@
                     },
                     "response": [
                         {
-                            "id": "05876fa0-cde1-46ce-b5a2-62cdc57c750f",
+                            "id": "6d18ae13-9fa3-4812-92a2-d9fdffa13d9a",
                             "name": "Deleted the campaign.",
                             "originalRequest": {
                                 "url": {
@@ -4693,7 +4709,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "904f42b1-a088-4718-934d-2fe8c9bdd701",
+                            "id": "113413af-908e-474a-8b5e-abf5a7eed98e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4744,7 +4760,7 @@
                     "event": []
                 },
                 {
-                    "id": "012be120-1e57-4ab5-b854-95e97864df7a",
+                    "id": "aa243e02-99bd-46a3-a0c1-54531a5f7750",
                     "name": "Send Campaign",
                     "request": {
                         "name": "Send Campaign",
@@ -4783,7 +4799,7 @@
                     },
                     "response": [
                         {
-                            "id": "65912ce0-afa8-45f1-8921-0eb24137e67a",
+                            "id": "24817d3c-b999-499d-8aac-1466d6066668",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4832,7 +4848,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cb594b0c-85ae-4df1-bb79-efe921fa0cc5",
+                            "id": "9811340c-2c4c-4dcd-acff-8a7f6e2fb6ad",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4887,7 +4903,7 @@
             "event": []
         },
         {
-            "id": "b27da3b4-76a8-4baa-8ef4-1503a908f436",
+            "id": "f82ee824-9890-4dc2-8836-75e98605a9dc",
             "name": "Card Orders",
             "description": {
                 "content": "The card orders endpoint allows you to easily create card orders for existing cards.\nThe API provides endpoints for creating card orders and listing card orders for a given card.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -4895,7 +4911,7 @@
             },
             "item": [
                 {
-                    "id": "9177387b-1aa5-4dec-b8e8-9fd88d32f8bc",
+                    "id": "83dd31fd-45f9-4bea-bfc1-7df6a67c8cdf",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -4947,7 +4963,7 @@
                     },
                     "response": [
                         {
-                            "id": "6f5884d9-9e7d-48ba-9d3f-2e37dd4adeaf",
+                            "id": "a6d32a77-df39-4aa0-9abd-02d986e0d828",
                             "name": "Returns the card orders associated with the given card id",
                             "originalRequest": {
                                 "url": {
@@ -5005,7 +5021,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "21a0344b-1b2d-4c41-8776-f025e0bc4d40",
+                            "id": "cf5ac77c-1597-41c1-9fa1-d619743cbe17",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5066,7 +5082,7 @@
                     "event": []
                 },
                 {
-                    "id": "73b80e15-e93c-4954-acef-ca377e630f10",
+                    "id": "d4f51fde-c8dd-4c8c-a953-c883fe7883e3",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -5120,7 +5136,7 @@
                     },
                     "response": [
                         {
-                            "id": "27e06403-1f7a-4362-9eb7-35ae4b88007a",
+                            "id": "59f420fa-1876-4007-8f5a-faa48897a5a3",
                             "name": "Card order created successfully",
                             "originalRequest": {
                                 "url": {
@@ -5182,7 +5198,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6d308afb-d7fd-4466-9c21-dc0fa3802362",
+                            "id": "cca8e29f-d84c-405e-b7e0-5a3ec423b89c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5253,7 +5269,7 @@
             "event": []
         },
         {
-            "id": "bff12e68-2f7c-4811-95ea-11ac4e3eebf8",
+            "id": "83d5f970-cd7c-4962-a369-5ccfa4772e85",
             "name": "Cards",
             "description": {
                 "content": "The cards endpoint allows you to easily create cards that can later be affixed to Letters.\nThe API provides endpoints for creating cards, retrieving individual cards, creating card orders, and retrieving a list of cards.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -5261,7 +5277,7 @@
             },
             "item": [
                 {
-                    "id": "be32e861-2879-4e76-b122-8453439afa4f",
+                    "id": "855578c4-e9a2-4f8c-8701-1b479e61d449",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -5321,7 +5337,7 @@
                     },
                     "response": [
                         {
-                            "id": "1219ceb6-047b-44d9-81a2-ef75c28a465a",
+                            "id": "c340646a-4c0f-4005-b94b-103d7ec1b51c",
                             "name": "Returns a list of card objects",
                             "originalRequest": {
                                 "url": {
@@ -5381,7 +5397,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1d0fb2ee-3f6a-4f10-a62d-fd8e8643b163",
+                            "id": "f7f1d08a-ec61-4d59-a1f1-e5f210d84328",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5444,7 +5460,7 @@
                     "event": []
                 },
                 {
-                    "id": "e8a14002-8d5c-4502-8b3c-450a71497029",
+                    "id": "100e13b9-79e1-461d-9128-0569bbe4484a",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -5502,7 +5518,7 @@
                     },
                     "response": [
                         {
-                            "id": "f2ccd67b-2a64-46e4-b239-755d04fb5f34",
+                            "id": "d20acf1a-18c4-4f07-b62d-13ee52e357ca",
                             "name": "Card created successfully",
                             "originalRequest": {
                                 "url": {
@@ -5565,7 +5581,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "027bbb69-9094-4ddf-9173-ee767fa0fd83",
+                            "id": "6954a593-fdc5-4964-8dee-428c9b230a05",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5634,7 +5650,7 @@
                     }
                 },
                 {
-                    "id": "7ea0b77b-20ab-47ba-8416-0c731b8ede7b",
+                    "id": "0f16afc0-bf5f-4593-9a51-08437b663731",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -5672,7 +5688,7 @@
                     },
                     "response": [
                         {
-                            "id": "ea9a75de-2697-4e25-a0cf-8a5a8ea4a5a1",
+                            "id": "3a6379a4-3380-4dae-ba13-de45f71d2da5",
                             "name": "Returns a card object",
                             "originalRequest": {
                                 "url": {
@@ -5720,7 +5736,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "88d160a3-2212-47ec-91e0-1d91f23bcf98",
+                            "id": "ff22180a-0522-4dd5-9648-1e339804e1a4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5771,7 +5787,7 @@
                     "event": []
                 },
                 {
-                    "id": "1abce040-eeaf-46b7-b428-cf374255d1f2",
+                    "id": "97afe17e-2021-4194-8867-c3b870f46533",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -5835,7 +5851,7 @@
                     },
                     "response": [
                         {
-                            "id": "c974e100-6b3d-4f36-8ed9-85ba35ca2c78",
+                            "id": "6274bd2e-0c9d-4598-baa0-ce95669f6383",
                             "name": "Returns a card object",
                             "originalRequest": {
                                 "url": {
@@ -5901,7 +5917,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "df700be9-9442-4cb0-944b-11507652a33d",
+                            "id": "a99308a8-93c9-4752-b496-49294b00a22a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5973,7 +5989,7 @@
                     }
                 },
                 {
-                    "id": "ed42588a-5fcd-4939-8c12-5b21fbe08023",
+                    "id": "f0a24337-20d0-4e91-83b8-488f43338d59",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -6011,7 +6027,7 @@
                     },
                     "response": [
                         {
-                            "id": "04a8b703-d433-449d-9066-e6a0f723fa8c",
+                            "id": "05a402e7-563c-4115-b166-bfdbbf5d65e4",
                             "name": "Deleted the card",
                             "originalRequest": {
                                 "url": {
@@ -6059,7 +6075,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "70499f93-44a2-4d9a-a69b-8227cd43eae2",
+                            "id": "8003b4f0-8ec8-4246-864f-a1ef44fab9a4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6113,7 +6129,7 @@
             "event": []
         },
         {
-            "id": "4165596f-8fdb-4746-9c8b-36ba027b8054",
+            "id": "c1693a9d-e008-4af9-8dc2-f85069692851",
             "name": "Checks",
             "description": {
                 "content": "Checks allow you to send payments via physical checks. The API provides endpoints\nfor creating checks, retrieving individual checks, canceling checks, and retrieving a list of checks.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -6121,7 +6137,7 @@
             },
             "item": [
                 {
-                    "id": "3865923a-1ccd-47f4-91c8-cc5a9e7b264b",
+                    "id": "c9e84e57-5e7f-4aca-ba61-49deb4eec66e",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -6169,19 +6185,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -6223,7 +6251,7 @@
                     },
                     "response": [
                         {
-                            "id": "b6a50096-787e-451f-bd60-5b37c83566c7",
+                            "id": "a1e74095-8801-42ea-ab9f-270bfe15a12e",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -6255,11 +6283,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -6307,7 +6331,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5da9267e-a3fb-4675-9f25-5805f8ef1d8a",
+                            "id": "0fd837f6-1017-4178-9a1b-e79e517c0e07",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6339,11 +6363,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -6394,7 +6414,7 @@
                     "event": []
                 },
                 {
-                    "id": "48ed8b75-11f3-4884-88fe-dfe65a84618f",
+                    "id": "3e04300d-d1a1-4b44-b294-d859fa9147ca",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -6485,7 +6505,7 @@
                     },
                     "response": [
                         {
-                            "id": "75770dd3-2c7a-4da6-a1e3-dd0be4939822",
+                            "id": "6d5e5da7-3812-42d6-989f-efb66e5cd122",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -6702,7 +6722,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7af6c220-8fd2-415f-9a1a-7d96cbfa01ee",
+                            "id": "dfc24d76-cf85-4d23-b265-545e5a4e88fb",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6907,7 +6927,7 @@
                     }
                 },
                 {
-                    "id": "53bd2763-6545-4129-8d66-e7c4defd623b",
+                    "id": "fb0889f8-9964-4069-b11c-99bef480f93f",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -6945,7 +6965,7 @@
                     },
                     "response": [
                         {
-                            "id": "dbffcb04-0982-44be-a62a-ae3e03eaac97",
+                            "id": "f5a90204-4623-4b02-ba93-d067d65f380e",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -6993,7 +7013,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "af10661b-dc9b-4bd9-9660-65416f4ee5f9",
+                            "id": "82903111-1304-43a6-beb5-81a6c20c7efb",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7044,7 +7064,7 @@
                     "event": []
                 },
                 {
-                    "id": "2af9d6c9-af68-443a-bb89-662edba245c3",
+                    "id": "6ce3eb1c-1d62-4f75-91c9-b2d2ceb6786e",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -7082,7 +7102,7 @@
                     },
                     "response": [
                         {
-                            "id": "14152509-9dc8-4f0f-8cc8-1367f15a6efa",
+                            "id": "25e6e68e-9336-4f5a-8248-90fe4fb29bc8",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -7130,7 +7150,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "50e20550-aa38-4df0-8089-2d2960ddfc1e",
+                            "id": "09352efc-2905-45f9-ab14-cd8cf82c0ba7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7184,7 +7204,7 @@
             "event": []
         },
         {
-            "id": "22e77bc6-a5a4-4fef-b20f-1357c09818f3",
+            "id": "69524d38-0735-43d6-9206-ff6fdae58fde",
             "name": "Creatives",
             "description": {
                 "content": "The creatives endpoint allows you to create and view creatives. Creatives are used to create\nreusable letter and postcard templates. The API provides endpoints for creating creatives, updating creatives,\nretrieving individual creatives, and deleting creatives.\n",
@@ -7192,7 +7212,7 @@
             },
             "item": [
                 {
-                    "id": "f4ef9961-8627-4bb6-bf62-58c008c3e64c",
+                    "id": "b9674287-8a97-4afe-b40a-e9c58f4afa2e",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -7286,7 +7306,7 @@
                     },
                     "response": [
                         {
-                            "id": "04d4f6c1-7c54-4be9-b252-184ad6b99390",
+                            "id": "71908c31-b59e-4266-85d7-d4ee6cb8c200",
                             "name": "Creative created successfully",
                             "originalRequest": {
                                 "url": {
@@ -7350,7 +7370,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a4541d77-878b-4ca2-bd8d-ff6941037592",
+                            "id": "f9277acb-6fa3-4c1d-a8ea-1de477025a29",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7420,7 +7440,7 @@
                     }
                 },
                 {
-                    "id": "196990ce-6b7f-4040-8e92-ba654e513021",
+                    "id": "97df9a3e-e51e-480f-84d4-834ce6dee804",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -7458,7 +7478,7 @@
                     },
                     "response": [
                         {
-                            "id": "c5b85d29-ad1c-4852-87a8-8214a99e2a3f",
+                            "id": "afa2d567-8300-4632-b596-b32716dc08c5",
                             "name": "Returns a creative object",
                             "originalRequest": {
                                 "url": {
@@ -7506,7 +7526,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c6df7d15-f77b-4036-9c60-8329e9a6ceca",
+                            "id": "e3b87037-af4d-4473-b183-46963d8668cd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7557,7 +7577,7 @@
                     "event": []
                 },
                 {
-                    "id": "4257c28f-6a20-438f-8f5f-b8af19eca825",
+                    "id": "d9e2f318-7e33-47ad-8d68-4d5a17b767c0",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -7612,14 +7632,14 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "/|S+zxm9NP]UFt]*?G!u_,cEi:Mo9F_u[IjIlX#M Hu:KEGbLSv="
+                                    "value": "ZAi<ud6:iK^uY|BX}t^k#u3nCpKhv$_Ep]&^]Qx/}%*,^CKXf :Odu[9c[>dL=je2[ A/#KK(  DzwD*EIqtG$+wwjO,X2i!!{=UYv 0zS9B?1vG#w*k:ck,X}U#hO[Cdn&AKht&:8YHRMfwS*T3y{.jQd ,9,EB!dTl$$JUK.k_|b^d.cLHO@2Ma}>c#r1Z|.a&uz+98@L?9>6~$th.wEC2x<H_In)nBX1AL<%6P?}miNO7XGQ7>r97jUl[pZ+=zo<sXg WXiqf(.%A{9@=q,Eek7O2F(($5XdZK0}UFVeN>3.Tgz}ww3eyc]_7}:2HG~L/72~[P3 j,<=tv"
                                 }
                             ]
                         }
                     },
                     "response": [
                         {
-                            "id": "692d1bdf-7e18-42de-88d5-e496be2e28a8",
+                            "id": "50dec96d-960e-4eee-a031-004a35dc4c76",
                             "name": "Returns a creative object",
                             "originalRequest": {
                                 "url": {
@@ -7676,7 +7696,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "dd8c0c0e-e575-4d1f-8cd5-a2c4cd6d4e3d",
+                            "id": "9e308437-8f4d-4ef2-8a16-a8270399c604",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7742,7 +7762,7 @@
             "event": []
         },
         {
-            "id": "774c34e5-ea58-434f-9cb9-c226d450c621",
+            "id": "3ec4f701-1a54-46a8-aa56-74c3c5fea28c",
             "name": "Errors",
             "description": {
                 "content": "Lob uses RESTful HTTP response codes to indicate success or failure of an API request - read below for more information. In general, 2xx indicates success, 4xx indicate an input error, and 5xx indicates an error on Lob's end.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">ATTRIBUTE</th>\n    <th style=\"white-space: nowrap\">DESCRIPTION</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>code</code></td>\n    <td style=\"white-space: nowrap\">A consistent machine-keyable string identifying the error</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>status_code</code></td>\n    <td style=\"white-space: nowrap\">A conventional HTTP status code</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>message</code></td>\n    <td style=\"white-space: nowrap\">A human-readable, subject-to-change message with more details about the error</td>\n  </tr>\n</table>\n\n### HTTP Status Code Summary\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>200</code></td>\n    <td style=\"white-space: nowrap\">SUCCESS</td>\n    <td style=\"white-space: nowrap\">Successful API request</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED</td>\n    <td style=\"white-space: nowrap\">Authorization error with your API key or account</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">FORBIDDEN</td>\n    <td style=\"white-space: nowrap\">Forbidden error with your API key or account</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">NOT FOUND</td>\n    <td style=\"white-space: nowrap\">The requested item does not exist</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BAD REQUEST</td>\n    <td style=\"white-space: nowrap\">The query or body parameters did not pass validation</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>429</code></td>\n    <td style=\"white-space: nowrap\">TOO MANY REQUESTS</td>\n    <td style=\"white-space: nowrap\">Too many requests have been sent with an API key in a given amount of time</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>500</code></td>\n    <td style=\"white-space: nowrap\">SERVER ERROR</td>\n    <td style=\"white-space: nowrap\">An internal server error occurred, please contact support@lob.com</td>\n  </tr>\n</table>\n\n### Error Codes - Generic\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BAD_REQUEST</td>\n    <td style=\"white-space: nowrap\">An invalid request was made. See error message for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>409/422</code></td>\n    <td style=\"white-space: nowrap\">CONFLICT</td>\n    <td style=\"white-space: nowrap\">This operation would leave data in a conflicted state.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">FEATURE_LIMIT_REACHED</td>\n    <td style=\"white-space: nowrap\">The account has reached its resource limit and requires upgrading to add more.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>500</code></td>\n    <td style=\"white-space: nowrap\">INTERNAL_SERVER_ERROR</td>\n    <td style=\"white-space: nowrap\">An error has occured on Lob's servers. Please try request again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID</td>\n    <td style=\"white-space: nowrap\">An invalid request was made. See error message for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">NOT_DELETABLE</td>\n    <td style=\"white-space: nowrap\">An attempt was made to delete a resource, but the resource cannot be deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">NOT_FOUND</td>\n    <td style=\"white-space: nowrap\">The requested resource was not found.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>408</code></td>\n    <td style=\"white-space: nowrap\">REQUEST_TIMEOUT</td>\n    <td style=\"white-space: nowrap\">The request took too long. Please try again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>503</code></td>\n    <td style=\"white-space: nowrap\">SERVICE_UNAVAILABLE</td>\n    <td style=\"white-space: nowrap\">The Lob servers are temporarily unavailable. Please try again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">UNRECOGNIZED_ENDPOINT</td>\n    <td style=\"white-space: nowrap\">The requested endpoint doesn't exist.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">UNSUPPORTED_LOB_VERSION</td>\n    <td style=\"white-space: nowrap\">An unsupported Lob API version was requested.</td>\n  </tr>\n</table>\n\n### Error Codes - Authentication\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">EMAIL_REQUIRED</td>\n    <td style=\"white-space: nowrap\">Account must have a verified email address before creating live resources.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED</td>\n    <td style=\"white-space: nowrap\">The request isn't authorized.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED_TOKEN</td>\n    <td style=\"white-space: nowrap\">Token isn't authorized.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401/403</code></td>\n    <td style=\"white-space: nowrap\">INVALID_API_KEY</td>\n    <td style=\"white-space: nowrap\">The API key is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">PUBLISHABLE_KEY_NOT_ALLOWED</td>\n    <td style=\"white-space: nowrap\">The requested operation needs a secret key, not a publishable key. See [API Keys](#tag/API-Keys) for more information.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>429</code></td>\n    <td style=\"white-space: nowrap\">RATE_LIMIT_EXCEEDED</td>\n    <td style=\"white-space: nowrap\">Requests were sent too quickly and must be slowed down.</td>\n  </tr>\n</table>\n\n ### Error Codes - Advanced\n\n <table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">PAYMENT_METHOD_UNVERIFIED</td>\n    <td style=\"white-space: nowrap\">You must have a verified bank account or credit card to submit live requests.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">DELETED_BANK_ACCOUNT</td>\n    <td style=\"white-space: nowrap\">Checks cannot be created with a deleted bank account.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">ADDRESS_LENGTH_EXCEEDS_LIMIT</td>\n    <td style=\"white-space: nowrap\">The sum of to.address_line1 and to.address_line2 cannot surpass 50 characters.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BANK_ACCOUNT_ALREADY_VERIFIED</td>\n    <td style=\"white-space: nowrap\">The bank account has already been verified.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BANK_ERROR</td>\n    <td style=\"white-space: nowrap\">There's an issue with the bank account.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">BILLING_ADDRESS_REQUIRED</td>\n    <td style=\"white-space: nowrap\">In order to create a live mail piece, your account needs to set up a billing address.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">CUSTOM_ENVELOPE_INVENTORY_DEPLETED</td>\n    <td style=\"white-space: nowrap\">Custom envelope inventory is depleted, and more will need to be ordered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FAILED_DELIVERABILITY_STRICTNESS</td>\n    <td style=\"white-space: nowrap\">The to address doesn't meet strictness requirements.\n    See <a href=\"https://dashboard.lob.com/#/settings/account\" target=\"_blank\">Account Settings</a> to configure strictness.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_PAGES_BELOW_MIN</td>\n    <td style=\"white-space: nowrap\">Not enough pages.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_PAGES_EXCEED_MAX</td>\n    <td style=\"white-space: nowrap\">Too many pages.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_SIZE_EXCEEDS_LIMIT</td>\n    <td style=\"white-space: nowrap\">The file size is too large. See description for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FOREIGN_RETURN_ADDRESS</td>\n    <td style=\"white-space: nowrap\">The 'from' address must be a US address.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INCONSISTENT_PAGE_DIMENSIONS</td>\n    <td style=\"white-space: nowrap\">All pages of the input file must have the same dimensions.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_BANK_ACCOUNT</td>\n    <td style=\"white-space: nowrap\">The provided bank routing number is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_BANK_ACCOUNT_VERIFICATION</td>\n    <td style=\"white-space: nowrap\">Verification amounts do not match.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_CHECK_INTERNATIONAL</td>\n    <td style=\"white-space: nowrap\">Checks cannot be sent internationally.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_COUNTRY_COVID</td>\n    <td style=\"white-space: nowrap\">The postal service in the specified country is currently unable to process the request due to COVID-19 restrictions.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE</td>\n    <td style=\"white-space: nowrap\">The file is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_DIMENSIONS</td>\n    <td style=\"white-space: nowrap\">File dimensions are incorrect for the selected mail type.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_DOWNLOAD_TIME</td>\n    <td style=\"white-space: nowrap\">File download from remote server took too long.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_URL</td>\n    <td style=\"white-space: nowrap\">The file URL when creating a resource is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_IMAGE_DPI</td>\n    <td style=\"white-space: nowrap\">DPI must be at least 300.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_INTERNATIONAL_FEATURE</td>\n    <td style=\"white-space: nowrap\">The specified product cannot be sent to the destination.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_PERFORATION_RETURN_ENVELOPE</td>\n    <td style=\"white-space: nowrap\">Both `return_envelope` and `perforation` must be used together.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_TEMPLATE_HTML</td>\n    <td style=\"white-space: nowrap\">The provided HTML is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MAIL_USE_TYPE_CAN_NOT_BE_NULL</td>\n    <td style=\"white-space: nowrap\">`use_type` must be one of \"marketing\" or \"operational\". Alternatively, an admin can set the account default use type in Account Settings.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MERGE_VARIABLE_REQUIRED</td>\n    <td style=\"white-space: nowrap\">A required merge variable is missing.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MERGE_VARIABLE_WHITESPACE</td>\n    <td style=\"white-space: nowrap\">Merge variable names cannot contain whitespace.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">PDF_ENCRYPTED</td>\n    <td style=\"white-space: nowrap\">An encrypted PDF was provided.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">SPECIAL_CHARACTERS_RESTRICTED</td>\n    <td style=\"white-space: nowrap\">Cannot use special characters for merge variable names.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">UNEMBEDDED_FONTS</td>\n    <td style=\"white-space: nowrap\">The provided PDF contains non-standard unembedded fonts. See description for details.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7752,17 +7772,17 @@
             "event": []
         },
         {
-            "id": "eb8cabc2-09f8-413b-b98d-866aa572e436",
+            "id": "f79573c4-5005-403b-a916-1493860de2d4",
             "name": "Events",
             "description": {
-                "content": "When various notable things happen within the Lob architecture, Events will be created. To get these events sent to your server\nautomatically when they occur, you can set up [Webhooks](#tag/Webhooks).\n\n<h3>Postcards</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n</table>\n\n<h3>Self Mailers</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n</table>\n\n<h3>Letters</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.pickup_available</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Pickup Available\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.issue</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"Issue\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A return envelope is created (occurs simultaneously with letter creation).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Checks</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Addresses</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully deleted.</td>\n  </tr>\n</table>\n\n<h3>Bank Accounts</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.verified</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully verified.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
+                "content": "When various notable things happen within the Lob architecture, Events will be created. To get these events sent to your server\nautomatically when they occur, you can set up [Webhooks](#tag/Webhooks).\n\n<h3>Postcards</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Failed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n</table>\n\n<h3>Self Mailers</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Failed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n</table>\n\n<h3>Letters</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Failed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.pickup_available</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Pickup Available\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.issue</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"Issue\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A return envelope is created (occurs simultaneously with letter creation).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Checks</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Failed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Addresses</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully deleted.</td>\n  </tr>\n</table>\n\n<h3>Bank Accounts</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.verified</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully verified.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
                 "type": "text/plain"
             },
             "item": [],
             "event": []
         },
         {
-            "id": "43a57371-ab32-4414-819e-c81e165928a8",
+            "id": "d92e0247-2b69-4b02-8951-405715c34f3f",
             "name": "Getting Started",
             "description": {
                 "content": "### 1. Get Setup\n* Create an account at <a href=\"https://dashboard.lob.com/#/register\" target=\"_blank\">Lob.com</a>\n* Obtain your API keys in the Lob dashboard <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">settings</a>\n* You'll use the format, `test_*.` for your Test API key and `live_*.` for your Live API key.\n\n### 2. Explore\n* Try out in Postman:\n<div class=\"postman-run-button\"\ndata-postman-action=\"collection/fork\"\ndata-postman-var-1=\"16169677-975ecb9f-ea22-4d8f-a4f9-53a42f2aee03\"\ndata-postman-collection-url=\"entityId=16169677-975ecb9f-ea22-4d8f-a4f9-53a42f2aee03&entityType=collection&workspaceId=5404d3a5-5a84-4df6-b078-a1547e1a68a7\"\nstyle=\"background:#0099d7;color: white;display: flex;justify-content: center;align-items: center;\">\n  Run in Postman\n</div>\n<script type=\"text/javascript\">\n  (function (p,o,s,t,m,a,n) {\n    !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });\n    !o.getElementById(s+t) && o.getElementsByTagName(\"head\")[0].appendChild((\n      (n = o.createElement(\"script\")),\n      (n.id = s+t), (n.async = 1), (n.src = m), n\n    ));\n  }(window, document, \"_pm\", \"PostmanRunObject\", \"https://run.pstmn.io/button.js\"));\n</script>\n* Launch your terminal and copy/paste a CURL command.\n```bash\ncurl https://api.lob.com/v1/addresses \\\n  -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc:\n```\n* Download a [Lob SDK](#tag/SDKs-and-Tools) into your favorite IDE (integrated development environment)\n\n### 3. Learn more\nTry our quick start (TypeScript, Python, PHP, Java or Ruby):\n* <a href=\"https://help.lob.com/developer-docs/quickstart-guide\" target=\"_blank\">Send your first Postcards</a>\n\nUse Case guides\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/mass-deletion-setup\" target=\"_blank\">Mass Deletion Setup</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/ncoa-restrictions\" target=\"_blank\">NCOA Restrictions</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/override-cancellation-window\" target=\"_blank\">Override Cancellation Window</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/visibility-of-address-changes\" target=\"_blank\">Visibility of Address Changes</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/ingesting-tracking-events-with-webhooks\" target=\"_blank\">Ingesting Tracking Events with Webhooks</a>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7772,7 +7792,7 @@
             "event": []
         },
         {
-            "id": "932c16b5-6a64-4ae7-b14e-94ad0b81165f",
+            "id": "978ece84-d8b2-41e5-b59a-e3105e7427a8",
             "name": "Identity Validation",
             "description": {
                 "content": "Validates whether a given name is associated with an address.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7780,7 +7800,7 @@
             },
             "item": [
                 {
-                    "id": "e6944c1f-30fe-4c1c-8b8d-324bbb34bdd2",
+                    "id": "23fba205-84b5-46f7-8df5-6c4710259255",
                     "name": "Identity Validation",
                     "request": {
                         "name": "Identity Validation",
@@ -7853,7 +7873,7 @@
                     },
                     "response": [
                         {
-                            "id": "d7dd13da-32bb-4af8-a9e4-dde6fd1a524e",
+                            "id": "74ed4c27-4174-48db-bb87-dff3e0c3019a",
                             "name": "Returns the likelihood a given name is associated with an address.",
                             "originalRequest": {
                                 "url": {
@@ -7944,7 +7964,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8ee857ab-d6b0-446a-b74b-0dff4b46dff2",
+                            "id": "d02d0781-412f-4544-a4e5-a9593f8109d4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8026,7 +8046,7 @@
             "event": []
         },
         {
-            "id": "6b81fa4f-883e-4988-9610-414e643eb582",
+            "id": "19781f43-bef8-46f2-8826-54574ab3f0b8",
             "name": "Intl Autocompletions",
             "description": {
                 "content": "Address autocompletion for non-US addresses. Given partial address information, this endpoint returns up to 10 address suggestions.\n## Autocompletion Test Env\nYour test API key does not autocomplete international addresses and is used to simulate\nbehavior. With your test API key, requests with specific values for `address_prefix`\nreturn predetermined values. When `address_prefix` is set to:\n- `0 suggestions` - Returns no suggestions\n- `[PRIMARY NUMBER] s[uggestion]` - Returns a maximum of ten predefined suggested addresses.\n  `[PRIMARY NUMBER]` does not have to be a valid primary number when sending a test request.\n  Each additional letter in `suggestion` reduces the number of suggestions by one (e.g.\n  `1 su` returns 9 suggested addresses). `[PRIMARY NUMBER]` does not affect the number of\n  suggestions returned.\nCountry is a required field.\nCity and state filters work as expected and filter the list of predetermined suggested addresses.\nSee the `test` request & response examples under [Autocomplete Examples](#operation/intl_autocompletions) within the \"Autocomplete\na partial address\" section in Intl Autocompletions.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -8034,7 +8054,7 @@
             },
             "item": [
                 {
-                    "id": "13191018-4fea-415d-8700-932cbb594820",
+                    "id": "7f935449-732a-438e-88c3-e014215a70ea",
                     "name": "Autocomplete",
                     "request": {
                         "name": "Autocomplete",
@@ -8114,7 +8134,7 @@
                     },
                     "response": [
                         {
-                            "id": "8201db2f-6703-4b37-8c75-e6cd94c53397",
+                            "id": "0027a048-98a8-4cb8-b190-b21d4f8f3811",
                             "name": "Returns an international autocompletions object.",
                             "originalRequest": {
                                 "url": {
@@ -8235,7 +8255,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "63dd4528-b63d-4318-b0d9-5850aff41d1c",
+                            "id": "d535666d-c3d6-49d4-a81e-e1048b42a45b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8347,7 +8367,7 @@
             "event": []
         },
         {
-            "id": "ff94efed-3551-434b-bf8a-97b1f3d0da2c",
+            "id": "8f415fab-3bd2-4846-a815-3a3fa0160d95",
             "name": "Intl Verifications",
             "description": {
                 "content": "Address verification for non-US addresses\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Intl Verifications Test Env\n\nWhen verifying international addresses, you'll likely want to test against\na wide array of addresses to ensure you're handling responses correctly.\nWith your test API key, requests that use specific values for `primary_line`\nlet you explore the responses to many types of addresses:\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">DELIVERABILITY OF SAMPLE RESPONSE</th>\n    <th style=\"white-space: nowrap\">SET <code>primary_line</code> TO</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\">deliverable</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>deliverable_missing_info</code></td>\n    <td style=\"white-space: nowrap\">deliverable missing info</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\">undeliverable</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>no_match</code></td>\n    <td style=\"white-space: nowrap\">no match</td>\n  </tr>\n</table>\n\nSee the `test` request & response examples under [Intl Verification Examples](#operation/intl_verification) within the\n\"Verify an international address section\" in Intl Verifications.\n\nYou can rely on the response from these examples generally matching the response\nyou'd see in the live environment with an address of that type (excluding the `recipient` field).\n\nThe test API key does not perform any verification, automatic correction, or standardization\nfor addresses. If you wish to try these features out, use our <a href=\"https://lob.com/address-verification\" target=\"_blank\">live demo</a>\nor the free plan (see <a href=\"https://lob.com/pricing/address-verification\" target=\"_blank\">our pricing</a> for details).\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -8355,7 +8375,7 @@
             },
             "item": [
                 {
-                    "id": "5157997d-f3d5-480a-8515-a2c9d8591e36",
+                    "id": "ada4a905-4130-44d5-ae6e-30636af0da88",
                     "name": "Bulk Verify",
                     "request": {
                         "name": "Bulk Verify",
@@ -8400,7 +8420,7 @@
                     },
                     "response": [
                         {
-                            "id": "692ad1ad-cd1b-4b6b-8097-c84f4bdcbf5d",
+                            "id": "8efad2dd-e935-4603-97fa-267880d98d27",
                             "name": "Returns an array of international verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -8471,7 +8491,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "00dd3e5f-8cd7-4d7e-a0b8-97c99223788f",
+                            "id": "6af5e99b-5c4c-492a-b3f7-c0320a14f1e7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8530,7 +8550,7 @@
                     }
                 },
                 {
-                    "id": "03efc3c2-98c8-4765-a8ac-7a5b71a53486",
+                    "id": "ad03e6ac-4c97-4cea-a2ba-ce6093445395",
                     "name": "Single Verify",
                     "request": {
                         "name": "Single Verify",
@@ -8609,7 +8629,7 @@
                     },
                     "response": [
                         {
-                            "id": "912cd45c-568b-449b-9653-3de83b0b7971",
+                            "id": "2d59db18-efba-46e5-b894-63cbd804cb91",
                             "name": "Returns an international verification object.",
                             "originalRequest": {
                                 "url": {
@@ -8711,7 +8731,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e058cf42-075f-497b-82f8-38e5ce720f82",
+                            "id": "59d26306-e406-4f0d-9017-c3be12279268",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8804,7 +8824,7 @@
             "event": []
         },
         {
-            "id": "1174692a-11cd-41c7-9b63-3857ddaff441",
+            "id": "8a8c5bb7-70b2-44bf-b5f0-40870c10bd9e",
             "name": "Introduction",
             "description": {
                 "content": "Lob’s Print & Mail and Address Verification APIs help companies transform outdated,\nmanual print-and-mail processes; save 1,000s of hours in processing time by sending mail much more\nquickly; and increase ROI on offline communications.\n\nAutomate direct mail by triggering on-demand postcards, letters, and checks directly from your\nCRM or customer data systems.\n\nAddress Verification corrects, standardizes, and cleanses address data for assured delivery with\ninstant verification across 240+ countries and territories.\n\nLob's print delivery network eliminates the hassle of vendor management with automated\nproduction and postage across a global network of vetted commercial printers.\n\nTracking & Analytics gives you complete visibility of production and delivery for each piece of\nmail you send to meet compliance requirements and measure campaign performance.\n",
@@ -8814,7 +8834,7 @@
             "event": []
         },
         {
-            "id": "c59d88c2-1ee0-4888-86d7-9c331e2b66ad",
+            "id": "db001280-2812-4ac0-aadf-6cd656aece5c",
             "name": "Letters",
             "description": {
                 "content": "The letters endpoint allows you to easily print and mail letters. The API provides endpoints for\ncreating letters, retrieving individual letters, canceling letters, and retrieving a list of letters.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -8822,7 +8842,7 @@
             },
             "item": [
                 {
-                    "id": "5cd3f6c7-86e1-4d15-81e3-d3981d055f00",
+                    "id": "0994f9ce-e994-40e5-b563-24c910ebac77",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -8860,7 +8880,7 @@
                     },
                     "response": [
                         {
-                            "id": "cea4fb67-13fe-4720-9a05-5abe155038ab",
+                            "id": "bac782ed-3924-4838-87e6-79048669e40c",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -8908,7 +8928,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b1c84595-d036-4162-9677-be0da78a3d6e",
+                            "id": "6e92a43d-9f26-4b25-8fb1-3495bc098b54",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8959,7 +8979,7 @@
                     "event": []
                 },
                 {
-                    "id": "4a820b22-2b53-4324-80d7-a2cba92c2c0b",
+                    "id": "ac75d693-3971-4a99-ac93-add6e6d37a8a",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -8997,7 +9017,7 @@
                     },
                     "response": [
                         {
-                            "id": "4185f799-14c7-4252-9a02-7d4e4fbff843",
+                            "id": "926f79a5-4f7b-4737-b513-db6e9353b98e",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -9045,7 +9065,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b8d73a89-bc56-426d-a701-23ef25acf243",
+                            "id": "b4fa0b3a-ea43-43b2-8e2a-60e957c2caa7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9096,7 +9116,7 @@
                     "event": []
                 },
                 {
-                    "id": "51c006e2-2434-445a-9eb6-15d318e761d9",
+                    "id": "7a83e63a-369b-4c3b-ac75-0e12204372dd",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -9144,19 +9164,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -9204,7 +9236,7 @@
                     },
                     "response": [
                         {
-                            "id": "86bf424e-e501-401a-a189-5c85186c6078",
+                            "id": "09eeee8f-2302-4ca8-8044-45af49340a34",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -9236,11 +9268,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -9292,7 +9320,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3f10e29c-0873-4a4c-9636-a8e5484930d0",
+                            "id": "7fe2269f-450a-4b53-8d7f-da6c41770394",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9324,11 +9352,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -9383,7 +9407,7 @@
                     "event": []
                 },
                 {
-                    "id": "212fe452-69f5-4ca7-ad57-1afd5b146827",
+                    "id": "35d3f4dd-536a-4839-a993-5bcefbc257af",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -9559,7 +9583,7 @@
                     },
                     "response": [
                         {
-                            "id": "61c5de5d-84fe-4487-95c0-656fbee7e65b",
+                            "id": "3b779e50-75a6-4b6e-87e6-538d900bf16b",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -9821,7 +9845,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e11eed2d-be90-4290-9714-5a82bc670bd2",
+                            "id": "3815f46d-7996-4cef-8ac6-c3400d8a3c43",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10074,7 +10098,7 @@
             "event": []
         },
         {
-            "id": "45058563-e72f-4e6f-85f2-db9c7ec5fa08",
+            "id": "dfeebe80-8cc0-4850-8cbd-542f26ac24eb",
             "name": "Manage Mail",
             "description": {
                 "content": "## Cancellation Windows\n\nBy default, all new accounts have a 5 minute cancellation window for postcards,\nself mailers, letters, and checks. Within that timeframe, you can cancel\nmailings from production, free of charge. Once the window has passed for a\npostcard, self mailer, letter, or check, the mailing is no longer cancelable.\nIn addition, certain customers can customize their cancellation windows by\nproduct in their <a href=\"https://dashboard.lob.com/#\" target=\"_blank\">Dashboard Settings</a>. Upgrade to\nthe appropriate <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>\nto automatically gain access to this ability. For more details on this feature,\ncheck out our <a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#cancellation-windows-4\" target=\"_blank\">Cancellation Guide</a>.\n\nIf you schedule a postcard, self mailer, letter, or check for up to 180 days\nin the future by supplying the `send_date` parameter, that will override any\ncancellation window you may have for that product.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Scheduled Mailings\n\nPostcards, self mailers, letters, and checks can be scheduled to be sent up\nto 180 days in advance. You can use this feature to:\n- Create automated drip campaigns (e.g. send a postcard at 15, 30, and 60\ndays)\n- Schedule recurring sends\n- Plan your mailing schedule ahead of time\n\nUp until the time a mailing is scheduled for, it can also be canceled.\nIf you use this feature in conjunction with [a cancellation window](\nindex.html#section/Cancellation-Windows), the `send_date` parameter will always\ntake precedence.\n\nFor implementation details, see documentation below for each respective\nendpoint. For more help, see our <a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/choosing-a-delivery-strategy#scheduled-mailings-15\" target=\"_blank\">Scheduled Mailings Guide</a>.\n\nThis feature is exclusive to certain customers. Upgrade to the appropriate\n<a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a> to\ngain access.\n\n### Example Create Request using Send Date\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Future Postcard\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    -d \"front=tmpl_b846a20859ae11a\" \\\n    -d \"back=tmpl_01b0d396a10c268\" \\\n    -d \"merge_variables[name]=Harry\" \\\n    -d \"send_date=2021-07-26\"\n```\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -10084,7 +10108,7 @@
             "event": []
         },
         {
-            "id": "6315a8cb-6d5e-4c03-bc2c-1bb028694b47",
+            "id": "45749c7b-2c06-49d0-bc51-360af0796200",
             "name": "National Change of Address",
             "description": {
                 "content": "National Change of Address Linkage (NCOALink) is a service offered by the USPS, which allows individuals\nor businesses who have recently moved to have any mail forwarded from their previous address\nto their new address.\n\nAs a CASS-certified Address Verification Provider, Lob also offers NCOALink\nfunctionality to our Print & Mail customers. With the Lob NCOALink feature enabled, Postcards,\nLetters, Checks and Addresses can automatically be corrected to reflect an individual's or business's\nnew address in the case that they have moved (only if they have registered for NCOALink with the USPS).\n\nDue to privacy concerns and USPS constraints, for customers with NCOALink enabled, our API responses\nfor a limited set of endpoints differ slightly in the case when an address has been changed through NCOALink.\n\n**NOTE**: This feature is exclusive to certain customers. Upgrade to the appropriate <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a> to gain access.\n\nFor more information, see our <a href=\"https://help.lob.com/print-and-mail/all-about-addresses#national-change-of-address-ncoa-7\" target=\"_blank\">NCOALink guide</a>.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## NCOALink Live Environment\nThough there are no changes to API requests, there are significant changes to our API responses, but\nonly in the event that an address has been changed through NCOALink. If an address has not been changed\nthrough NCOALink, the response would be identical to our standard responses, except the addition of a\n`recipient_moved` field, which is `false` for unchanged addresses.\n\nIf an address has been changed through NCOALink, we are required to suppress the following response\nfields for that address:\n- `address_line1`\n- `address_line2`\n- The +4 portion of the ZIP+4 (5-digit ZIP code will still be present)\n\nSee the `ncoa_us_live` example under [Response samples](#operation/address_create) within the \"Create an Address\" section in Addresses\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## NCOALink Test Environment\n\nIn addition to sending live requests, you may also want to simulate what an NCOALink response might\nlook like so that you can ensure your application behaves as expected. The behavior of NCOALink in\nLob's Test Environment is very similar to our [US Verifications Test Mode](#section/US-Verifications-Test-Env).\n\nTo simulate an NCOALink request, send a POST request to any of the four endpoints below with an `address_line1` field equal to `NCOA`:\n- `POST /v1/addresses`\n- `POST /v1/checks`\n- `POST /v1/letters`\n- `POST /v1/postcards`\n- `POST /v1/self_mailers`\n\nA static address will always be returned, as documented in the `ncoa_us_test` example under [Response samples](#operation/address_create) within the \"Create an Address\"\nsection in Addresses (along with the corresponding request under \"Request samples\").\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -10094,7 +10118,7 @@
             "event": []
         },
         {
-            "id": "b8ea0443-c737-48fa-bbde-cda618213182",
+            "id": "405db204-f936-4ddb-a810-7eade8e98326",
             "name": "Postcards",
             "description": {
                 "content": "The postcards endpoint allows you to easily print and mail postcards. The API provides endpoints for creating postcards,\nretrieving individual postcards, canceling postcards, and retrieving a list of postcards.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -10102,7 +10126,7 @@
             },
             "item": [
                 {
-                    "id": "19427888-0c29-4ca1-8493-9fa09d380ba6",
+                    "id": "b3258d42-c521-475d-855f-04397bd38555",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -10140,7 +10164,7 @@
                     },
                     "response": [
                         {
-                            "id": "d1ab0287-3774-4564-abd9-1391b9130fa6",
+                            "id": "4e73e53a-c3db-4f20-983f-f704173c63ae",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -10188,7 +10212,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2fb967fe-ae78-48a3-ab01-2b7a69e3f640",
+                            "id": "f581447d-a177-4704-b4b9-5883c08f1668",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10239,7 +10263,7 @@
                     "event": []
                 },
                 {
-                    "id": "de41c149-e0ea-4816-8ffe-e26ef9329adf",
+                    "id": "1e0ca1e5-4e3a-40b9-9fa4-51e7edd908bc",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -10277,7 +10301,7 @@
                     },
                     "response": [
                         {
-                            "id": "44dc12e8-72fe-4598-a5aa-78fb3c566524",
+                            "id": "01aa4861-e72e-454a-a471-45d48790623b",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -10325,7 +10349,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a334562d-8e7c-4039-8392-847ffb74f71c",
+                            "id": "f28c8a97-9783-44b9-ba43-395d0cc5dc08",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10376,7 +10400,7 @@
                     "event": []
                 },
                 {
-                    "id": "cac5f7b3-d9bf-4f97-8d69-567f26e19f9b",
+                    "id": "f86bb4a6-df4d-47d7-ba8b-3e590ebec51b",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -10424,19 +10448,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -10490,7 +10526,7 @@
                     },
                     "response": [
                         {
-                            "id": "d9fad010-c6e8-450c-8895-713738552a92",
+                            "id": "2fbdc47a-92b6-48f6-b6ef-dea3c8d3dae3",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -10522,11 +10558,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -10582,7 +10614,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1e804cad-72ea-4471-b7e8-3f769dd44c9b",
+                            "id": "b08421f2-0e30-4466-9a1a-0537de58ef5e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10614,11 +10646,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -10677,7 +10705,7 @@
                     "event": []
                 },
                 {
-                    "id": "c1113533-00d0-4922-818c-b1c75014eff7",
+                    "id": "10f2ee78-53d8-4e48-a31f-4f89dbe8e93e",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -10833,7 +10861,7 @@
                     },
                     "response": [
                         {
-                            "id": "3f8ca267-21d5-4544-910f-ee6ad058d87e",
+                            "id": "62eef20a-739a-4f4f-b5c7-46d508351749",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -11095,7 +11123,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "98c84da9-8578-4680-a4f9-9f20cdf96562",
+                            "id": "5d1411f4-d4de-4fa3-b094-aad180192506",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11348,7 +11376,7 @@
             "event": []
         },
         {
-            "id": "6172dbea-98ed-4afc-960f-8433a9520ced",
+            "id": "ccad61ad-cd4c-46b6-9de4-1fa2e523e679",
             "name": "QR Codes",
             "description": {
                 "content": "\nLob QR codes allow you to generate a QR code that is unique to each mailpiece, thereby allowing each and every customers to receive a personalized link. See the Create endpoint for <a href=\"#tag/Letters/operation/letter_create\">Letters</a>, <a href=\"#tag/Postcards/operation/postcard_create\">Postcards</a> or <a href=\"#tag/Self-Mailers/operation/self_mailer_create\">Self Mailers</a> to learn how to embed a QR code into your mail piece.\n\nWebhooks can be used to integrate Lob QR code scans into your omni channel marketing strategy. See the <a href=\"#tag/Webhooks\">Webhooks</a> section of our documentation to learn how to enable the `letter.viewed`, `postcard.viewed` and `self_mailer.viewed` event notifications for your mail pieces.\n\nFurthermore, our QR code Analytics endpoint can be used to track the impact and engagement rate of your mail sends. Lob can tell you exactly which recipients opened your mailpiece. Our Analytics endpoint allows you to see exactly which recipient scanned a mailpiece, when they scanned it, and more!\n\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11356,7 +11384,7 @@
             },
             "item": [
                 {
-                    "id": "943c9b73-6945-47e8-9384-d49590e74a50",
+                    "id": "5d9a5665-403d-4ef2-910b-871f88a6c59a",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -11398,19 +11426,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -11434,7 +11474,7 @@
                     },
                     "response": [
                         {
-                            "id": "8dc215fb-41c5-4540-8b36-2b8d75b020d3",
+                            "id": "22bd819c-7e5f-43ad-9c54-c259b06d5fc0",
                             "name": "Returns a list of QR Codes and their analytics.",
                             "originalRequest": {
                                 "url": {
@@ -11462,11 +11502,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -11508,7 +11544,7 @@
             "event": []
         },
         {
-            "id": "9cbf2ab5-b181-47f9-a8ff-bfba6f43d3f5",
+            "id": "731b0d3d-7245-4c46-bdcf-424079fd7918",
             "name": "Rate Limiting",
             "description": {
                 "content": "To prevent misuse, we enforce a rate limit on an API Key and endpoint basis, similar to the way many other APIs enforce rate limits. By default, all accounts and their corresponding Test and Live API Keys have a rate limit of 150 requests per 5 seconds per endpoint. The `POST /v1/us_verifications` and `POST /v1/us_autocompletions` endpoints have a limit of 300 requests per 5 seconds for all accounts.\n\nWhen your application exceeds the rate limit for a given API endpoint, the Lob API will return an HTTP 429 \"Too Many Requests\" response code instead of the variety of codes you would find across the other API endpoints.\n\n**HTTP Headers**\n\nHTTP headers are returned on each request to a rate limited endpoint. Ensure that you inspect these headers during your requests as they provide relevant data on how many more requests your application is allowed to make for the endpoint you just utilized.\n\nWhile the headers are documented here in titlecase, HTTP headers are case insensitive and certain libraries may transform them to lowercase. Please inspect your headers carefully to see how they will be represented in your chosen development scenario.\n<table>\n  <tbody>\n    <tr>\n      <td>X-Rate-Limit-Limit:</td>\n      <td>the rate limit ceiling for a given request</td>\n    </tr>\n    <tr>\n      <td>X-Rate-Limit-Remaining:</td>\n      <td>the number of requests remaining in this window</td>\n    </tr>\n    <tr>\n      <td>X-Rate-Limit-Reset:</td>\n      <td>the time at which the rate limit window resets (in <a  href=\"https://en.wikipedia.org/wiki/Unix_time\"  target=\"_blank\">UTC epoch seconds</a>)\n    </td>\n    </tr>\n  </tbody>\n</table>\n\n### Example HTTP Headers\n\n```bash\n  X-Rate-Limit-Limit:150\n  X-Rate-Limit-Remaining:100\n  X-Rate-Limit-Reset:1528749846\n```\n\n### Example Response\n\nIf you hit the rate limit on a given endpoint, this is the body of the HTTP 429 message that you will see:\n\n```javascript\n  {\n    \"error\": {\n      \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n      \"code\": \"rate_limit_exceeded\",\n      \"status_code\": 429\n    }\n  }\n``` <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>",
@@ -11518,7 +11554,7 @@
             "event": []
         },
         {
-            "id": "33f339d3-dba0-4f3a-8c79-47eb6b5875dd",
+            "id": "034caee9-39bc-4bc5-bd75-90bd8e300dd1",
             "name": "Requests and Responses",
             "description": {
                 "content": "## Asset URLs\n\nAll asset URLs returned by the Lob API (postcards, letters, thumbnails,\netc) are signed links served over HTTPS. All links returned will expire in\n30 days to prevent mis-sharing. Each time a GET request is initiated, a\nnew signed URL will be generated.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Query Parameters\n\nQuery parameters which consist of lists of strings require that all elements of\nthe list be double-quoted, as per query filter standards.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Idempotent Requests\n\nLob supports idempotency for safely retrying `POST` requests to create\npostcards, self mailers, letters, and checks without accidentally creating\nduplicates.\n\nFor example, if a request to create a check fails due to a network error,\nyou can safely retry the same request with the same idempotency key and\nguarantee that only one check will ultimately be created and sent. When a\nrequest is sent with an idempotency key for an already created resource,\nthe response object for the existing resource will be returned.\n\nTo perform an idempotent `POST` request to one of the mailpiece product\nendpoints, provide an additional `Idempotency-Key` header or an `idempotency_key`\nquery parameter to the request. If multiple idempotency keys are provided,\nthe request will fail. How you create unique keys is up to you, but we\nsuggest using random values, such as V4 UUIDs. Idempotency keys are intended\nto prevent issues over a short periods of time, therefore keys expire after\n24 hours. Keys are unique by mode (Test vs. Live) as well as by resource\n(postcard vs. letter, etc.).\n\nBy default, all `GET` and `DELETE` requests are idempotent by nature, so\nthey do not require an additional idempotency key.\n\nFor more help integrating idempotency keys, refer to our\n<a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#idempotent-requests-12\" target=\"_blank\">implementation guide</a>.\n\n**Headers**\n<table>\n  <tbody>\n    <tr>\n      <td>Idempotency-Key:</td>\n      <td>\n        optional\n        <p style=\"color:#888;margin-top:0px;\">\n          <font size=\"-1\">\n            A string of no longer than 256 characters\n            that uniquely identifies this resource.\n          </font>\n        </p>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n**Query Parameters**\n<table>\n  <tbody>\n    <tr>\n      <td>idempotency-key:</td>\n      <td>\n        optional\n        <p style=\"color:#888;margin-top:0px;\">\n          <font size=\"-1\">\n            A string of no longer than 256 characters\n            that uniquely identifies this resource.\n          </font>\n        </p>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n### Example Request\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -H \"Idempotency-Key: 026e7634-24d7-486c-a0bb-4a17fd0eebc5\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    --data-urlencode \"front=<html style='margin: 130px; font-size: 50;'>Front HTML for {{name}}</html>\" \\\n    --data-urlencode \"back=<html style='margin: 130px; font-size: 50;'>Back HTML</html>\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Metadata\n\nWhen creating any Lob object, you can include a metadata object with up to 20 key-value pairs of\ncustom data. You can use metadata to store information like `metadata[customer_id] = \"987654\"` or\n`metadata[campaign] = \"NEWYORK2015\"`. This is especially useful for filtering and matching to internal\nsystems.\n\nEach metadata key must be less than 40 characters long and values must be less than 500 characters.\nMetadata does not support nested objects.\n\n### Example Create Request with Metadata\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Postcard job\" \\\n    -d \"metadata[campaign]=NEWYORK2015\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    --data-urlencode \"front=<html style='margin: 130px; font-size: 50;'>Front HTML for {{name}}</html>\" \\\n    --data-urlencode \"back=<html style='margin: 130px; font-size: 50;'>Back HTML</html>\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n\n### Example List Request with Metadata Filter\n\n```bash\n  curl -g \"https://api.lob.com/v1/postcards?metadata[campaign]=NEWYORK2015&limit=2\" \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc:\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n\n## Request Body\n\nWhen manually sending a POST HTTP request directly to the Lob API, without\nthe use of a library, you may represent the body as either a Form URL\nEncoded request, a JSON document, or a Multipart Form Data request.\n\nHowever, if you're using one of our [SDKs](#tag/SDKs-and-Tools),\nthe generation of the request bodies is done for you automatically and you don't\nneed to worry about the format.\n\n### Form URL Encoded\n\nThis request body encoding is accompanied with the\n`Content-Type: application/x-www-form-urlencoded` header. The content is an\nexample of what the [Verify a US address](index.html#operation/us_verification)\nendpoint accepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  primary_line=210 King Street&city=San Francisco&state=CA&zip_code=94107\n```\n\n### JSON\n\nThis request body encoding is accompanied with the `Content-Type: application/json` header.\nThe content is an example of what the [Verify a US address endpoint](index.html#operation/us_verification)\naccepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  {\n    \"primary_line\": \"210 King Street\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"zip_code\": \"94107\"\n  }\n```\n\n### Multipart Form Data\n\nThis request body encoding is accompanied with the `Content-Type: multipart/form-data`\nheader. This is the only format that can be used for uploading a file to the API. The\ncontent is an example of what the [Create a check](index.html#operation/check_create)\nendpoint accepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"description\"\n\n  Demo Letter\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"to\"\n\n  adr_bae820679f3f536b\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"from\"\n\n  adr_210a8d4b0b76d77b\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"file\"; filename=\"file.pdf\"\n  Content-Type: application/pdf\n\n  <FILE CONTENT>\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"color\"\n\n  true\n  --------------------------7015ebe79c0a5f8c--\n```\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11528,7 +11564,7 @@
             "event": []
         },
         {
-            "id": "f01ad166-81e9-43d8-bdb2-6fa15f949869",
+            "id": "bffb1946-b023-4494-bef8-ef4922aa96ed",
             "name": "Reverse Geocode Lookups",
             "description": {
                 "content": "Find a list of zip codes associated with a valid US location via latitude and longitude. <br> <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11536,7 +11572,7 @@
             },
             "item": [
                 {
-                    "id": "f5943456-9f49-464b-87d9-60989304a90e",
+                    "id": "8ff6f0d0-2519-4dfc-bc25-1d7237e503ff",
                     "name": "Reverse Geocode Lookup",
                     "request": {
                         "name": "Reverse Geocode Lookup",
@@ -11593,7 +11629,7 @@
                     },
                     "response": [
                         {
-                            "id": "c55d1b40-d5af-4ae8-ad6d-170e0be4c6ee",
+                            "id": "95fac5ac-6414-4d96-8a57-b8e8f8fed945",
                             "name": "Returns a zip lookup object if a valid zip was provided.",
                             "originalRequest": {
                                 "url": {
@@ -11677,7 +11713,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "be34a09e-2d97-47cf-8c58-8990beb80612",
+                            "id": "53f0b763-d075-4fcf-89d8-238b7dac0491",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11752,7 +11788,7 @@
             "event": []
         },
         {
-            "id": "ff37bac6-6232-41cb-8df7-f9d3ef7c7234",
+            "id": "1fde8574-4781-4270-bb16-671a7b1bc44a",
             "name": "SDKs and Tools",
             "description": {
                 "content": "Please visit our <a href=\"https://www.github.com/lob\" target=\"_blank\">Github</a> for a list of our supported libraries.\n- <a href=\"https://github.com/lob/lob-typescript-sdk\" target=\"_blank\">Typescript</a>\n- <a href=\"https://github.com/lob/lob-php\" target=\"_blank\">PHP</a>\n- <a href=\"https://github.com/lob/lob-python\" target=\"_blank\">Python</a>\n- <a href=\"https://github.com/lob/lob-java\" target=\"_blank\">Java</a>\n- <a href=\"https://github.com/lob/lob-ruby/tree/main\" target=\"_blank\">Ruby</a>\n- <a href=\"https://github.com/lob/lob-dotnet\" target=\"_blank\">CSharp</a>\n- <a href=\"https://github.com/lob/lob-elixir\" target=\"_blank\">Elixir</a>\n- <a href=\"https://github.com/lob/lob-go\" target=\"_blank\">Go</a>\n- <a href=\"https://github.com/lob/lob-node\" target=\"_blank\">Node.js (legacy)</a>\n- <a href=\"https://github.com/lob/lob-java/tree/12.3.7-Legacy\" target=\"_blank\">Java (legacy)</a>\n- <a href=\"https://github.com/lob/lob-php/tree/v3-legacy\" target=\"_blank\">PHP (legacy)</a>\n- <a href=\"https://github.com/lob/lob-python/tree/legacy_v4\" target=\"_blank\">Python (Legacy)</a>\n- <a href=\"https://github.com/lob/lob-ruby/tree/legacy-v5\" target=\"_blank\">Ruby (Legacy)</a>\n\n<br><br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11762,7 +11798,7 @@
             "event": []
         },
         {
-            "id": "fd6fb5de-ead9-4dcb-af0c-f46c31e2d964",
+            "id": "32f57a7f-3f9d-4ad3-806e-cef478974855",
             "name": "Self Mailers",
             "description": {
                 "content": "The self mailer endpoint allows you to easily print and mail self mailers. The API provides endpoints\nfor creating self mailers, retrieving individual self mailers, canceling self mailers, and retrieving a list of self mailers.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11770,7 +11806,7 @@
             },
             "item": [
                 {
-                    "id": "3356592e-5624-4586-9c86-106f0b72b37d",
+                    "id": "478ad781-f524-4ea3-9587-5fd450ea4185",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -11808,7 +11844,7 @@
                     },
                     "response": [
                         {
-                            "id": "d317ea71-b615-4812-b431-e715dab357b6",
+                            "id": "918ba075-fe5f-4986-a89d-9cf6ef3c93ff",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -11856,7 +11892,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "389a81f0-56da-4e23-a81c-cfd98ae1b9f0",
+                            "id": "e5db8a7a-5e0a-46d0-a94b-eeded303d7ab",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11907,7 +11943,7 @@
                     "event": []
                 },
                 {
-                    "id": "7505e91e-f9a7-47fa-bfb7-ca5453ddafb8",
+                    "id": "321a2d7e-4831-4592-befd-65637c73b9b2",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -11945,7 +11981,7 @@
                     },
                     "response": [
                         {
-                            "id": "5f989920-fc27-48fb-aad8-500d17e61b1b",
+                            "id": "e11652d5-316a-4d69-aef5-7f74c1845100",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -11993,7 +12029,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2ea3b106-85b2-45be-b7dc-1ed0ea2a34d6",
+                            "id": "eb416598-0e1c-4c85-8579-c61530112833",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12044,7 +12080,7 @@
                     "event": []
                 },
                 {
-                    "id": "146f321b-c00b-4037-a71b-b9219a4dd9f0",
+                    "id": "da88c8f3-d9fc-4c88-a7ed-c1ab978776fb",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -12092,19 +12128,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -12158,7 +12206,7 @@
                     },
                     "response": [
                         {
-                            "id": "768e96e9-c2e2-465e-a13a-811bb64807f4",
+                            "id": "a5c656a2-f3ed-4afb-871c-db8db56faeb9",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -12190,11 +12238,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -12250,7 +12294,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5c1fe04f-c491-4665-b249-e3520d9837ec",
+                            "id": "b64733a8-c68d-496a-9aa0-c3632588a868",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12282,11 +12326,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -12345,7 +12385,7 @@
                     "event": []
                 },
                 {
-                    "id": "9616f5ca-f765-4d56-8fd4-16bbe542537f",
+                    "id": "99b34f03-e7f2-4b96-aaff-c981dae55423",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -12501,7 +12541,7 @@
                     },
                     "response": [
                         {
-                            "id": "db9e2594-c444-4155-90dc-18376cc9ef4f",
+                            "id": "6e5ad5e3-825e-4167-b388-0c82918a343a",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -12663,7 +12703,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "11cbcfd5-1c99-4fcf-9850-40a191e4e195",
+                            "id": "76cfa7e7-61c9-48b8-8a3d-72d6edb414de",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12816,7 +12856,7 @@
             "event": []
         },
         {
-            "id": "29f70567-dc03-4093-bbd6-135f218f88ef",
+            "id": "c84aca93-77e2-4c98-99b5-7a488b43aa6b",
             "name": "Template Design",
             "description": {
                 "content": "## HTML Templates\nYou can save commonly used HTML as templates within Lob to more easily manage them. You can reference\nyour saved templates in postcard, letter, and check requests instead of having to pass a long HTML\nstring on each request. Additionally, you can make changes to your HTML templates and update them\nindependently, without having to touch your API integration. Templates can be created, edited,\nand viewed on your <a href=\"https://dashboard.lob.com/#/templates\" target=\"_blank\">Dashboard</a>. To use a template in a postcard,\nletter, or check, see the documentation for each endpoint below. For help using templates, check out our\n<a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/dynamic-personalization#html-templates-1\" target=\"_blank\">HTML Templates Guide</a> or get started with a\n<a href=\"https://lob.com/template-gallery\" target=\"_blank\">pre-designed template from our gallery</a>. In Live mode, you can only have\nas many templates as allotted in your current\n<a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>. There is no limit in Test mode.\n\nIf you'd like to interact with templates programmatically, check out our Beta Program for API access\nto the [HTML Templates Endpoints](#tag/Templates).\n\n### Example Create Request using HTML Templates\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Postcard job\" \\\n    -d \"to=adr_78c304d54912c502\" \\\n    -d \"from=adr_61a0865c8c573139\" \\\n    -d \"front=tmpl_b846a20859ae11a\" \\\n    -d \"back=tmpl_01b0d396a10c268\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## HTML Examples\nUse a pre-designed template from our <a href=\"https://lob.com/resources/template-gallery\" target=\"_blank\">gallery</a> or follow these\nbasic <a href=\"https://github.com/lob/examples\" target=\"_blank\">guidelines</a> as starting points for creating custom Postcards,\nSelf Mailers, Letters, and Checks.\n\nPlease follow the standards used in these templates, such as:\n- For any linked assets, you must use a performant file hosting provider with no rate limits such as Amazon\nS3.\n- Use inline styles or an internal stylesheet, do not link to external stylesheets.\n- Link to images that are 300DPI and sized at the final desired size on the physical mailing. For example,\nfor a photo that is desired to be 1in x 1in on the final postcard, the image asset should be sized at 1in\nx 1in at 300DPI (which equates to 300px by 300px).\n- The sum of all linked assets should not exceed 5MB in file size.\n- Use `-webkit` prefixes for CSS properties when recommended <a href=\"http://shouldiprefix.com/\" target=\"_blank\">here</a>.\n\nBecause different browsers have varying user-agent styles, the HTML you see in your browser will not\nalways look identical to what is produced through the API. It is **strongly** recommended that you test all\nHTML requests by reviewing the final PDF files in your Test Environment, as these are the files that will be\nprinted.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Image Prepping\nCurrently we support the following file types for all endpoints:\n- PDF\n- PNG\n- JPEG\n\n**Templates**\n\nYou can find pre-made templates that already adhere to all of these guidelines here:\n- [Postcards](#tag/Postcards)\n- [Letters](#tag/Letters)\n- [Checks](#tag/Checks)\n- [Self Mailers](#tag/Self-Mailers)\n\n**Prepping All Images**\n\nThe following guidelines apply to image types:\n- Images should be 300 dpi or higher - PNG/JPEG files with less than 300 dpi will be rejected.\n- Your artwork should include a 1/8\" border around the final trim size. This means your final file size will be a total of 0.25\" larger than your expected printed piece (ie, a 4\"x6\" postcard should be submitted as 4.25\"x6.25\"). There is no need to include crop marks in your submitted content.\n- Include a safe zone – make sure no critical elements are within 1/8\" from the edge of the final size.\n- Do not include any additional postage marks or indicia.\n- File sizes should be no larger than 5MB.\n\n**Prepping PDFs**\n\nTo ensure that you are producing PDF's correctly please follow the guidelines below:\n- [Make sure all non-standard fonts are embedded.](#section/Standard-PDF-Fonts)\n- Generated PDF's need to be be PDF/A compliant.\n\n**Prepping PNGs/JPEGs**\n\nTo ensure that you are producing PNG's/JPEG's correctly please follow the guidelines below:\n\n- Minimum 300 dpi. The dpi is calculated as (width of image in pixels) / (width of product in inches) and (length of image in pixels) / (length of product in inches). For Example: 1275px x 1875px image used to create a 4.25\" x 6.25\" postcard has a dpi of 300.\n- Submitted images must have the same length to width ratio as the chosen product. Images will not be cropped or stretched by the API.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Standard PDF Fonts\nIdeally, all fonts in provided PDFs should be embedded. Embedding a font in a PDF ensures that the final\nprinted product will look as it was designed. Fonts can vary greatly in size and shape, even within the\nsame family. If the exact font that was used to design the artwork is not used to print, the look and\nplacement of the text is not guaranteed to be the same.\n\nIn general, requests that provide PDFs with un-embedded fonts will be rejected. We make an exception for\n\"standard fonts\", a set of fonts that we have identified as being common. PDFs that contain un-embedded\nfonts that are found in the list, and match the accepted <a href=\"https://en.wikipedia.org/wiki/Category:Font_formats\" target=\"_blank\">font type</a>\nwill be accepted. Otherwise, the request will be rejected.\n\nFont embedding is an essential part of standard PDF workflows. Fonts should be embedded automatically by\nPDF editing software that are compliant with PDF standards.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">FONT NAME</th>\n    <th style=\"white-space: nowrap\">TYPES</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,BoldItalic</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-BoldItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialNarrow</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialNarrow-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri-Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-Oblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-BoldOblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPSMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPS-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPS-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-BoldOblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-Oblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>LucidaConsole</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>MsSansSerif</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>MsSansSerif,Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Symbol</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Tahoma</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Tahoma-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-BoldItalic</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Italic</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Roman</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-BoldItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPSMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPSMT,Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana,Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ZapfDingbats</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12826,7 +12866,7 @@
             "event": []
         },
         {
-            "id": "72f7da91-93ce-453c-9c55-f6c574d0cfb3",
+            "id": "f3f00ab1-4396-4ccc-9776-889199117936",
             "name": "Template Versions",
             "description": {
                 "content": "These API endpoints allow you to create, retrieve, update and delete versions of reusable HTML templates for use with the Print & Mail API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12834,7 +12874,7 @@
             },
             "item": [
                 {
-                    "id": "b4e38da5-a913-4eb5-a1a5-4a9f4ed0f918",
+                    "id": "4ec00c48-84c5-4c04-99b9-b0138b1facd2",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -12881,7 +12921,7 @@
                     },
                     "response": [
                         {
-                            "id": "ebf499c9-62d5-4bcf-9c61-66025c1fd574",
+                            "id": "3c58055f-f65f-46f3-b75f-cde5d508e5dd",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -12938,7 +12978,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e0ab5dd9-6cfd-494a-95cf-bc9bb72fb0bb",
+                            "id": "f32260b9-e479-49c7-bb0a-e0f681f41014",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12998,7 +13038,7 @@
                     "event": []
                 },
                 {
-                    "id": "c499aa5b-62d6-4fb9-8579-885d0f144289",
+                    "id": "2a242e98-2a0c-4e6b-b3b3-b7721853c4cb",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -13074,7 +13114,7 @@
                     },
                     "response": [
                         {
-                            "id": "01cf575a-56ad-4745-97e1-14bd0d5f75e8",
+                            "id": "b85b3711-79b4-45ba-b047-62b0d7ec0520",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -13158,7 +13198,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bf3aab50-d02f-49d6-b754-968454392d84",
+                            "id": "4047c3fc-8b47-4f5f-bd33-a5cf7ab921c4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13230,7 +13270,7 @@
                     }
                 },
                 {
-                    "id": "89667114-faa2-419a-8627-a4c8bb6e3641",
+                    "id": "37b25d88-4b33-4aa6-b1cb-afe09a006834",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -13277,7 +13317,7 @@
                     },
                     "response": [
                         {
-                            "id": "fc46a7ec-8449-4fee-93f6-1ef547b2928c",
+                            "id": "686b8c31-0e71-4980-84e6-3f6c24c52e0b",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -13334,7 +13374,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "12ff0d13-8349-4095-bd4c-6f02cef54a0a",
+                            "id": "5b661041-e50f-424f-809c-2b60d7777848",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13394,7 +13434,7 @@
                     "event": []
                 },
                 {
-                    "id": "fade1ec6-6b90-4038-bf49-43e05cc43a9e",
+                    "id": "da92979b-c8b3-4148-8114-e14cd482a2a7",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -13444,19 +13484,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -13482,7 +13534,7 @@
                     },
                     "response": [
                         {
-                            "id": "27d4b8a0-2419-4e8a-b025-a7c41d1706e4",
+                            "id": "3ce5a4a9-a9a9-4718-974f-fdd2e4861463",
                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -13516,11 +13568,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -13560,7 +13608,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "755f2cee-ce15-474b-8860-a75e5ddff61a",
+                            "id": "e0911ac1-9f6f-4ecb-8864-511125d422b1",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13594,11 +13642,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -13641,7 +13685,7 @@
                     "event": []
                 },
                 {
-                    "id": "ddf08642-db22-434c-8cf9-f0f4ffc7bd76",
+                    "id": "896795b2-c057-4b6d-be24-551dc18f18a8",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -13715,7 +13759,7 @@
                     },
                     "response": [
                         {
-                            "id": "477df98b-8e5a-4087-a71d-a108387e02a4",
+                            "id": "c9247b82-7d32-4702-8024-4f6e1d2cd4b2",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -13800,7 +13844,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b0200040-5d8c-4ca9-9006-0986deeab659",
+                            "id": "9a63cb13-5230-44a2-b2b9-5f49fe734703",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13876,7 +13920,7 @@
             "event": []
         },
         {
-            "id": "b53e0124-1d93-469e-8ca4-8553de6532c7",
+            "id": "611b3eff-8446-4415-9712-ce19d2a65451",
             "name": "Templates",
             "description": {
                 "content": "These API endpoints allow you to create, retrieve, update and delete reusable HTML templates for use with the Print & Mail API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -13884,7 +13928,7 @@
             },
             "item": [
                 {
-                    "id": "d22d1ce0-25ad-435a-824b-ad24aecd8a68",
+                    "id": "b4cbef9d-a6dd-4cb2-9034-f25cb955f169",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -13922,7 +13966,7 @@
                     },
                     "response": [
                         {
-                            "id": "34ebe35c-b26c-4d20-a612-1a2af2669ebf",
+                            "id": "164b7dec-85ab-4b08-8527-78069c36bc96",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -13970,7 +14014,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a0fac9fe-7e74-4bd0-bee0-5070c6ef77fe",
+                            "id": "d14f9e26-4f6f-4d2d-aa6f-b1e18a38767b",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14021,7 +14065,7 @@
                     "event": []
                 },
                 {
-                    "id": "b27f15c2-5505-4652-a56e-687ce0e951b8",
+                    "id": "47deceb7-97e7-448f-89ba-280bc0e0ee2b",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -14078,7 +14122,7 @@
                     },
                     "response": [
                         {
-                            "id": "2e01fcce-1c56-4886-ab34-0804c1e850c0",
+                            "id": "d5c7abcb-1bc5-4d46-8017-4a5d240e9bd0",
                             "name": "Returns the updated template object",
                             "originalRequest": {
                                 "url": {
@@ -14158,7 +14202,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "588510c6-f88b-452a-b51a-a2b03a816216",
+                            "id": "ab3d4598-705e-4aba-aa27-ab7e32ff734d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14226,7 +14270,7 @@
                     }
                 },
                 {
-                    "id": "fd66c551-8831-465e-b0b0-a0383822b440",
+                    "id": "0227ea01-87cc-4d35-92d6-63be51e62ee5",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -14264,7 +14308,7 @@
                     },
                     "response": [
                         {
-                            "id": "03d4bf76-5d5c-4a4e-ae78-9a1286b2da8b",
+                            "id": "30a22d3d-0d9f-4523-87b0-d7ca8e1c257e",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -14312,7 +14356,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "36f1ba30-b1a9-4b44-b7d2-d7e3abed3edd",
+                            "id": "1d82b9dd-7ce1-46d0-900a-d8f149a3744f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14363,7 +14407,7 @@
                     "event": []
                 },
                 {
-                    "id": "d5d569b5-54d7-4a85-86c0-6252ab465b10",
+                    "id": "7bc6b42f-542a-4422-9059-f47269967a7f",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -14411,19 +14455,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -14441,7 +14497,7 @@
                     },
                     "response": [
                         {
-                            "id": "dfa07df4-1a04-47d4-b065-a80133006b08",
+                            "id": "27c161b6-597a-4e43-bab5-53f695b94ce5",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -14473,11 +14529,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -14509,7 +14561,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0502f43c-d6d3-4f44-b899-293130475066",
+                            "id": "29abd80c-9417-4f19-9f0a-41c86f31d99d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14541,11 +14593,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -14580,7 +14628,7 @@
                     "event": []
                 },
                 {
-                    "id": "e7eed465-7f1b-4705-ac56-0fc9359ec807",
+                    "id": "6eeb69ae-3f42-4638-9110-821687c8ed7f",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -14627,7 +14675,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "pp)YdZB9Snfjd$c'&-cO$z Qfb {mLz[u]sx4GuV> nd* z3i*n8RA/h;a8y2ckLWX)un/xxMyk=ZSd8=r`wi<w-yeNBjncVbW D/ONG%#R8N8?P+539WtCc>a6#<35Fo=V-{<Vu1'n $V^QF Cj4]OBztw1cn"
+                                    "value": "3_SP&3#GeP^*aiB_:WMhU9<b!Vt9b'3wd=C4`D/3[OnIV<!0hCLjG,?WfG8l!M}CRYzBoy2sH]+Sok8m0Al.TW9M9|Ag*V8K&|<,V)92Tn)Xio3#R^3!*1!WfwW^|4%KIjJ<3z'%Q@8v3BK>@iuO?Kbg9D/4P33N kRnI_vODi@ZK]ydx$Er)`t'.x0s*MW(O]:4?L=>Tl52h{|t**K!Gt54C!rb9<o+5$L+=yL}.#*rx<,+nO1ZCH;/e@f;=giJ.f@rNO/^:C3%z64|+d->(gA#pWSL9fD)"
                                 },
                                 {
                                     "disabled": false,
@@ -14649,7 +14697,7 @@
                     },
                     "response": [
                         {
-                            "id": "9fac2c3d-6cd4-4055-a8fb-efff97e1a54f",
+                            "id": "fba0c6d2-9e5b-45b5-96c4-89e55b82ff97",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -14734,7 +14782,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fb645ea6-0152-407e-8788-50d17a2f0648",
+                            "id": "9685d9fc-2323-4c86-8260-41a7e33fef0d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14810,7 +14858,7 @@
             "event": []
         },
         {
-            "id": "689b8ac5-df62-4271-8ea7-e11f36d95f1b",
+            "id": "a195a811-898c-4b97-a91a-bbf768734732",
             "name": "Test and Live Environments",
             "description": {
                 "content": "To make the API as explorable as possible, accounts have test and live\nenvironment API keys. You're not charged any fees in the test environment,\nso we encourage you to use it to try out services, perform quality\nassurance, and run automated testing. Objects―addresses, letters, checks,\netc―in one environment cannot be manipulated by objects in the other.\n\nIn general, a payment method (either credit card or ACH account) must be\nadded to your account to make live API requests. However, a payment method\nis not required for the first 300 live requests per month to the\n`/v1/us_verifications` endpoint. After the first 300 requests, you will\nbegin receiving errors with status code `403`.\n\nRequests made in the test environment always validate request arguments,\nsimulate live environment behavior, and enforce rate limits. _They never\nprint, mail nor, for verification services, verify addresses._ The US &\nInternational verification services trigger behavior with specific\nargument values, and, if you plan on using those, we recommend reading\n[US Verification Test Environment](#tag/US-Verifications-Test-Environment)\nand [Intl Verification Test Environment](#tag/Intl-Verifications-Test-Environment).\n\nTo switch between environments, use the appropriate key for that\nenvironment when performing a request. You can find each environment's API\nkey in your dashboard under Settings; test API keys are always prefixed\nwith `test_` and production API keys with `live_`.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -14820,7 +14868,7 @@
             "event": []
         },
         {
-            "id": "6c7c9995-7268-4767-8be3-36f3ee4acb86",
+            "id": "05c3386e-2c02-4bb7-844d-ce1eeb5f0fed",
             "name": "Tracking Events",
             "description": {
                 "content": "As mailpieces travel through the mail stream, USPS scans their unique barcodes, and Lob processes these mail scans to generate tracking events.\n\n<h3>Certified Tracking Event Details</h3>\n\nLetters sent with USPS Certified Mail are fully tracked by USPS, and\ntherefore their [tracking events](#operation/tracking_event) have an\nadditional `details` object with more detailed information about the\ntracking event. The following table shows the potential values for\nthe fields in the `details` object mapped to the tracking event `name`.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">NAME</th>\n    <th style=\"white-space: nowrap\">EVENT</th>\n    <th style=\"white-space: nowrap\">DESCRIPTION</th>\n    <th style=\"white-space: nowrap\">ACTION REQUIRED</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Mailed</td>\n    <td style=\"white-space: nowrap\"><code>package_accepted</code></td>\n    <td>Package has been accepted into the carrier network for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_arrived</code></td>\n    <td>Package has arrived at an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_departed</code></td>\n    <td>Package has departed from an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_processing</code></td>\n    <td>Package is processing at an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_processed</code></td>\n    <td>Package has been processed at an intermediate location.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Local Area</td>\n    <td style=\"white-space: nowrap\"><code>package_in_local_area</code></td>\n    <td>Package is at a location near the end destination.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Processed For Delivery</td>\n    <td style=\"white-space: nowrap\"><code>delivery_scheduled</code></td>\n    <td>Package is scheduled for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Processed For Delivery</td>\n    <td style=\"white-space: nowrap\"><code>out_for_delivery</code></td>\n    <td>Package is out for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Pickup Available</td>\n    <td style=\"white-space: nowrap\"><code>pickup_available</code></td>\n    <td>Package is available for pickup at carrier location.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Delivered</td>\n    <td style=\"white-space: nowrap\"><code>delivered</code></td>\n    <td>Package has been delivered.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Re-Routed</td>\n    <td style=\"white-space: nowrap\"><code>package_forwarded</code></td>\n    <td>Package has been forwarded.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Returned to Sender</td>\n    <td style=\"white-space: nowrap\"><code>returned_to_sender</code></td>\n    <td>Package is to be returned to sender.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>address_issue</code></td>\n    <td>Address information is incorrect. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>contact_carrier</code></td>\n    <td>Contact the carrier for more information.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delayed</code></td>\n    <td>Delivery of package is delayed.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delivery_attempted</code></td>\n    <td>Delivery of package has been attempted. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delivery_rescheduled</code></td>\n    <td>Delivery of package has been rescheduled.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>location_inaccessible</code></td>\n    <td>Delivery location inaccessible to carrier. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>notice_left</code></td>\n    <td>Carrier left notice during attempted delivery. Follow carrier instructions on notice.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_damaged</code></td>\n    <td>Package has been damaged. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_disposed</code></td>\n    <td>Package has been disposed.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_held</code></td>\n    <td>Package held at carrier location. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_lost</code></td>\n    <td>Package has been lost. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_unclaimed</code></td>\n    <td>Package is unclaimed.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_undeliverable</code></td>\n    <td>Package is not able to be delivered.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>reschedule_delivery</code></td>\n    <td>Contact carrier to reschedule delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>other</code></td>\n    <td>Unrecognized carrier status.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -14830,7 +14878,7 @@
             "event": []
         },
         {
-            "id": "98b58037-36b9-44e9-b965-a4bba6a001a6",
+            "id": "f950d780-7d46-4465-9257-fc2355745773",
             "name": "Uploads",
             "description": {
                 "content": "The uploads endpoint allows you to upload audience files that are then associated with a given campaign.\nAt this time, only CSV files are allowed. The API provides endpoints for creating uploads, uploading audience files,\nand marking uploaded files as ready for processing. The API also provides endpoints for downloading files that\ndescribe the results, both successful and not, of the processing.\n",
@@ -14838,7 +14886,7 @@
             },
             "item": [
                 {
-                    "id": "e2be4c63-bcb5-4670-9c09-8f55003a62c5",
+                    "id": "323a3aed-d4c9-4652-87e5-41751aa15c55",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -14874,7 +14922,7 @@
                     },
                     "response": [
                         {
-                            "id": "1c4de47e-24dd-44da-ab31-81cc7417c377",
+                            "id": "75072310-5b09-4868-8631-b7a8e70ca4d6",
                             "name": "An array of matching uploads. Each entry in the array is a separate upload.",
                             "originalRequest": {
                                 "url": {
@@ -14921,7 +14969,7 @@
                     "event": []
                 },
                 {
-                    "id": "26be1946-c7ab-4db5-9a2e-d80d62daeea2",
+                    "id": "d655b00c-511b-4660-80b9-965900f51575",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -14963,7 +15011,7 @@
                     },
                     "response": [
                         {
-                            "id": "1fe45b8a-7ead-4f3f-abbb-e4b32cf15179",
+                            "id": "eb1c185b-9b6b-44c2-a42f-6bac098a7d3a",
                             "name": "Upload created successfully",
                             "originalRequest": {
                                 "url": {
@@ -15010,7 +15058,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d424b62e-0c1b-4342-98bc-7373fd348974",
+                            "id": "463c1d41-e6f0-442a-87dc-38b63a7f085e",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15052,7 +15100,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"dolore in commodo eu\",\n        \"consectetur\"\n      ],\n      \"msg\": \"occaecat aute\",\n      \"type\": \"et in eu quis\"\n    },\n    {\n      \"loc\": [\n        \"in velit tempor\",\n        \"magna ex aliq\"\n      ],\n      \"msg\": \"dolor exercitation laboris occaecat\",\n      \"type\": \"Lorem magna\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"cillum in\",\n        \"anim tempor occaecat veniam\"\n      ],\n      \"msg\": \"consequat consectetur ut\",\n      \"type\": \"consequat esse ut mollit amet\"\n    },\n    {\n      \"loc\": [\n        \"officia ex occaecat aliquip\",\n        \"in reprehenderit nulla\"\n      ],\n      \"msg\": \"consequat\",\n      \"type\": \"ea ut Ut\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15063,7 +15111,7 @@
                     }
                 },
                 {
-                    "id": "356c9d5f-4424-4c64-ab15-729847df194d",
+                    "id": "cf36abb4-70e4-4c52-850a-9b0c63b4b20c",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -15101,7 +15149,7 @@
                     },
                     "response": [
                         {
-                            "id": "994812bb-a6fb-4bd5-8b4f-d19af91f6f29",
+                            "id": "f3dc7115-28ad-463c-beaa-e3edb0105af4",
                             "name": "Returns an upload object",
                             "originalRequest": {
                                 "url": {
@@ -15149,7 +15197,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d92992e9-aa13-49d6-8ec0-ce141497c428",
+                            "id": "4a78bb02-acc6-4c33-9caa-8929b72dadbe",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -15197,7 +15245,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3a86aae3-2db9-4350-914f-4eef98837e28",
+                            "id": "afac279d-9abd-4280-889b-6474604a3faf",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15240,7 +15288,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"sunt officia velit Duis\",\n        \"consectetur labore aute laborum\"\n      ],\n      \"msg\": \"fugiat ullamco\",\n      \"type\": \"sunt\"\n    },\n    {\n      \"loc\": [\n        \"aute deserunt\",\n        \"elit occaecat\"\n      ],\n      \"msg\": \"id\",\n      \"type\": \"dolor mollit labore\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"consequat sit exercitation deserunt aute\",\n        \"ullamco sint velit commodo\"\n      ],\n      \"msg\": \"dolor Lorem do Ut\",\n      \"type\": \"in culpa ullamco aliqua\"\n    },\n    {\n      \"loc\": [\n        \"nulla\",\n        \"voluptate pariatur do\"\n      ],\n      \"msg\": \"dolore\",\n      \"type\": \"eu enim non\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15248,7 +15296,7 @@
                     "event": []
                 },
                 {
-                    "id": "f01db7e6-3523-473e-b4a2-bee06b7bdb57",
+                    "id": "fa4e6d75-b29c-4e51-b5e6-700ca6342b7f",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -15299,7 +15347,7 @@
                     },
                     "response": [
                         {
-                            "id": "280a48aa-28c6-442b-9364-4a0dcdcc8100",
+                            "id": "72373cba-d4cd-4da7-8ae7-640e2d50ada6",
                             "name": "Returns an upload object",
                             "originalRequest": {
                                 "url": {
@@ -15355,7 +15403,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8bbcbdcd-c767-48cc-874d-6dde528132b6",
+                            "id": "ca45a22e-1f0c-4410-badc-93db4d8d7389",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -15411,7 +15459,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5bae0ca2-ad46-4fe0-8c70-8e81cf5de0c4",
+                            "id": "442d4f83-6108-47a8-933b-a995c7b8a651",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15462,7 +15510,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"sunt officia velit Duis\",\n        \"consectetur labore aute laborum\"\n      ],\n      \"msg\": \"fugiat ullamco\",\n      \"type\": \"sunt\"\n    },\n    {\n      \"loc\": [\n        \"aute deserunt\",\n        \"elit occaecat\"\n      ],\n      \"msg\": \"id\",\n      \"type\": \"dolor mollit labore\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"consequat sit exercitation deserunt aute\",\n        \"ullamco sint velit commodo\"\n      ],\n      \"msg\": \"dolor Lorem do Ut\",\n      \"type\": \"in culpa ullamco aliqua\"\n    },\n    {\n      \"loc\": [\n        \"nulla\",\n        \"voluptate pariatur do\"\n      ],\n      \"msg\": \"dolore\",\n      \"type\": \"eu enim non\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15473,7 +15521,7 @@
                     }
                 },
                 {
-                    "id": "44392083-e664-40d6-acd0-472163b8faa1",
+                    "id": "6f685f58-7a84-4807-ba55-2af72c6adfcb",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -15505,7 +15553,7 @@
                     },
                     "response": [
                         {
-                            "id": "e6fc5a4f-afeb-49f9-86c0-eff278f5752e",
+                            "id": "b11b4d41-c801-4545-8409-b2fc255359be",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -15556,7 +15604,7 @@
                     "event": []
                 },
                 {
-                    "id": "3764b8f0-ec96-48ad-96e9-12178db48138",
+                    "id": "90af1ec9-831a-4da6-9eb8-745ea3b550e5",
                     "name": "Upload file",
                     "request": {
                         "name": "Upload file",
@@ -15609,7 +15657,7 @@
                     },
                     "response": [
                         {
-                            "id": "9f52cb52-20d6-4af0-9be4-2e5d41ecc768",
+                            "id": "b7ac50f4-e83d-42cb-9b8d-cf388b687526",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -15666,12 +15714,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"message\": \"File uploaded successfully\",\n  \"filename\": \"eiu\"\n}",
+                            "body": "{\n  \"message\": \"File uploaded successfully\",\n  \"filename\": \"id irure\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c9dfed3a-e904-4840-8bfc-e23938ea682a",
+                            "id": "029fc041-4c14-4ec5-b58b-dcb799c5d6d5",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15728,7 +15776,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"sunt officia velit Duis\",\n        \"consectetur labore aute laborum\"\n      ],\n      \"msg\": \"fugiat ullamco\",\n      \"type\": \"sunt\"\n    },\n    {\n      \"loc\": [\n        \"aute deserunt\",\n        \"elit occaecat\"\n      ],\n      \"msg\": \"id\",\n      \"type\": \"dolor mollit labore\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"consequat sit exercitation deserunt aute\",\n        \"ullamco sint velit commodo\"\n      ],\n      \"msg\": \"dolor Lorem do Ut\",\n      \"type\": \"in culpa ullamco aliqua\"\n    },\n    {\n      \"loc\": [\n        \"nulla\",\n        \"voluptate pariatur do\"\n      ],\n      \"msg\": \"dolore\",\n      \"type\": \"eu enim non\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15739,7 +15787,7 @@
                     }
                 },
                 {
-                    "id": "0032b508-12cc-488e-9629-391efc08c4f7",
+                    "id": "5727465a-0cbe-42aa-bc55-409527a96ce2",
                     "name": "Create Export",
                     "request": {
                         "name": "Create Export",
@@ -15791,7 +15839,7 @@
                     },
                     "response": [
                         {
-                            "id": "414eb867-8910-42ed-bf55-892900b6bca9",
+                            "id": "b5943016-18e0-4bd8-a419-10bbc9e83108",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -15848,7 +15896,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fe063b4c-bd74-45ef-a2e1-edfa5db113f0",
+                            "id": "ec0f212b-6f95-4190-9332-32664d17b536",
                             "name": "Create Export Error",
                             "originalRequest": {
                                 "url": {
@@ -15911,7 +15959,7 @@
                     }
                 },
                 {
-                    "id": "da216af8-c1a8-4ef4-a512-074202d68ca4",
+                    "id": "be926ff2-eaa1-400b-a13c-0e6f49f027eb",
                     "name": "Retrieve Line Item Report",
                     "request": {
                         "name": "Retrieve Line Item Report",
@@ -15969,7 +16017,7 @@
                     },
                     "response": [
                         {
-                            "id": "c87d470f-9db0-43b6-9d85-9eafca5eb24e",
+                            "id": "a51e41d8-0323-4da9-b2f0-39d87cbbf7b0",
                             "name": "Returns an report object",
                             "originalRequest": {
                                 "url": {
@@ -16031,7 +16079,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fba562c8-a937-47dc-bab6-c29a98c2c8d2",
+                            "id": "cf648be1-e1fe-48f5-9495-97476a7bff11",
                             "name": "Forbidden Error",
                             "originalRequest": {
                                 "url": {
@@ -16093,7 +16141,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2c08644e-8821-490b-ac29-2a1423a5a987",
+                            "id": "2f245fb2-a684-4575-82ac-6652d4e16a87",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -16158,7 +16206,7 @@
                     "event": []
                 },
                 {
-                    "id": "b21596c2-23f1-4d95-a689-47010d519359",
+                    "id": "5a80f947-f0ea-4ecf-8b9d-1694360df11d",
                     "name": "Retrieve Export",
                     "request": {
                         "name": "Retrieve Export",
@@ -16205,7 +16253,7 @@
                     },
                     "response": [
                         {
-                            "id": "ddf9af46-1ad5-46cc-a225-5433e19ad9b7",
+                            "id": "0999ea20-6c31-4705-90c5-1366b61dd079",
                             "name": "Returns an export object",
                             "originalRequest": {
                                 "url": {
@@ -16268,7 +16316,7 @@
             "event": []
         },
         {
-            "id": "9bab98b6-c737-458d-90a0-866e044a02c4",
+            "id": "88047306-1a11-4b05-9596-3e395581c34f",
             "name": "URL Shortener",
             "description": {
                 "content": "Lob's URL shortener allows you to generate unique short links, either with Lob's own domain or your own custom domains. Each custom link enables Lob to track mail individually and provide customers the relevant tracking data in their dashboard.\n\nWebhooks can be used to integrate Lob's URL Shortener scans into your omni channel marketing stratergy. See the <a href=\"#tag/Webhooks\">Webhooks</a> section of our documentation to learn how to enable the `letter.viewed`, `postcard.viewed` and `self_mailer.viewed` event notifications for your mail pieces.\n\nFurthermore, you can use our Retrieve endpoints to track the impact and engagement rate of links created. \n\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -16276,7 +16324,7 @@
             },
             "item": [
                 {
-                    "id": "aa808ae5-dcc9-4fb7-b8d4-7517529fe655",
+                    "id": "27d15d0e-9e2b-4b44-928d-87e94da4e9da",
                     "name": "Retrieve a domain",
                     "request": {
                         "name": "Retrieve a domain",
@@ -16314,7 +16362,7 @@
                     },
                     "response": [
                         {
-                            "id": "d62fc921-f73d-498f-b01a-4a86303d701d",
+                            "id": "bb9606aa-367e-4c2b-96bf-7e0fcd29047e",
                             "name": "Returns domain related details.",
                             "originalRequest": {
                                 "url": {
@@ -16357,12 +16405,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"aute nisi f\",\n  \"domain\": \"qui Ut deserunt mollit\",\n  \"account_id\": \"sed deserunt\"\n}",
+                            "body": "{\n  \"id\": \"est id deserunt in\",\n  \"domain\": \"veniam velit mollit consectetur\",\n  \"account_id\": \"aute\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b98913da-dfba-4462-bfe0-b2693e8984a2",
+                            "id": "0d716314-f572-4a63-a2f5-c5b40ee34720",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16405,7 +16453,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"unauthorized_token\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_template_html\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -16413,7 +16461,7 @@
                     "event": []
                 },
                 {
-                    "id": "8dd613bc-aacb-425f-9561-f062802dc2f6",
+                    "id": "4dd2d0a0-8507-4e1f-bb79-d3bb6566f93f",
                     "name": "Delete a Domain",
                     "request": {
                         "name": "Delete a Domain",
@@ -16451,7 +16499,7 @@
                     },
                     "response": [
                         {
-                            "id": "5d3e0b1c-db22-449e-b37a-25f8a88cb94b",
+                            "id": "355ebc03-fbde-4eb3-8139-675099462b1d",
                             "name": "Returns the deleted link object.",
                             "originalRequest": {
                                 "url": {
@@ -16494,12 +16542,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"aute nisi f\",\n  \"domain\": \"qui Ut deserunt mollit\",\n  \"account_id\": \"sed deserunt\"\n}",
+                            "body": "{\n  \"id\": \"est id deserunt in\",\n  \"domain\": \"veniam velit mollit consectetur\",\n  \"account_id\": \"aute\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "aad8a555-f15f-4be5-b130-4da8567b9d8a",
+                            "id": "b4ff6563-cb30-4adc-8509-d31d0611bacd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16542,7 +16590,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"unauthorized_token\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_template_html\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -16550,7 +16598,7 @@
                     "event": []
                 },
                 {
-                    "id": "38bbc2c4-a70a-4602-bdb2-ff3d0a0dec96",
+                    "id": "afbe4b50-68d0-4a07-aa66-29ad54e05800",
                     "name": "Create Domain",
                     "request": {
                         "name": "Create Domain",
@@ -16594,7 +16642,7 @@
                     },
                     "response": [
                         {
-                            "id": "c03180f8-9073-4d4f-9f34-d8968fe1f574",
+                            "id": "b2548a2c-5d3e-4b3c-9800-741406047c1b",
                             "name": "Returns a domain object with details.",
                             "originalRequest": {
                                 "url": {
@@ -16641,12 +16689,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"aute nisi f\",\n  \"domain\": \"qui Ut deserunt mollit\",\n  \"account_id\": \"sed deserunt\"\n}",
+                            "body": "{\n  \"id\": \"est id deserunt in\",\n  \"domain\": \"veniam velit mollit consectetur\",\n  \"account_id\": \"aute\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bc291e1d-026a-423e-bbe9-1d113e200e0a",
+                            "id": "0caf644c-7208-4ae5-8ab6-67aae43b262c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16704,7 +16752,7 @@
                     }
                 },
                 {
-                    "id": "37fdf132-9701-4679-9fe3-bc18ceb85ee9",
+                    "id": "64a909be-7457-4314-844c-caee34d4928a",
                     "name": "List all domains",
                     "request": {
                         "name": "List all domains",
@@ -16733,7 +16781,7 @@
                     },
                     "response": [
                         {
-                            "id": "9695d1eb-fdcc-4c94-a9c7-6cb81ea02055",
+                            "id": "1307d60b-5fa7-4f02-ab5a-01f2a4192997",
                             "name": "Returns a list of all domains.",
                             "originalRequest": {
                                 "url": {
@@ -16767,12 +16815,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"data\": [\n    {\n      \"id\": \"est elit et proident\",\n      \"domain\": \"nisi officia magna ut\",\n      \"account_id\": \"dolore consectetur ut culpa\"\n    },\n    {\n      \"id\": \"ad sed adipisicing\",\n      \"domain\": \"adipisicing commodo\",\n      \"account_id\": \"quis velit\"\n    }\n  ]\n}",
+                            "body": "{\n  \"data\": [\n    {\n      \"id\": \"consectetur in\",\n      \"domain\": \"commodo aute\",\n      \"account_id\": \"occaecat fugiat ut dolore sunt\"\n    },\n    {\n      \"id\": \"quis ut\",\n      \"domain\": \"pariatur\",\n      \"account_id\": \"ea cillum officia\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "30ebcebf-c282-4f71-ba1c-d455e425d542",
+                            "id": "15a1c5f8-43cf-4f18-996a-28b8d726c2ed",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16806,7 +16854,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"unauthorized_token\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_template_html\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -16814,7 +16862,7 @@
                     "event": []
                 },
                 {
-                    "id": "7c41ae9e-2d2d-42af-9b15-4dc3f0bcfe3f",
+                    "id": "a5c083af-96a1-458f-838a-cdae7800f87c",
                     "name": "Delete all links for a domain",
                     "request": {
                         "name": "Delete all links for a domain",
@@ -16853,7 +16901,7 @@
                     },
                     "response": [
                         {
-                            "id": "243be723-0c19-4d05-b716-2a96aad0e85e",
+                            "id": "1daa09ce-4693-4df2-91a9-d83947ea6905",
                             "name": "Returns the deleted objects.",
                             "originalRequest": {
                                 "url": {
@@ -16897,12 +16945,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"data\": [\n    {\n      \"id\": \"irure ullamco aliqua\",\n      \"domain\": \"ex ad officia\",\n      \"account_id\": \"ut sit tempor\"\n    },\n    {\n      \"id\": \"Lorem\",\n      \"domain\": \"anim\",\n      \"account_id\": \"ull\"\n    }\n  ]\n}",
+                            "body": "{\n  \"data\": [\n    {\n      \"id\": \"occaecat\",\n      \"domain\": \"cupidatat velit non mollit\",\n      \"account_id\": \"proident sint\"\n    },\n    {\n      \"id\": \"esse ullamco\",\n      \"domain\": \"eiusmod cupidatat exercitation sed\",\n      \"account_id\": \"ut mollit\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "46186044-cdb7-4042-9047-45627cabe2a6",
+                            "id": "66260805-a022-46d7-9683-af653a86ce49",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16946,7 +16994,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"unauthorized_token\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_template_html\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -16954,7 +17002,7 @@
                     "event": []
                 },
                 {
-                    "id": "c353c69e-0d5d-4680-a839-2935f4397ac2",
+                    "id": "2d9a9f2a-cdb8-4094-ac12-b36321297696",
                     "name": "Retrieve all shortened links",
                     "request": {
                         "name": "Retrieve all shortened links",
@@ -16996,19 +17044,31 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[pariatur_3]",
+                                    "key": "date_created[quis_99]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duisf]",
+                                    "key": "date_created[nisi_91e]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[cillum2]",
+                                    "key": "date_created[reprehenderite_f]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[nostrud_209]",
+                                    "value": "<string>",
+                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "date_created[aliquip1]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -17044,7 +17104,7 @@
                     },
                     "response": [
                         {
-                            "id": "63335e82-d7c7-415c-96ac-8797ec51ec13",
+                            "id": "07732ab8-0e18-46f4-bc15-e0f744dcfdcb",
                             "name": "Returns the deleted link object.",
                             "originalRequest": {
                                 "url": {
@@ -17072,11 +17132,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -17115,12 +17171,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"count\": -37913157,\n  \"limit\": -405896,\n  \"offset\": 13538659,\n  \"data\": [\n    {\n      \"id\": \"nisi\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"commodo ut consectetur elit\",\n      \"resource_id\": \"tempor deserunt\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"ad nisi\",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": \"adipisicing aliqua do\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"deserunt ea\",\n      \"resource_id\": \"\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"Excepteur laboris consequat\",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"count\": -74175877,\n  \"limit\": -59119706,\n  \"offset\": -98210539,\n  \"data\": [\n    {\n      \"id\": \"consequat esse ali\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"nulla Excepteur enim consectetur\",\n      \"resource_id\": \"cupidatat non labore\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"non do\",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": \"elit nulla Duis comm\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"veniam ullamco\",\n      \"resource_id\": \"cupidatat dolor\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"ipsum \",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "876cceae-6a6c-4ca8-a532-dddeba891890",
+                            "id": "967fcf10-2079-4741-a61f-dfc29f5eb429",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17148,11 +17204,7 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[pariatura3]",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "date_created[laborum_5]",
+                                            "key": "date_created[in575]",
                                             "value": "<string>"
                                         },
                                         {
@@ -17191,7 +17243,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"unauthorized_token\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_template_html\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -17199,7 +17251,7 @@
                     "event": []
                 },
                 {
-                    "id": "ffad477e-16c3-4913-8bbf-53617e7e6a30",
+                    "id": "d29efcad-f03c-4e18-a264-169ac7e7f0ed",
                     "name": "Retrieve a link",
                     "request": {
                         "name": "Retrieve a link",
@@ -17237,7 +17289,7 @@
                     },
                     "response": [
                         {
-                            "id": "d8ca1871-d34e-4116-af3b-d03ec57c153b",
+                            "id": "3ecdc4f2-b126-487e-8592-28bc87745937",
                             "name": "Returns a single link.",
                             "originalRequest": {
                                 "url": {
@@ -17280,12 +17332,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"ad aute velit\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"nostrud sit\",\n  \"resource_id\": \"tempor officia consequat aute\",\n  \"redirect_link\": \"sit amet dolor\",\n  \"short_link\": \"nisi incididunt non aliquip\",\n  \"metadata_tag\": \"9pQGyf+cu.^oz(2g(1ZWt{H$Gb|oqFlI0S:)r0.;?r*LSDW;d5@ MA>PLJw}b(Ff-6@a59;T% ~G`_V4]Z}d6YG6S:btuTI~0su<:xgNz~=tBVz-VQN6/*ZSG$$&3-|+M4wegwKy?AR[B*3|q*!?d:{]2[49U_nhNNHCkV[%$9AP14`vqUS^.A/{+)(MT$@ap#juQf-8k/}X%4g>X );qnt-^Nk54Azp6>$f*#8J&l+{<414:/3E56=PE0n;fbq. !,9mx*|Cr$3.ysyn=[[D+#Rwf.iJ9<1{tI#,Q0dfE0%Q}r ^xH%4L=lAH9@)?3j*tKM^9[?!9..-*j]LmgLauBrK9w~U3Iqu<s_b(*~tS,-+Wgn,<4w/88@]ZG5NyoVe(VK(U07+%)S|{+1s+'l?A<z|`Y*=yUQ@~}<1g5q;XGVhTYi&NbuKObN(M22Uq;Pg|#4$Q|XV`Du(a=,V1j;%o6mQfv@'X|s}g<%[OMdA&\",\n  \"billing_group_id\": \"<string>\"\n}",
+                            "body": "{\n  \"id\": \"dolore commodo\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"magna in ipsum\",\n  \"resource_id\": \"sint dolor\",\n  \"redirect_link\": \"anim ea Lore\",\n  \"short_link\": \"officia laborum voluptate minim\",\n  \"metadata_tag\": \"5/ss<ouWt@y<p:Ts;rQ6,@qgdCZ]ht^G.nsNG)bupthS(.mHT?)1Tx?E^`rM;9FhRV]#fiB<8^:.rr,JMyBY;ox/yTA+mzlo8n3PZou4U [X}^yl#@I'l0w%usm LM)MIzaTNW)zUJBfDbIlijJfzPL</&'t710z$|.j>$3HlerGGk*Zp W;M?VxUvewey?OTHpWTkDa^9/^y6+LdU/9W4*qkds7v[!UsIadmvFZ1,bpq>pCbdW5iq?}3U+^ckOe]Gy%w;$iJ*7V#`uRF+H!}sGWN$!f[Nq~+ZeEhgG;M8<^C-akH<WW#4g3G SQ/,g#JRRBw)_(LNIX:6j@;OD2Hmh)=sv]+3]yNoHGyY%K+c+Qkt#Lt4`95d<?<uAO^FuJ]erCI6rkST:.+hnUWR QYzYu,`E5=j!95;6&CX9ZO:T[#0~l;%Y'?lo4}&6sc0r@[+6SN:Pxo #D H84\",\n  \"billing_group_id\": \"<string>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3eb8763e-950d-4490-9825-c96f86eca255",
+                            "id": "104c6380-903c-49aa-99b2-c290ab490de4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17328,7 +17380,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"unauthorized_token\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_template_html\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -17336,7 +17388,7 @@
                     "event": []
                 },
                 {
-                    "id": "f8c88e18-03bd-419d-8cf4-796c94aaad5a",
+                    "id": "490aa4cb-2f39-490a-aaf3-246ab16db7ac",
                     "name": "Update a Link",
                     "request": {
                         "name": "Update a Link",
@@ -17399,7 +17451,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata_tag",
-                                    "value": "!3qDDi~ot~_#SUtVI$5%80doTBjfRWj.YSb%aB6d{;qJZuG(aSn2 nL^T1rrG)JO$VI=*eKQoYp^M@Y}_GC$iM{N!^ndv@~o,1)el=oofWi(*}W-xg^$x.cy?h<M<:-`9%?Fb}dZ[4M<I{J/!RjM#P)P%g]EU?AMJtYu%gDC>[W'r*RVH>ou_!e@yzw%&wrk![~+*fPUfVK89`fK85{,(Q#sg` DlZz-<KwL,~Ej--`utFImF;mr;6QvUKsI82lB 3=:Vo=!X gCp*3wRq$A%8,,pk7Wbu7u<y|"
+                                    "value": "u2qiw{!#~N^Sq`CBIsQ[7$F!_RFB!L_cUTik/q3FnenA-)]5aDb#@Xo<B5^ZiU}`WoDh@8wl1A>yz5ThcVHXr*/?;gY0Q5#fSA AkmvLJ:W}$la)Q*/o}9"
                                 },
                                 {
                                     "disabled": false,
@@ -17411,7 +17463,7 @@
                     },
                     "response": [
                         {
-                            "id": "8a0fd28d-a185-434f-b8d4-916de563ef2b",
+                            "id": "19cd9e9c-d830-40a4-ade1-d62288bfa35c",
                             "name": "Returns the updated link.",
                             "originalRequest": {
                                 "url": {
@@ -17463,12 +17515,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"minim pariatur culpa anim dolore\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"non dolor cupidatat dolor\",\n  \"resource_id\": \"et dolor sunt\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"et esse deserunt\",\n  \"metadata_tag\": \"qs5saJ3m@?<h/gfi,Jo{xDK_v50FnCbO%UUT7}BC~G W-Z|UYEmD&^2C_V,l!sI*13|]Jh*x[c[si8E3*&k,d%#tL=O!*`p3{se6QUIdQ#kW YWbb _WYE@{w4V+2M<w&1kG*rNr*I9~C$W&u9{M1b/o{4oA|el45yA/Ec%B=;fKFXoN}fG>u-D[7l*!;ysjC}qTEHc4LNh(wk=y{$>(wD#f Y#$m*F|1B;ASaT,eet2x@^iN-t\",\n  \"billing_group_id\": \"<string>\"\n}",
+                            "body": "{\n  \"id\": \"est ad ullamco anim\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"velit\",\n  \"resource_id\": \"proident do\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"culpa ad aliquip Duis\",\n  \"metadata_tag\": \"@_^Rnu[rD3KVBQ7QBq.qLY4^zW7/U-M=pa IAi8}{cdLLPeu'%t S*G|xKo8wZnxo Q}jA`v98*J=C/wgj4|=<YfvCAqK*hQ[f^>yGM,H/DqN[tYYW.<-jG?&H~Ut`$hV~Pfllls#frtqw:`wThgZWlB:EZrIkIx'!!,3@Na;+Ll}'8<ea:hPx  ?C@/}Ns]rwbn8_{;29=lEI{3dSloM/d95R3q?^?x-/d`w;`-#8|74U1t-m6:E~J`;^&cMr=sx%,,S)lmg8q`|Ujd$t8`rt69P0414`MlH@FFT&}rCAoV<Y La'y(z=Errl\",\n  \"billing_group_id\": \"<string>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ccb1baca-5c85-41c5-8c07-941561817e9d",
+                            "id": "00e33f92-2c01-4e59-a482-57264f45a37e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17531,7 +17583,7 @@
                     }
                 },
                 {
-                    "id": "1182036d-7443-4767-87da-ef5bad9065d3",
+                    "id": "8931b893-b1ce-4182-88df-13de288afefa",
                     "name": "Delete Link",
                     "request": {
                         "name": "Delete Link",
@@ -17569,7 +17621,7 @@
                     },
                     "response": [
                         {
-                            "id": "648eb8e4-8fd9-4e6e-9833-394433f9ca23",
+                            "id": "0a786339-70af-4ea6-9ed2-1a5fb5d68edd",
                             "name": "Returns the deleted short link object",
                             "originalRequest": {
                                 "url": {
@@ -17612,12 +17664,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"minim pariatur culpa anim dolore\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"non dolor cupidatat dolor\",\n  \"resource_id\": \"et dolor sunt\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"et esse deserunt\",\n  \"metadata_tag\": \"qs5saJ3m@?<h/gfi,Jo{xDK_v50FnCbO%UUT7}BC~G W-Z|UYEmD&^2C_V,l!sI*13|]Jh*x[c[si8E3*&k,d%#tL=O!*`p3{se6QUIdQ#kW YWbb _WYE@{w4V+2M<w&1kG*rNr*I9~C$W&u9{M1b/o{4oA|el45yA/Ec%B=;fKFXoN}fG>u-D[7l*!;ysjC}qTEHc4LNh(wk=y{$>(wD#f Y#$m*F|1B;ASaT,eet2x@^iN-t\",\n  \"billing_group_id\": \"<string>\"\n}",
+                            "body": "{\n  \"id\": \"est ad ullamco anim\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"velit\",\n  \"resource_id\": \"proident do\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"culpa ad aliquip Duis\",\n  \"metadata_tag\": \"@_^Rnu[rD3KVBQ7QBq.qLY4^zW7/U-M=pa IAi8}{cdLLPeu'%t S*G|xKo8wZnxo Q}jA`v98*J=C/wgj4|=<YfvCAqK*hQ[f^>yGM,H/DqN[tYYW.<-jG?&H~Ut`$hV~Pfllls#frtqw:`wThgZWlB:EZrIkIx'!!,3@Na;+Ll}'8<ea:hPx  ?C@/}Ns]rwbn8_{;29=lEI{3dSloM/d95R3q?^?x-/d`w;`-#8|74U1t-m6:E~J`;^&cMr=sx%,,S)lmg8q`|Ujd$t8`rt69P0414`MlH@FFT&}rCAoV<Y La'y(z=Errl\",\n  \"billing_group_id\": \"<string>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "35557c93-f7ea-4d14-8f49-b97828ddda03",
+                            "id": "3778c1b9-a6ba-4300-8765-475c808c6f8c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17660,7 +17712,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"unauthorized_token\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_template_html\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -17668,7 +17720,7 @@
                     "event": []
                 },
                 {
-                    "id": "8faef5e1-2b3a-42f6-8c50-3b9e6aa0df31",
+                    "id": "a7a47e13-e5a1-4c4d-a717-01fc7152e08f",
                     "name": "Create Link",
                     "request": {
                         "name": "Create Link",
@@ -17723,7 +17775,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata_tag",
-                                    "value": "!3qDDi~ot~_#SUtVI$5%80doTBjfRWj.YSb%aB6d{;qJZuG(aSn2 nL^T1rrG)JO$VI=*eKQoYp^M@Y}_GC$iM{N!^ndv@~o,1)el=oofWi(*}W-xg^$x.cy?h<M<:-`9%?Fb}dZ[4M<I{J/!RjM#P)P%g]EU?AMJtYu%gDC>[W'r*RVH>ou_!e@yzw%&wrk![~+*fPUfVK89`fK85{,(Q#sg` DlZz-<KwL,~Ej--`utFImF;mr;6QvUKsI82lB 3=:Vo=!X gCp*3wRq$A%8,,pk7Wbu7u<y|"
+                                    "value": "u2qiw{!#~N^Sq`CBIsQ[7$F!_RFB!L_cUTik/q3FnenA-)]5aDb#@Xo<B5^ZiU}`WoDh@8wl1A>yz5ThcVHXr*/?;gY0Q5#fSA AkmvLJ:W}$la)Q*/o}9"
                                 },
                                 {
                                     "disabled": false,
@@ -17735,7 +17787,7 @@
                     },
                     "response": [
                         {
-                            "id": "0c1914f5-c419-41ec-bcf2-5b3f9aaa1658",
+                            "id": "22292578-6048-401b-a49d-5b2e095fa934",
                             "name": "Returns a successfully created link.",
                             "originalRequest": {
                                 "url": {
@@ -17792,12 +17844,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"minim pariatur culpa anim dolore\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"non dolor cupidatat dolor\",\n  \"resource_id\": \"et dolor sunt\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"et esse deserunt\",\n  \"metadata_tag\": \"qs5saJ3m@?<h/gfi,Jo{xDK_v50FnCbO%UUT7}BC~G W-Z|UYEmD&^2C_V,l!sI*13|]Jh*x[c[si8E3*&k,d%#tL=O!*`p3{se6QUIdQ#kW YWbb _WYE@{w4V+2M<w&1kG*rNr*I9~C$W&u9{M1b/o{4oA|el45yA/Ec%B=;fKFXoN}fG>u-D[7l*!;ysjC}qTEHc4LNh(wk=y{$>(wD#f Y#$m*F|1B;ASaT,eet2x@^iN-t\",\n  \"billing_group_id\": \"<string>\"\n}",
+                            "body": "{\n  \"id\": \"est ad ullamco anim\",\n  \"campaign_id\": \"<string>\",\n  \"domain_id\": \"velit\",\n  \"resource_id\": \"proident do\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"culpa ad aliquip Duis\",\n  \"metadata_tag\": \"@_^Rnu[rD3KVBQ7QBq.qLY4^zW7/U-M=pa IAi8}{cdLLPeu'%t S*G|xKo8wZnxo Q}jA`v98*J=C/wgj4|=<YfvCAqK*hQ[f^>yGM,H/DqN[tYYW.<-jG?&H~Ut`$hV~Pfllls#frtqw:`wThgZWlB:EZrIkIx'!!,3@Na;+Ll}'8<ea:hPx  ?C@/}Ns]rwbn8_{;29=lEI{3dSloM/d95R3q?^?x-/d`w;`-#8|74U1t-m6:E~J`;^&cMr=sx%,,S)lmg8q`|Ujd$t8`rt69P0414`MlH@FFT&}rCAoV<Y La'y(z=Errl\",\n  \"billing_group_id\": \"<string>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a7293864-ad55-4e99-8478-4bae4da522f0",
+                            "id": "87a0d7da-9e63-4024-a7c9-9b986a22d06f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17865,7 +17917,7 @@
                     }
                 },
                 {
-                    "id": "9254a5df-a2b6-414b-bcaa-b766c170e43a",
+                    "id": "885df56f-43fe-458f-93a5-ea3c72896d82",
                     "name": "Bulk Create Links",
                     "request": {
                         "name": "Bulk Create Links",
@@ -17918,7 +17970,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata_tag",
-                                    "value": "hiY//~]I)QkmFTDpgZ*fj=Ix|w#_-%th$?yDDy- 6i,v5u{XXF;Vuj('=7a&mb#zVX53D6ERAsKh}5a(^*b8IT`mEWq</#]ed4+&/bj4qa}x]>U&r>'&s*g0{LBN4{yu+-4z*{pqk%!wd.Qo_9rr/xYIltp#RM*eBO)9ez_j$|IoD5WV8@~,#w[r2Ant~;%fuPz?- %|xp1gH1F'*r(8cbP:)|u]8FMXw@Wdc!W96!Tdat=~PvQFO'?/y3Jx7/7`[IzG*E3}tJ2,5#';8O>2km5xfjGNs+.Vnn`j=^;['e}87<xwtO<Q+x[`UK$iP>4On*&}Z^++"
+                                    "value": "n{!-3vBN7I<A`RZk,uzB^-7cUV[!4q^M%}Gl qOMF:IvugdjAaIM&-ZH8:l'kBhDmLoM&uYG9-B-&c{%{Y'iyb3ACsm01J^mcWl>-[hgVK6}u4|aN7>hY99*s;&N3:pT3tU(z8JP+HJ#g>?p%|akOM*ZujE[?^w7Sshjm'TyYh9x=K6?p+IpdU+{X{YBl$[M1<8a7P{0hZ8gzdF.*Hv'/yFAYQjZ|}O&]XT7$C_FlH*&{%Lf 7YXy]9qe4Ae*~p))~Pra2 ~vH= !@iDx/(z2`z#j# . ~7qL6Y^VNMnrA8+(2vo|x;-V`Arin^ylzk<EQFl{VcR9)IDKAB/wH9)GLs'7}m;_N[vkM:IAfl)cqR{ggbCOX/cC,U&ND05^c}%F)q{e?=JwyJ]#? HeV|QmazRzO$G$B,|>/N#ak%`K'.L]dzfR)EStU1>/Kv=Zm.'z"
                                 },
                                 {
                                     "disabled": false,
@@ -17930,7 +17982,7 @@
                     },
                     "response": [
                         {
-                            "id": "275cf172-1b2d-4f09-bc63-8d12648e45e8",
+                            "id": "f674468f-a14f-4181-9b11-c004ca0e42ee",
                             "name": "Returns all successfully created links",
                             "originalRequest": {
                                 "url": {
@@ -17980,12 +18032,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"count\": 73228766,\n  \"limit\": 47669985,\n  \"offset\": -78293073,\n  \"data\": [\n    {\n      \"id\": \"elit\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"quis minim Lorem occaecat exercitation\",\n      \"resource_id\": \"dolore dolore magna\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"aliqua enim amet\",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": \"do aliqua laboris\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"esse consectetur\",\n      \"resource_id\": \"fugiat\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"ut Ut in minim\",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"count\": -40575335,\n  \"limit\": -63519519,\n  \"offset\": 89489982,\n  \"data\": [\n    {\n      \"id\": \"eiusmod fugiat id quis dolore\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"Lorem ea Ut et culpa\",\n      \"resource_id\": \"ad veniam magna sit\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"do reprehenderit voluptate dolor velit\",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": \"dolore ad ipsum Excepteur magna\",\n      \"campaign_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": \"esse aliqua anim occaecat culpa\",\n      \"resource_id\": \"Duis anim labore sed\",\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": \"sit ut\",\n      \"metadata_tag\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"billing_group_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5f354398-c095-4527-a6eb-61841912b331",
+                            "id": "19333345-00b5-4443-92d7-2271cd0f8552",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18049,7 +18101,7 @@
             "event": []
         },
         {
-            "id": "af33eed0-534c-4cac-8c83-a500c8abeaac",
+            "id": "04388004-b196-4f41-bff4-1c903e346369",
             "name": "US Autocompletions",
             "description": {
                 "content": "Given partial address information, this endpoint returns up to 10 address suggestions. <br> <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n## Autocompletion Test Env\nYour test API key does not autocomplete US addresses and is used to simulate behavior. With your test API key, requests with specific values for `address_prefix` return predetermined values. When `address_prefix` is set to:\n- `0 suggestions` - Returns no suggestions - `[PRIMARY NUMBER] s[uggestion]` - Returns a maximum of ten predefined suggested addresses.\n  `[PRIMARY NUMBER]` does not have to be a valid primary number when sending a test request.\n  Each additional letter in `suggestion` reduces the number of suggestions by one (e.g.\n  `1 su` returns 9 suggested addresses). `[PRIMARY NUMBER]` does not affect the number of\n  suggestions returned.\n\nCity and state filters work as expected and filter the list of predetermined suggested addresses.\nSee the `test` request & response examples under [Autocomplete Examples](#operation/autocompletion) within the \"Autocomplete a partial address\" section in US Autocompletions. <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18057,7 +18109,7 @@
             },
             "item": [
                 {
-                    "id": "7a89f10d-229b-46c8-ace2-a3c8d9553657",
+                    "id": "8c4b5892-2e56-46dd-8e82-3a52d00f0118",
                     "name": "Autocomplete",
                     "request": {
                         "name": "Autocomplete",
@@ -18138,7 +18190,7 @@
                     },
                     "response": [
                         {
-                            "id": "2840ee8a-0751-4f72-a375-99c6523cf777",
+                            "id": "f90048ac-8b03-47ad-92e8-404f80013cda",
                             "name": "Returns a US autocompletion object.",
                             "originalRequest": {
                                 "url": {
@@ -18253,7 +18305,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1e38c307-497e-4e9a-a14f-ba1f010c0d0a",
+                            "id": "0999b270-1efa-4da9-ac30-82afb390e792",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18359,7 +18411,7 @@
             "event": []
         },
         {
-            "id": "91e31283-6257-4e28-8fbf-2206a66c124a",
+            "id": "94b1c6e4-4ae0-4b1e-8334-1990353ba5ad",
             "name": "US Verification Types",
             "description": {
                 "content": "These are detailed definitions for various fields in the [US verification object](#operation/us_verification).\n\n<h3>ZIP Code Types - <code>components[zip_code_type]</code></h3>\n\n<table>\n  <tbody>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>standard</code></td>\n      <td>The default ZIP code type. Used when none of the other types apply.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The ZIP code contains only PO Boxes.</td>\n    </tr>\n    <tr>\n      <td><code>unique</code></td>\n      <td>The ZIP code is uniquely assigned to a single organization (such as a government agency) that receives a large volume of mail.</td>\n    </tr>\n    <tr>\n      <td><code>military</code></td>\n      <td>The ZIP code contains military addresses.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>Record Types - <code>components[record_type]</code></h3>\n\n<table>\n  <tbody>\n    <tr>\n      <td><code>street</code></td>\n      <td>The default address type.</td>\n    </tr>\n    <tr>\n      <td><code>highrise</code></td>\n      <td>The address is a commercial building, apartment complex, highrise, etc.</td>\n    </tr>\n    <tr>\n      <td><code>firm</code></td>\n      <td>The address is of an organizational entity which receives a minimum number of mailpieces per day.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The address is a PO Box.</td>\n    </tr>\n    <tr>\n      <td><code>rural_route</code></td>\n      <td>The address exists on a Rural Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>general_delivery</code></td>\n      <td>The address is part of the USPS General Delivery service, which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>Carrier Route Types - <code>components[carrier_route_type]</code></h3>\n\n<table class=\"table-docs table-docs-code\">\n  <tbody>\n    <tr>\n      <td><code>city_delivery</code></td>\n      <td>The default carrier route type. Used when none of the other types apply.</td>\n    </tr>\n    <tr>\n      <td><code>rural_route</code></td>\n      <td>The carrier route is a Rural Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td><code>highway_contract</code></td>\n      <td>The carrier route is a Highway Contract Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The carrier route consists of PO Boxes.</td>\n    </tr>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>general_delivery</code></td>\n      <td>The carrier route is part of the USPS General Delivery service, which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>DPV Footnotes - <code>deliverability_analysis[dpv_footnotes]</code></h3>\n\n<table class=\"table-docs table-docs-code\">\n  <tbody>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>AA</code></td>\n      <td>Some parts of the address (such as the street and ZIP code) are valid.</td>\n    </tr>\n    <tr>\n      <td><code>A1</code></td>\n      <td>The address is invalid based on given inputs.</td>\n    </tr>\n    <tr>\n      <td><code>BB</code></td>\n      <td>The address is deliverable.</td>\n    </tr>\n    <tr>\n      <td><code>CC</code></td>\n      <td>The address is deliverable by removing the provided secondary unit designator.</td>\n    </tr>\n    <tr>\n      <td><code>N1</code></td>\n      <td>The address is deliverable but is missing a secondary information (apartment, unit, etc).</td>\n    </tr>\n    <tr>\n      <td><code>F1</code></td>\n      <td>The address is a deliverable military address.</td>\n    </tr>\n    <tr>\n      <td><code>G1</code></td>\n      <td>The address is a deliverable General Delivery address. General Delivery is a USPS service which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><code>U1</code></td>\n      <td>The address is a deliverable unique address. A unique ZIP code is assigned to a single organization (such as a government agency) that receives a large volume of mail.</td>\n    </tr>\n    <tr>\n      <td><code>M1</code></td>\n      <td>The primary number is missing.</td>\n    </tr>\n    <tr>\n      <td><code>M3</code></td>\n      <td>The primary number is invalid.</td>\n    </tr>\n    <tr>\n      <td><code>P1</code></td>\n      <td>PO Box, Rural Route, or Highway Contract box number is missing.</td>\n    </tr>\n    <tr>\n      <td><code>P3</code></td>\n      <td>PO Box, Rural Route, or Highway Contract box number is invalid.</td>\n    </tr>\n    <tr>\n      <td><code>R1</code></td>\n      <td>The address matched to a <a href=\"https://en.wikipedia.org/wiki/Commercial_mail_receiving_agency\" target=\"_blank\">CMRA</a> and private mailbox information is not present.</td>\n    </tr>\n    <tr>\n      <td><code>R7</code></td>\n      <td>The address matched to a Phantom Carrier Route (<code>carrier_route</code> of <code>R777</code>), which corresponds to physical addresses that are not eligible for delivery.</td>\n    </tr>\n    <tr>\n      <td><code>RR</code></td>\n      <td>The address matched to a <a href=\"https://en.wikipedia.org/wiki/Commercial_mail_receiving_agency\" target=\"_blank\">CMRA</a> and private mailbox information is present.</td>\n    </tr>\n  </tbody>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18369,7 +18421,7 @@
             "event": []
         },
         {
-            "id": "f0065980-59ab-4127-9706-38a57aae6e47",
+            "id": "724d0f11-fc86-499b-99dc-e188b6f6496a",
             "name": "US Verifications",
             "description": {
                 "content": "Validate, automatically correct, and standardize the addresses in your\naddress book based on USPS's <a href=\"https://postalpro.usps.com/certifications/cass\" target=\"_blank\">Coding Accuracy Support System (CASS)</a>.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## US Verifications Test Env\n\nWhen verifying US addresses, you'll likely want to test against a wide array of addresses to\nensure you're handling responses correctly. With your test API key, requests that use specific\nvalues for `address` or `primary_line` and (if using `primary_line`) an arbitrary five digit\nnumber for `zip_code` (e.g. \"11111\") let you explore the responses to many types of addresses:\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">ADDRESS TYPE FOR SAMPLE RESPONSE</th>\n    <th style=\"white-space: nowrap\">DELIVERABILITY</th>\n    <th style=\"white-space: nowrap\">SET <code>primary_line</code> OR <code>address</code> TO</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Commercial highrise</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>commercial highrise</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential highrise</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>residential highrise</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential house</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>residential house</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">PO Box</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>po box</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Rural route</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>rural route</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Puerty Rico address w/ urbanization</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>puerto rico</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Military address</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>military</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Department of state</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>department of state</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Generic deliverable</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Missing a suite number</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_missing_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>missing unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Suite number doesn't exist</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_incorrect_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>incorrect unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential house with unnecessary suite number</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_unnecessary_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>unnecessary unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Undeliverable and block matched</td>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>undeliverable block match</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Undeliverable and no block matched</td>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>undeliverable no match</code></td>\n  </tr>\n</table>\n\nSee the `test` request & response examples under [US Verification Examples](#operation/us_verification) within the\n\"Verify a US or US territory address\" section in US Verifications.\n\nYou can rely on the response from these examples generally matching the response you'd see in the live environment with an\naddress of that type (excluding the `recipient` field).\n\nThe test API key does not perform any verification, automatic correction, or standardization for addresses. If you wish to\ntry these features out, use our <a href=\"https://lob.com/address-verification\" target=\"_blank\">live demo</a> or the free plan (see <a href=\"https://lob.com/pricing/address-verification\" target=\"_blank\">our pricing</a> for details).\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18377,7 +18429,7 @@
             },
             "item": [
                 {
-                    "id": "759f809a-354f-409f-bbe0-070466c9683f",
+                    "id": "583fbf8d-19f1-41e6-b405-30c559fb95b2",
                     "name": "Bulk Verify",
                     "request": {
                         "name": "Bulk Verify",
@@ -18429,7 +18481,7 @@
                     },
                     "response": [
                         {
-                            "id": "d25e340d-6307-4a29-951d-58c0e4f3d884",
+                            "id": "94668267-b703-4536-a4ef-7257a0500f2f",
                             "name": "Returns a list of US verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -18514,7 +18566,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ec8607f8-39c5-484d-a870-25c9793eeea4",
+                            "id": "4ba051cd-45d6-42d4-aed8-d4d5827f11ed",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18587,7 +18639,7 @@
                     }
                 },
                 {
-                    "id": "76d1295e-43a8-47c7-8fb4-b8da564d98e6",
+                    "id": "8467099c-f6ef-4127-ade9-902bb837f0b8",
                     "name": "Single Verify",
                     "request": {
                         "name": "Single Verify",
@@ -18667,7 +18719,7 @@
                     },
                     "response": [
                         {
-                            "id": "0c1aa3c3-227c-46ba-a7c7-136d86a7d5d5",
+                            "id": "98038318-a5cd-4ee4-bd4c-a63cdb95371d",
                             "name": "Returns a US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -18753,7 +18805,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "343d7870-b147-471c-836d-4d66d27e3c58",
+                            "id": "de0ce2c1-4602-4a92-aefb-54b0ed283b02",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18830,7 +18882,7 @@
             "event": []
         },
         {
-            "id": "be1dcccd-26a5-4fde-9a3b-fc905d49dc23",
+            "id": "803433d9-632a-405c-aa2e-c479e30cf6ef",
             "name": "Versioning and Changelog",
             "description": {
                 "content": "### API Versioning\n\nWhen backwards-incompatible changes are made to the API, a new dated version\nis released. The latest version of the API is version **2020-02-11**. \nAll versions prior to, and inclusive of, 2019-02-11 have been sunsetted. You can\nview your version and upgrade to the latest version in your\n<a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Dashboard Settings</a>. You will\nonly need to specify a version if you would like to test a newer version of\nthe API without doing a full upgrade. The API will return an error if a\nversion older than your current one is passed in.\n\n### Example Request\n\n```bash\n  curl https://api.lob.com/v1/addresses \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -H \"Lob-Version: 2020-02-11\"\n```\n\n### Specification Versioning\nYou might be wondering why our API and specification use different versioning schemes.\nLob's API predates our specification and follows the <a href=\"https://stripe.com/blog/api-versioning\" target=\"_blank\">Stripe versioning</a>\napproach. This works well to manage backwards-incompatible changes to our API.\n\nFor our API specification (used to create this documentation), we've chosen <a href=\"https://semver.org/\" target=\"_blank\">semantic\nversioning</a>. This versioning reflects the backward-compatible\nchanges that do not require a versioning of Lob's API.\n\nLob's API specification will be used to generate artifacts like documentation, client SDKs,\nand other developer tooling. Semantic versioning of our specification will inform how we\nversion those artifacts like SDKs. It is helpful to know the version of a specification\nused to produce an artifact in order reference the specification release notes.\n\n\n### Changelog\n <a href=\"https://app.getbeamer.com/lob/en?all\" target=\"_blank\">View our Changelog here.</a>\n",
@@ -18840,7 +18892,7 @@
             "event": []
         },
         {
-            "id": "8ddfb946-1c09-479e-8b33-24bdede708bc",
+            "id": "a9f8de32-ecf9-4fa5-a0c4-bb7c17d3a9a7",
             "name": "Webhooks",
             "description": {
                 "content": "Webhooks are an easy way to get notifications on events happening asynchronously\nwithin Lob's architecture. For example, when a postcard gets a \"Processed For\nDelivery\" tracking event, an event object of type `postcard.processed_for_delivery`\nwill be created. If you are subscribed to that event type in that Environment\n(Test vs. Live), Lob will send that event to any URLs you've specified via an\nHTTP POST request. In Live mode, you can only have as many webhooks as allotted\nin your current <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>.\nThere is no limit in Test mode.\nYou can view and create <a href=\"https://dashboard.lob.com/#/webhooks\" target=\"_blank\">webhooks</a> on the\nLob Dashboard, as well as view your <a href=\"https://dashboard.lob.com/#/events\" target=\"_blank\">events</a>.\nSee our <a href=\"https://help.lob.com/print-and-mail/getting-data-and-results/using-webhooks\" target=\"_blank\">Webhooks Integration Guide</a> for more\ndetails on how to integrate. Please see the full list of event types available for\nsubscription here.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18850,7 +18902,7 @@
             "event": []
         },
         {
-            "id": "d6f4da61-533f-4a20-aead-1f6d493f411e",
+            "id": "479d9dd4-eccb-471d-aa53-ee8ddc1c9d66",
             "name": "Zip Lookups",
             "description": {
                 "content": "Find a list of cities, states and associated information about a US ZIP code. <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18858,7 +18910,7 @@
             },
             "item": [
                 {
-                    "id": "22c4785a-e67d-4d3e-8830-c5674b35034a",
+                    "id": "8703b427-dd24-45f2-b66f-6233a2b545e3",
                     "name": "Lookups",
                     "request": {
                         "name": "Lookups",
@@ -18902,7 +18954,7 @@
                     },
                     "response": [
                         {
-                            "id": "8a7091d0-faa3-4cd7-b08d-000efe29b388",
+                            "id": "51281358-9a68-48f9-8a0b-34f88737c087",
                             "name": "Returns a zip lookup object if a valid zip was provided.",
                             "originalRequest": {
                                 "url": {
@@ -18972,7 +19024,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3a34f30a-27d6-4f47-bf0c-bdee66a7c247",
+                            "id": "42fee7e0-172f-4ffc-acae-6b5abce8d18d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -19055,7 +19107,7 @@
         ]
     },
     "info": {
-        "_postman_id": "148434d4-ffc1-40ed-80df-6ba1b6ff41a8",
+        "_postman_id": "3b17196b-6929-44f5-b816-336787211444",
         "name": "Lob",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.13",
+  "version": "1.19.14",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/resources/creatives/models/letter_details.yml
+++ b/resources/creatives/models/letter_details.yml
@@ -1,6 +1,6 @@
 # only diff b/t `writable` and `returned` are the `custom_envelope` and `return_envelope` fields
 writable:
-  description: Properties that the letters in your Creative should have.
+  description: Properties that the letters in your Creative should have. Check within in order to add a qr code to your creative.
 
   required:
     - color
@@ -63,7 +63,7 @@ writable:
     # size:
 
 returned:
-  description: Properties that the letters in your Creative should have.
+  description: Properties that the letters in your Creative should have. Check within in order to add a qr code to your creative.
 
   properties:
     address_placement:

--- a/resources/creatives/models/letter_details.yml
+++ b/resources/creatives/models/letter_details.yml
@@ -1,6 +1,6 @@
 # only diff b/t `writable` and `returned` are the `custom_envelope` and `return_envelope` fields
 writable:
-  description: Properties that the letters in your Creative should have. Check within in order to add a qr code to your creative.
+  description: Properties that the letters in your Creative should have. Check within in order to add a QR code to your creative.
 
   required:
     - color
@@ -63,7 +63,7 @@ writable:
     # size:
 
 returned:
-  description: Properties that the letters in your Creative should have. Check within in order to add a qr code to your creative.
+  description: Properties that the letters in your Creative should have. Check within in order to add a QR code to your creative.
 
   properties:
     address_placement:

--- a/resources/creatives/models/postcard_details.yml
+++ b/resources/creatives/models/postcard_details.yml
@@ -1,5 +1,5 @@
 writable:
-  description: Properties that the postcards in your Creative should have.
+  description: Properties that the postcards in your Creative should have. Check within in order to add a qr code to your creative.
 
   required:
     - color
@@ -15,7 +15,7 @@ writable:
       $ref: "../../../shared/models/qr_code_campaigns.yml"
 
 returned:
-  description: Properties that the postcards in your Creative should have.
+  description: Properties that the postcards in your Creative should have. Check within in order to add a qr code to your creative.
 
   properties:
     mail_type:

--- a/resources/creatives/models/postcard_details.yml
+++ b/resources/creatives/models/postcard_details.yml
@@ -1,5 +1,5 @@
 writable:
-  description: Properties that the postcards in your Creative should have. Check within in order to add a qr code to your creative.
+  description: Properties that the postcards in your Creative should have. Check within in order to add a QR code to your creative.
 
   required:
     - color
@@ -15,7 +15,7 @@ writable:
       $ref: "../../../shared/models/qr_code_campaigns.yml"
 
 returned:
-  description: Properties that the postcards in your Creative should have. Check within in order to add a qr code to your creative.
+  description: Properties that the postcards in your Creative should have. Check within in order to add a QR code to your creative.
 
   properties:
     mail_type:

--- a/resources/creatives/models/returned_resource.yml
+++ b/resources/creatives/models/returned_resource.yml
@@ -30,3 +30,19 @@ oneOf:
           details:
             $ref: "letter_details.yml#/returned"
       - $ref: "creative_base.yml"
+  - allOf:
+      - title: Self Mailer Creative
+        required:
+          - resource_type
+          - details
+        properties:
+          resource_type:
+            type: string
+            description: Mailpiece type for the creative
+            enum:
+              - self_mailer
+
+          details:
+            $ref: "self_mailer_details.yml#/returned"
+
+      - $ref: "creative_base.yml"

--- a/resources/creatives/models/self_mailer_details.yml
+++ b/resources/creatives/models/self_mailer_details.yml
@@ -1,0 +1,39 @@
+writable:
+  description: Properties that the self mailers in your Creative should have.
+
+  required:
+    - color
+
+  properties:
+    mail_type:
+      $ref: "../../../shared/attributes/mail_type.yml"
+
+    size:
+      $ref: "../../self_mailers/attributes/self_mailer_size.yml"
+
+    qr_code:
+      $ref: "../../../shared/models/qr_code_campaigns.yml"
+
+returned:
+  description: Properties that the self mailers in your Creative should have.
+
+  properties:
+    mail_type:
+      $ref: "../../../shared/attributes/mail_type.yml"
+
+    size:
+      $ref: "../../self_mailers/attributes/self_mailer_size.yml"
+
+    inside_original_url:
+      description: The original URL of the `inside` template.
+      maxLength: 2083
+      minLength: 1
+      type: string
+      format: uri
+
+    outside_original_url:
+      description: The original URL of the `outside` template.
+      maxLength: 2083
+      minLength: 1
+      type: string
+      format: uri

--- a/resources/creatives/models/self_mailer_details.yml
+++ b/resources/creatives/models/self_mailer_details.yml
@@ -1,5 +1,5 @@
 writable:
-  description: Properties that the self mailers in your Creative should have. Check within in order to add a qr code to your creative.
+  description: Properties that the self mailers in your Creative should have. Check within in order to add a QR code to your creative.
 
   required:
     - color
@@ -15,7 +15,7 @@ writable:
       $ref: "../../../shared/models/qr_code_campaigns.yml"
 
 returned:
-  description: Properties that the self mailers in your Creative should have. Check within in order to add a qr code to your creative.
+  description: Properties that the self mailers in your Creative should have. Check within in order to add a QR code to your creative.
 
   properties:
     mail_type:

--- a/resources/creatives/models/self_mailer_details.yml
+++ b/resources/creatives/models/self_mailer_details.yml
@@ -1,5 +1,5 @@
 writable:
-  description: Properties that the self mailers in your Creative should have.
+  description: Properties that the self mailers in your Creative should have. Check within in order to add a qr code to your creative.
 
   required:
     - color
@@ -15,7 +15,7 @@ writable:
       $ref: "../../../shared/models/qr_code_campaigns.yml"
 
 returned:
-  description: Properties that the self mailers in your Creative should have.
+  description: Properties that the self mailers in your Creative should have. Check within in order to add a qr code to your creative.
 
   properties:
     mail_type:

--- a/shared/models/qr_code.yml
+++ b/shared/models/qr_code.yml
@@ -10,15 +10,15 @@ properties:
     type: string
     enum:
       - relative
-    description: Sets how a QR code is being positioned in the document.
+    description: Sets how a QR code is being positioned in the document. When using position 'relative', you should provide one of 'top' or 'bottom', and one of 'left' or 'right'.
 
   top:
     type: string
-    description: Vertical distance(in inches) to place QR code from the top.
+    description: Vertical distance (in inches) to place QR code from the top.
 
   right:
     type: string
-    description: Horizonal distance(in inches) to place QR code from the right.
+    description: Horizonal distance (in inches) to place QR code from the right.
 
   left:
     type: string
@@ -26,7 +26,7 @@ properties:
 
   bottom:
     type: string
-    description: Vertical distance(in inches) to place QR code from the bottom.
+    description: Vertical distance (in inches) to place QR code from the bottom.
 
   redirect_url:
     type: string
@@ -34,8 +34,8 @@ properties:
 
   width:
     type: string
-    description: The size(in inches) of the QR code with a minimum of 1 inch. All QR codes are generated as a square.
+    description: The size (in inches) of the QR code with a minimum of 1 inch. All QR codes are generated as a square.
 
   pages:
     type: string
-    description: Specify the pages where the QR code should be stamped in a comma separated format. For postcards, the values should be either `front`, `back`, or `front,back`. For letters, the values can be specific page numbers or page number ranges. For selfmailers, the values should be either `inside`, `outside`, or `inside,outside`.
+    description: Specify the pages where the QR code should be stamped in a comma separated format. Your QR code can be printed in the same position on multiple pages. For postcards, the values should either be "front", "back" (for either front or back) or "front,back" (for the QR code to be printed on both sides). For self-mailers, the values should either be "inside", "outside" (for either inside or outside) or "inside,outside" (for the QR code to be printed on both sides). For letters, the values can be specific page numbers ("1", "3"), page number ranges such as "1-3", or a comma separated combination of both ("1,3,5-7").

--- a/shared/models/qr_code_campaigns.yml
+++ b/shared/models/qr_code_campaigns.yml
@@ -1,5 +1,5 @@
 type: object
-description: Customize and place a QR code on all the postcards and letters in a campaign. Redirect URLs can either be unqiue for each recipient, or a single link can be used for the whole campaign. See `redirect_url` attribute below for more details.
+description: Customize and place a QR code on all the postcards and letters in a campaign. Redirect URLs can either be unique for each recipient, or a single link can be used for the whole campaign. See `redirect_url` attribute below for more details.
 required:
   - position
   - width
@@ -8,24 +8,24 @@ properties:
   position:
     type: string
     enum:
-      - relative
-    description: Sets how a QR code is being positioned in the document.
+      - relative, fixed
+    description: Sets how a QR code is being positioned in the document. When using position 'relative', you should provide one of 'top' or 'bottom', and one of 'left' or 'right'.
 
   top:
     type: string
-    description: Vertical distance(in inches) to place QR code from the top.
+    description: Vertical distance (in inches) to place QR code from the top.
 
   right:
     type: string
-    description: Horizonal distance(in inches) to place QR code from the right.
+    description: Horizonal distance (in inches) to place QR code from the right.
 
   left:
     type: string
-    description: Horizonal distance(in inches) to place QR code from the left.
+    description: Horizonal distance (in inches) to place QR code from the left.
 
   bottom:
     type: string
-    description: Vertical distance(in inches) to place QR code from the bottom.
+    description: Vertical distance (in inches) to place QR code from the bottom.
 
   redirect_url:
     description: >
@@ -39,8 +39,8 @@ properties:
 
   width:
     type: string
-    description: The size(in inches) of the QR code with a minimum of 1 inch. All QR codes are generated as a square.
+    description: The size (in inches) of the QR code with a minimum of 1 inch. All QR codes are generated as a square.
 
   pages:
     type: string
-    description: Specify the pages where the QR code should be stamped in a comma separated format. For postcards, the values should be either `front`, `back`, or `front,back`. For letters, the values can be specific page numbers or page number ranges.
+    description: Specify the pages where the QR code should be stamped in a comma separated format. Your QR code can be printed in the same position on multiple pages. For postcards, the values should either be "front", "back" (for either front or back) or "front,back" (for the QR code to be printed on both sides). For self-mailers, the values should either be "inside", "outside" (for either inside or outside) or "inside,outside" (for the QR code to be printed on both sides). For letters, the values can be specific page numbers ("1", "3"), page number ranges such as "1-3", or a comma separated combination of both ("1,3,5-7").

--- a/shared/models/qr_code_campaigns.yml
+++ b/shared/models/qr_code_campaigns.yml
@@ -1,5 +1,5 @@
 type: object
-description: Customize and place a QR code on all the postcards and letters in a campaign. Redirect URLs can either be unique for each recipient, or a single link can be used for the whole campaign. See `redirect_url` attribute below for more details.
+description: Customize and place a QR code on all the postcards, letters or self mailers in a campaign. Redirect URLs can either be unique for each recipient, or a single link can be used for the whole campaign. See `redirect_url` attribute below for more details.
 required:
   - position
   - width


### PR DESCRIPTION
Fixes [GC-1466](https://lobsters.atlassian.net/browse/GC-1466)

- Updates QR code documentation to include self mailers (apart from letters and postcards).
- Updates `pages` to: `Specify the pages where the QR code should be stamped in a comma separated format. Your QR code can be printed in the same position on multiple pages. For postcards, the values should either be "front", "back" (for either front or back) or "front,back" (for the QR code to be printed on both sides). For self-mailers, the values should either be "inside", "outside" (for either inside or outside) or "inside,outside" (for the QR code to be printed on both sides). For letters, the values can be specific page numbers ("1", "3"), page number ranges such as "1-3", or a comma separated combination of both ("1,3,5-7").`
- Updates `position` description to: `Sets how a QR code is being positioned in the document. When using position 'relative', you should provide one of 'top' or 'bottom', and one of 'left' or 'right'.`
- Updates the `details` description: `Properties that the letters in your Creative should have. Check within in order to add a QR code to your creative.`

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

## Areas of Concern (optional)


[GC-1466]: https://lobsters.atlassian.net/browse/GC-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ