### PR TITLE
GC-1559/updates documentation for qr codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![CI](https://github.com/lob/lob-openapi/workflows/CI/badge.svg) ![CD](https://github.com/lob/lob-openapi/workflows/CD/badge.svg) Lob [OpenAPI v3](https://github.com/OAI/OpenAPI-Specification) Specification
 
-- [  Lob OpenAPI v3 Specification](#--lob-openapi-v3-specification)
+- [ Lob OpenAPI v3 Specification](#--lob-openapi-v3-specification)
   - [What is this project?](#what-is-this-project)
   - [Contributing](#contributing)
   - [Design](#design)

--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.17
+  version: 1.19.18
   description: >
     The Lob API is organized around REST. Our API is designed to have
     predictable, resource-oriented URLs and uses HTTP response codes to indicate
@@ -7774,33 +7774,42 @@ components:
         position:
           type: string
           enum:
-            - relative, fixed
+            - relative
           description: >-
-            Sets how a QR code is being positioned in the document. When using
-            position 'relative', you should provide one of 'top' or 'bottom',
-            and one of 'left' or 'right'.
+            Sets how a QR code is being positioned in the document. Together
+            with this, you should provide one of 'top' or 'bottom', and one of
+            'left' or 'right'.
         top:
           type: string
-          description: Vertical distance (in inches) to place QR code from the top.
+          description: >-
+            Vertical distance (in inches) to place QR code from the top. Only
+            allowed if "bottom" isn't provided.
         right:
           type: string
-          description: Horizonal distance (in inches) to place QR code from the right.
+          description: >-
+            Horizonal distance (in inches) to place QR code from the right. Only
+            allowed if "left" isn't provided.
         left:
           type: string
-          description: Horizonal distance (in inches) to place QR code from the left.
+          description: >-
+            Horizonal distance (in inches) to place QR code from the left. Only
+            allowed if "right" isn't provided.
         bottom:
           type: string
-          description: Vertical distance (in inches) to place QR code from the bottom.
+          description: >-
+            Vertical distance (in inches) to place QR code from the bottom. Only
+            allowed if "top" isn't provided.
         redirect_url:
           description: >
-            Redirect all mail receipients to either a single URL or a custom
-            personalized URL for each address.  To redirect to a single URL for
-            the whole campaign, add a `redirect_url` in the request body along
-            with the url as string. To redirect to a custom URL for each
-            address, create an extra column in the [audience
+            Redirect all mail recipients to either a single URL or a custom
+            personalized URL for each recipient.  To redirect to a single URL
+            for the whole campaign, add a `redirect_url` in the request body
+            along with the url as string. To redirect to a custom URL for each
+            recipient, do not provide any value for `redirect_url`. Instead,
+            create an extra column in the [audience
             file](https://help.lob.com/print-and-mail/building-a-mail-strategy/campaign-or-triggered-sends/campaign-audience-guide)
-            with a unique link against each address row and map that row using
-            the merge variable mapping while creating an upload. If the QR code
+            with a unique link against each address row and while creating an
+            upload, map `qr_code_redirect_url` to this column. If the QR code
             section is used but a redirection url is not provided or mapped
             while creating an upload, then there might be failures in creating
             individual mail pieces.
@@ -9066,21 +9075,29 @@ components:
           enum:
             - relative
           description: >-
-            Sets how a QR code is being positioned in the document. When using
-            position 'relative', you should provide one of 'top' or 'bottom',
-            and one of 'left' or 'right'.
+            Sets how a QR code is being positioned in the document. Together
+            with this, you should provide one of 'top' or 'bottom', and one of
+            'left' or 'right'.
         top:
           type: string
-          description: Vertical distance (in inches) to place QR code from the top.
+          description: >-
+            Vertical distance (in inches) to place QR code from the top. Only
+            allowed if "bottom" isn't provided.
         right:
           type: string
-          description: Horizonal distance (in inches) to place QR code from the right.
+          description: >-
+            Horizonal distance (in inches) to place QR code from the right. Only
+            allowed if "left" isn't provided.
         left:
           type: string
-          description: Horizonal distance(in inches) to place QR code from the left.
+          description: >-
+            Horizonal distance (in inches) to place QR code from the left. Only
+            allowed if "right" isn't provided.
         bottom:
           type: string
-          description: Vertical distance (in inches) to place QR code from the bottom.
+          description: >-
+            Vertical distance (in inches) to place QR code from the bottom. Only
+            allowed if "top" isn't provided.
         redirect_url:
           type: string
           description: >-

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Lob
-  version: "1.19.17"
+  version: "1.19.18"
   description: >
     The Lob API is organized around REST. Our API is designed to have predictable,
     resource-oriented URLs and uses HTTP response codes to indicate any API errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.17",
+  "version": "1.19.18",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/shared/models/qr_code.yml
+++ b/shared/models/qr_code.yml
@@ -10,23 +10,23 @@ properties:
     type: string
     enum:
       - relative
-    description: Sets how a QR code is being positioned in the document. When using position 'relative', you should provide one of 'top' or 'bottom', and one of 'left' or 'right'.
+    description: Sets how a QR code is being positioned in the document. Together with this, you should provide one of 'top' or 'bottom', and one of 'left' or 'right'.
 
   top:
     type: string
-    description: Vertical distance (in inches) to place QR code from the top.
+    description: Vertical distance (in inches) to place QR code from the top. Only allowed if "bottom" isn't provided.
 
   right:
     type: string
-    description: Horizonal distance (in inches) to place QR code from the right.
+    description: Horizonal distance (in inches) to place QR code from the right. Only allowed if "left" isn't provided.
 
   left:
     type: string
-    description: Horizonal distance(in inches) to place QR code from the left.
+    description: Horizonal distance(in inches) to place QR code from the left. Only allowed if "right" isn't provided.
 
   bottom:
     type: string
-    description: Vertical distance (in inches) to place QR code from the bottom.
+    description: Vertical distance (in inches) to place QR code from the bottom. Only allowed if "top" isn't provided.
 
   redirect_url:
     type: string

--- a/shared/models/qr_code.yml
+++ b/shared/models/qr_code.yml
@@ -22,7 +22,7 @@ properties:
 
   left:
     type: string
-    description: Horizonal distance(in inches) to place QR code from the left. Only allowed if "right" isn't provided.
+    description: Horizonal distance (in inches) to place QR code from the left. Only allowed if "right" isn't provided.
 
   bottom:
     type: string

--- a/shared/models/qr_code_campaigns.yml
+++ b/shared/models/qr_code_campaigns.yml
@@ -29,9 +29,9 @@ properties:
 
   redirect_url:
     description: >
-      Redirect all mail recipients to either a single URL or a custom personalized URL for each address. 
+      Redirect all mail recipients to either a single URL or a custom personalized URL for each recipient. 
       To redirect to a single URL for the whole campaign, add a `redirect_url` in the request body along with the url as string.
-      To redirect to a custom URL for each address, do not provide any value for `redirect_url`. Instead, create an extra column in the [audience file](https://help.lob.com/print-and-mail/building-a-mail-strategy/campaign-or-triggered-sends/campaign-audience-guide) with a unique link against each address row and while creating an upload, map `qr_code_redirect_url` to this column.
+      To redirect to a custom URL for each recipient, do not provide any value for `redirect_url`. Instead, create an extra column in the [audience file](https://help.lob.com/print-and-mail/building-a-mail-strategy/campaign-or-triggered-sends/campaign-audience-guide) with a unique link against each address row and while creating an upload, map `qr_code_redirect_url` to this column.
       If the QR code section is used but a redirection url is not provided or mapped while creating an upload, then there might be failures in creating individual mail pieces.
     oneOf:
       - $ref: "../attributes/single_redirect_url.yml"

--- a/shared/models/qr_code_campaigns.yml
+++ b/shared/models/qr_code_campaigns.yml
@@ -8,30 +8,30 @@ properties:
   position:
     type: string
     enum:
-      - relative, fixed
-    description: Sets how a QR code is being positioned in the document. When using position 'relative', you should provide one of 'top' or 'bottom', and one of 'left' or 'right'.
+      - relative
+    description: Sets how a QR code is being positioned in the document. Together with this, you should provide one of 'top' or 'bottom', and one of 'left' or 'right'.
 
   top:
     type: string
-    description: Vertical distance (in inches) to place QR code from the top.
+    description: Vertical distance (in inches) to place QR code from the top. Only allowed if "bottom" isn't provided.
 
   right:
     type: string
-    description: Horizonal distance (in inches) to place QR code from the right.
+    description: Horizonal distance (in inches) to place QR code from the right. Only allowed if "left" isn't provided.
 
   left:
     type: string
-    description: Horizonal distance (in inches) to place QR code from the left.
+    description: Horizonal distance (in inches) to place QR code from the left. Only allowed if "right" isn't provided.
 
   bottom:
     type: string
-    description: Vertical distance (in inches) to place QR code from the bottom.
+    description: Vertical distance (in inches) to place QR code from the bottom. Only allowed if "top" isn't provided.
 
   redirect_url:
     description: >
       Redirect all mail receipients to either a single URL or a custom personalized URL for each address. 
       To redirect to a single URL for the whole campaign, add a `redirect_url` in the request body along with the url as string.
-      To redirect to a custom URL for each address, create an extra column in the [audience file](https://help.lob.com/print-and-mail/building-a-mail-strategy/campaign-or-triggered-sends/campaign-audience-guide) with a unique link against each address row and map that row using the merge variable mapping while creating an upload.
+      To redirect to a custom URL for each address, do not provide any value for `redirect_url`. Instead, create an extra column in the [audience file](https://help.lob.com/print-and-mail/building-a-mail-strategy/campaign-or-triggered-sends/campaign-audience-guide) with a unique link against each address row and while creating an upload, map `qr_code_redirect_url` to this column.
       If the QR code section is used but a redirection url is not provided or mapped while creating an upload, then there might be failures in creating individual mail pieces.
     oneOf:
       - $ref: "../attributes/single_redirect_url.yml"

--- a/shared/models/qr_code_campaigns.yml
+++ b/shared/models/qr_code_campaigns.yml
@@ -29,7 +29,7 @@ properties:
 
   redirect_url:
     description: >
-      Redirect all mail receipients to either a single URL or a custom personalized URL for each address. 
+      Redirect all mail recipients to either a single URL or a custom personalized URL for each address. 
       To redirect to a single URL for the whole campaign, add a `redirect_url` in the request body along with the url as string.
       To redirect to a custom URL for each address, do not provide any value for `redirect_url`. Instead, create an extra column in the [audience file](https://help.lob.com/print-and-mail/building-a-mail-strategy/campaign-or-triggered-sends/campaign-audience-guide) with a unique link against each address row and while creating an upload, map `qr_code_redirect_url` to this column.
       If the QR code section is used but a redirection url is not provided or mapped while creating an upload, then there might be failures in creating individual mail pieces.


### PR DESCRIPTION
[GC-1559](https://lobsters.atlassian.net/browse/GC-1559)

Updates QR codes documentation:

- for `position`, we now only show `relative` (not `fixed` anymore as an option)
- for `redirect_url`, we clarify what the user should do if they want a single URL vs a dynamic URL from their audience file

[GC-1559]: https://lobsters.atlassian.net/browse/GC-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ