### PR TITLE
bump version to go with changes in RC-898

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.20
+  version: 1.19.21
   description: >
     The Lob API is organized around REST. Our API is designed to have
     predictable, resource-oriented URLs and uses HTTP response codes to indicate

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Lob
-  version: "1.19.20"
+  version: "1.19.21"
   description: >
     The Lob API is organized around REST. Our API is designed to have predictable,
     resource-oriented URLs and uses HTTP response codes to indicate any API errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.20",
+  "version": "1.19.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.20",
+  "version": "1.19.21",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"


### PR DESCRIPTION
Adds version bump for changes introduced in https://github.com/lob/lob-openapi/pull/471

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [ ] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [x] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect
