### PR TITLE
CMB-341: docs to support legal letters

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.24
+  version: 1.19.25
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.24",
+  "version": "1.19.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/openapi",
-      "version": "1.19.24",
+      "version": "1.19.25",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11145,6 +11145,16 @@
       "integrity": "sha512-oajWz4kOajqpKJMPgnCvBajPq8QAvl2xIWoFjlAJPKGu6n7pjov5SxGE45a+0RxHDoo4ycOMoZw1SCOWtDERbw==",
       "dev": true
     },
+    "node_modules/redoc-cli/node_modules/@types/chokidar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
+      "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
+      "deprecated": "This is a stub types definition. chokidar provides its own type definitions, so you do not need this installed.",
+      "extraneous": true,
+      "dependencies": {
+        "chokidar": "*"
+      }
+    },
     "node_modules/redoc-cli/node_modules/@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -11174,11 +11184,30 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/redoc-cli/node_modules/@types/handlebars": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "deprecated": "This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.",
+      "extraneous": true,
+      "dependencies": {
+        "handlebars": "*"
+      }
+    },
     "node_modules/redoc-cli/node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
+    },
+    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/redoc-cli/node_modules/@types/node": {
       "version": "15.12.2",
@@ -11886,7 +11915,6 @@
       "version": "3.20.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
       "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
       "hasInstallScript": true,
       "peer": true,
@@ -13165,7 +13193,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.24",
+  "version": "1.19.25",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/resources/letters/attributes/extra_service.yml
+++ b/resources/letters/attributes/extra_service.yml
@@ -9,4 +9,6 @@ description: |
     * `certified` - track and confirm delivery for domestic destinations. An extra sheet (1 PDF page single-sided or 2 PDF pages double-sided) is added to the beginning of your letter for address and barcode information. See here for templates: <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_certified_template.pdf" target="_blank">#10 envelope</a> and <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/letter_certified_flat_template.pdf" target="_blank">flat envelope</a> (used for letters over 6 pages single-sided or 12 pages double-sided). You will not be charged for this extra sheet.
     * `certified_return_receipt` - request an electronic copy of the recipient's signature to prove delivery of your certified letter
     * `registered` - provides tracking and confirmation for international addresses
+    
+  Not available for `us_legal` letter size.
 nullable: true

--- a/resources/letters/attributes/ltr_size.yml
+++ b/resources/letters/attributes/ltr_size.yml
@@ -1,10 +1,17 @@
 type: string
 
 enum:
+  - us_letter
   - us_legal
 
 description: >
-  Specifies the size of the letter. Currently only applicable for legal letters.
-  To use `us_legal`, set the [Lob-Version header](#tag/Versioning-and-Changelog) to `2024-01-01`. Do not include this attribute as well the header version set to 2024-01-01 if you are not sending a legal letter.
+  Specifies the size of the letter. It accepts two values `us_letter` and `us_legal`.
+  If the [Lob-Version header](#tag/Versioning-and-Changelog) in the request is set to `2024-01-01` and above,
+  the `size` property is automatically included with the default value of `us_letter`,
+  unless explicitly specified.
 
-default: us_legal
+
+  Please note that attempting to include the `size` property in the request with the `Lob-Version` header
+  predating to `2024-01-01` will result in an error.
+
+default: us_letter

--- a/resources/letters/attributes/ltr_size.yml
+++ b/resources/letters/attributes/ltr_size.yml
@@ -1,0 +1,10 @@
+type: string
+
+enum:
+  - us_legal
+
+description: >
+  Specifies the size of the letter. Currently only applicable for legal letters.
+  To use `us_legal`, set the [Lob-Version header](#tag/Versioning-and-Changelog) to `2024-01-01`. Do not include this attribute as well the header version set to 2024-01-01 if you are not sending a legal letter.
+
+default: us_legal

--- a/resources/letters/letters.yml
+++ b/resources/letters/letters.yml
@@ -172,6 +172,7 @@ post:
   parameters:
     - $ref: "../../shared/parameters/idempotency.yml#/idem-header"
     - $ref: "../../shared/parameters/idempotency.yml#/idem-query"
+    - $ref: "../../shared/parameters/lob_version.yml#/lob-version"
 
   requestBody:
     required: true

--- a/resources/letters/models/letter_editable.yml
+++ b/resources/letters/models/letter_editable.yml
@@ -20,7 +20,7 @@ allOf:
         $ref: "../attributes/extra_service.yml"
 
       cards:
-        description: A single-element array containing an existing card id in a string format. See [cards](#tag/Cards) for more information.
+        description: A single-element array containing an existing card id in a string format. See [cards](#tag/Cards) for more information. Not available for `us_legal` letter size.
         type: array
         items:
           $ref: "../../../shared/attributes/model_ids/card_id.yml"
@@ -69,5 +69,8 @@ allOf:
 
       fsc:
         type: boolean
-        description: This is in beta. Contact support@lob.com or your account contact to learn more. Not available for `A4` letter size.
+        description: This is in beta. Contact support@lob.com or your account contact to learn more. Not available for `A4` and `us_legal` letter size.
         default: false
+
+      size:
+        $ref: "../attributes/ltr_size.yml"

--- a/shared/models/qr_code.yml
+++ b/shared/models/qr_code.yml
@@ -1,5 +1,5 @@
 type: object
-description: Customize and place a QR code on the creative at the required position.
+description: Customize and place a QR code on the creative at the required position. Not available for `us_legal` letter size.
 required:
   - position
   - redirect_url

--- a/shared/parameters/lob_version.yml
+++ b/shared/parameters/lob_version.yml
@@ -1,0 +1,15 @@
+lob-version:
+  in: header
+
+  name: Lob-Version
+
+  required: false
+
+  description: >
+    A string representing the version of the API being used. For more information on versioning,
+    refer to our [Versioning and Changelog]((#tag/Versioning-and-Changelog) documentation.
+
+  schema:
+    type: string
+    example: 2024-01-01
+    pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"


### PR DESCRIPTION
Fixes #\<CMB-341\>

https://lobsters.atlassian.net/browse/CMB-341

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

Adds support for legal letters. Legal letters are supported via the `size` property with the `Lob-Version` header set to `2024-01-01`. The following properties are not applicable / available to legal letters.

- `cards`
- `extra_service`
- `qr_code`
- `fsc`

## Areas of Concern

First time contributing to the repo. Let me know if I've missed anything.
