### PR TITLE
CMB-435: add snap packs to the public docs

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -2342,6 +2342,7 @@ x-tagGroups:
       - Self Mailers
       - Letters
       - Checks
+      - Snap Packs
       - Bank Accounts
       - Templates
       - Template Versions
@@ -2493,6 +2494,8 @@ paths:
     $ref: resources/self_mailers/self_mailer.yml
   /self_mailers:
     $ref: resources/self_mailers/self_mailers.yml
+  /snap_packs:
+    $ref: resources/snap_packs/snap_packs.yml
   /templates/{tmpl_id}/versions/{vrsn_id}:
     $ref: resources/templates/template_versions/template_version.yml
   /templates/{tmpl_id}/versions:

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.25
+  version: 1.19.26
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.25",
+  "version": "1.19.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/openapi",
-      "version": "1.19.25",
+      "version": "1.19.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.25",
+  "version": "1.19.26",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/resources/snap_packs/attributes/color.yml
+++ b/resources/snap_packs/attributes/color.yml
@@ -1,0 +1,4 @@
+type: boolean
+description: >-
+  Set this key to `true` if you would like to print in color.
+  Set to `false` if you would like to print in black and white.

--- a/resources/snap_packs/attributes/snap_pack_id.yml
+++ b/resources/snap_packs/attributes/snap_pack_id.yml
@@ -1,0 +1,5 @@
+type: string
+
+description: Unique identifier prefixed with `ord_`.
+
+pattern: "^ord_[0-9a-f]{26}$"

--- a/resources/snap_packs/attributes/snap_pack_size.yml
+++ b/resources/snap_packs/attributes/snap_pack_size.yml
@@ -1,0 +1,8 @@
+type: string
+
+enum:
+  - 8.5x11
+
+description: Specifies the size of the snap pack.
+
+default: 8.5x11

--- a/resources/snap_packs/attributes/snap_pack_use_type.yml
+++ b/resources/snap_packs/attributes/snap_pack_use_type.yml
@@ -1,0 +1,7 @@
+description: The use type for each mailpiece. Can be one of marketing, operational, or null. Null use_type is only allowed if an account default use_type is selected in Account Settings. For more information on use_type, see our  [Help Center article](https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings/declaring-mail-use-type).
+type: string
+enum:
+  - marketing
+  - operational
+  - null
+nullable: true

--- a/resources/snap_packs/models/snap_pack.yml
+++ b/resources/snap_packs/models/snap_pack.yml
@@ -1,0 +1,82 @@
+allOf:
+  - $ref: "snap_pack_base.yml"
+  - $ref: "../../../shared/models/form_factor/generated.yml"
+  - $ref: "../../../shared/models/form_factor/from_us.yml"
+
+  - type: object
+
+    required:
+      - id
+      - url
+      - use_type
+
+    properties:
+      id:
+        $ref: "../attributes/snap_pack_id.yml"
+
+      outside_template_id:
+        description: The unique ID of the HTML template used for the outside of the snap pack.
+        allOf:
+          - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+          - type: string
+            nullable: true
+
+      inside_template_id:
+        description: The unique ID of the HTML template used for the inside of the snap pack.
+        allOf:
+          - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+          - type: string
+            nullable: true
+
+      outside_template_version_id:
+        description: The unique ID of the specific version of the HTML template used for the outside of the snap pack.
+        allOf:
+          - $ref: "../../../shared/attributes/model_ids/vrsn_id.yml"
+          - type: string
+            nullable: true
+
+      inside_template_version_id:
+        description: The unique ID of the specific version of the HTML template used for the inside of the snap pack.
+        allOf:
+          - $ref: "../../../shared/attributes/model_ids/vrsn_id.yml"
+          - type: string
+            nullable: true
+
+      object:
+        type: string
+        description: Value is resource type.
+        enum:
+          - snap_pack
+        default: snap_pack
+
+      tracking_events:
+        description: >-
+          An array of tracking events ordered by ascending `time`. Not populated in test mode.
+        type: array
+        items:
+          $ref: "../../../shared/resources/tracking_events/models/tracking_event_normal.yml"
+
+      use_type:
+        $ref: "../attributes/snap_pack_use_type.yml"
+
+      url:
+        $ref: "../../../shared/attributes/signed_link.yml"
+
+      fsc:
+        type: boolean
+        description: Contact support@lob.com or your account contact to learn more. Not available for snap_pack currently.
+        default: false
+
+      status:
+        $ref: "../../../shared/attributes/status.yml"
+
+      campaign_id:
+        $ref: "../../../shared/attributes/campaign_id.yml"
+
+      failure_reason:
+        allOf:
+          - $ref: "../../../shared/models/failure_reason/failure_reason.yml"
+          - nullable: true
+
+      color:
+        $ref: "../attributes/color.yml"

--- a/resources/snap_packs/models/snap_pack_base.yml
+++ b/resources/snap_packs/models/snap_pack_base.yml
@@ -1,0 +1,8 @@
+allOf:
+  - $ref: "../../../shared/models/form_factor/editable.yml"
+
+  - type: object
+
+    properties:
+      size:
+        $ref: "../attributes/snap_pack_size.yml"

--- a/resources/snap_packs/models/snap_pack_editable.yml
+++ b/resources/snap_packs/models/snap_pack_editable.yml
@@ -1,0 +1,68 @@
+allOf:
+  - $ref: "snap_pack_base.yml"
+  - $ref: "../../../shared/models/form_factor/input_to.yml"
+  - $ref: "../../../shared/models/form_factor/input_from_us.yml"
+
+  - type: object
+
+    required:
+      - to
+      - inside
+      - outside
+      - use_type
+
+    properties:
+      inside:
+        description: >
+          The artwork to use as the inside of your snap pack.
+
+
+          Notes:
+
+          - HTML merge variables should not include delimiting whitespace.
+
+          - PDF, PNG, and JPGs must be sized at 8.5"x11" at 300 DPI, while supplied
+          HTML will be rendered to the specified `size`.
+
+          - Be sure to leave room for address and postage information by following
+          the template provided here:
+            - <a href="https://s3.us-west-2.amazonaws.com/public.lob.com/assets/8.5x11_Snappack_template_address.pdf" target="_blank">8.5x11 snap pack template</a>
+
+
+          See [here](#section/HTML-Examples) for HTML examples.
+        oneOf:
+          - $ref: "../../../shared/attributes/html_string.yml"
+          - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+          - $ref: "../../../shared/attributes/remote_file_url.yml"
+          - $ref: "../../../shared/attributes/local_file_path.yml"
+
+      outside:
+        description: >
+          The artwork to use as the outside of your snap pack.
+
+
+          Notes:
+
+          - HTML merge variables should not include delimiting whitespace.
+
+          - PDF, PNG, and JPGs must be sized at 6"x18" at 300 DPI, while supplied
+          HTML will be rendered to the specified `size`.
+
+
+          See [here](#section/HTML-Examples) for HTML examples.
+        oneOf:
+          - $ref: "../../../shared/attributes/html_string.yml"
+          - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+          - $ref: "../../../shared/attributes/remote_file_url.yml"
+          - $ref: "../../../shared/attributes/local_file_path.yml"
+
+      billing_group_id:
+        $ref: "../../../shared/attributes/billing_group_id.yml"
+
+      use_type:
+        $ref: "../attributes/snap_pack_use_type.yml"
+
+      color:
+        allOf:
+          - $ref: "../attributes/color.yml"
+          - default: false

--- a/resources/snap_packs/parameters/lob_version.yml
+++ b/resources/snap_packs/parameters/lob_version.yml
@@ -1,0 +1,16 @@
+lob-version:
+  in: header
+
+  name: Lob-Version
+
+  required: true
+
+  description: >
+    A string representing the version of the API being used. Please note that attempting to use snap packs with the `Lob-Version` header predating to `2024-01-01` will result in an error.
+
+    For more information on versioning, refer to our [Versioning and Changelog]((#tag/Versioning-and-Changelog) documentation.
+
+  schema:
+    type: string
+    example: 2024-01-01
+    pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"

--- a/resources/snap_packs/responses/post_snap_pack.yml
+++ b/resources/snap_packs/responses/post_snap_pack.yml
@@ -1,0 +1,12 @@
+description: Returns a snap_pack object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "snap_pack.yml"

--- a/resources/snap_packs/responses/snap_pack.yml
+++ b/resources/snap_packs/responses/snap_pack.yml
@@ -1,0 +1,68 @@
+application/json:
+  schema:
+    $ref: "../models/snap_pack.yml"
+  example:
+    id: ord_0d6a16a3fff6318ac8f8008dc1
+    description: April Campaign
+    to:
+      id: adr_bae820679f3f536b
+      description:
+      name: HARRY ZHANG
+      company:
+      phone:
+      email:
+      address_line1: 210 KING ST STE 6100
+      address_line2:
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
+      metadata: {}
+      date_created: "2017-09-05T17:47:53.767Z"
+      date_modified: "2017-09-05T17:47:53.767Z"
+      deleted: true
+      object: address
+    from:
+      id: adr_210a8d4b0b76d77b
+      description:
+      name: LEORE AVIDAR
+      company:
+      phone:
+      email:
+      address_line1: 210 KING ST STE 6100
+      address_line2:
+      address_city: SAN FRANCISCO
+      address_state: CA
+      address_zip: 94107-1741
+      address_country: UNITED STATES
+      metadata: {}
+      date_created: "2017-09-05T17:47:53.767Z"
+      date_modified: "2017-09-05T17:47:53.767Z"
+      deleted: true
+      object: address
+    url: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA
+    outside_template_id: tmpl_a3cb937f26d7eec
+    inside_template_id: tmpl_a3cb937f26d7eec
+    inside_template_version_id: vrsn_bfdf70893b00a85
+    outside_template_version_id: vrsn_bfdf70893b00a85
+    carrier: USPS
+    tracking_events: []
+    thumbnails:
+      - small: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA
+        medium: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ
+        large: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg
+      - small: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ
+        medium: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA
+        large: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw
+    merge_variables:
+      name:
+    size: 8.5x11
+    mail_type: usps_first_class
+    expected_delivery_date: "2021-03-24"
+    date_created: "2021-03-16T18:40:40.504Z"
+    date_modified: "2021-03-16T18:40:40.504Z"
+    send_date: "2021-03-16T18:45:40.493Z"
+    use_type: marketing
+    fsc: false
+    color: false
+    object: snap_pack

--- a/resources/snap_packs/snap_packs.yml
+++ b/resources/snap_packs/snap_packs.yml
@@ -1,0 +1,353 @@
+post:
+  operationId: snap_pack_create
+
+  summary: Create
+
+  description: >-
+    Creates a new snap_pack given information
+
+  tags:
+    - Snap Packs
+
+  parameters:
+    - $ref: "../../shared/parameters/idempotency.yml#/idem-header"
+    - $ref: "../../shared/parameters/idempotency.yml#/idem-query"
+    - $ref: "parameters/lob_version.yml#/lob-version"
+
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "models/snap_pack_editable.yml"
+        example:
+          description: Demo Snap Pack Job
+          to: adr_bae820679f3f536b
+          from: adr_210a8d4b0b76d77b
+          inside: "https://lob.com/snappackinside.pdf"
+          outside: "https://lob.com/snappackoutside.pdf"
+          size: 8.5x11
+          metadata:
+            spiffy: "true"
+          mail_type: usps_standard
+          merge_variables:
+            name: Harry
+          send_date: "2017-11-01T00:00:00.000Z"
+          use_type: marketing
+
+      multipart/form-data:
+        schema:
+          $ref: "models/snap_pack_editable.yml"
+        example:
+          description: Demo Snap Pack job
+          to: adr_bae820679f3f536b
+          from: adr_210a8d4b0b76d77b
+          inside: "https://lob.com/snappackinside.pdf"
+          outside: "https://lob.com/snappackoutside.pdf"
+          size: 8.5x11
+          metadata:
+            spiffy: "true"
+          mail_type: usps_standard
+          merge_variables:
+            name: Harry
+          send_date: "2017-11-01T00:00:00.000Z"
+          use_type: marketing
+
+  responses:
+    "200":
+      $ref: responses/post_snap_pack.yml
+
+    default:
+      $ref: "../../shared/responses/mailpiece_error.yml"
+
+  x-codeSamples:
+    - lang: Shell
+      source: |
+        curl https://api.lob.com/v1/snap_packs \
+          -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
+          -d "description=Demo Snap Pack job" \
+          -d "to[name]=Harry Zhang" \
+          -d "to[address_line1]=210 King St" \
+          -d "to[address_city]=San Francisco" \
+          -d "to[address_state]=CA" \
+          -d "to[address_zip]=94107" \
+          -d "from=adr_210a8d4b0b76d77b" \
+          -d "use_type=marketing" \
+          --data-urlencode "inside=<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>" \
+          --data-urlencode "outside=<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>" \
+          -d "merge_variables[name]=Harry" \
+          -d 'fsc=false'
+      label: CURL
+    - lang: Typescript
+      source: |
+        const snapPackCreate = new SnapPackEditable({
+          to: {
+          name: 'Harry Zhang',
+          address_line1: '210 King St',
+          address_line2: '# 6100',
+          address_city: 'San Francisco',
+          address_state: 'CA',
+          address_zip: '94107',
+        },
+          from: 'adr_xxxx',
+          inside:
+          'https://s3.us-west-2.amazonaws.com/public.lob.com/assets/8.5x11_Snappack_template_address.pdf',
+          outside:
+          'https://s3.us-west-2.amazonaws.com/public.lob.com/assets/8.5x11_Snappack_template_address.pdf',
+          use_type: 'marketing'
+          fsc: false
+        });
+
+        try {
+          const mySnapPack = await new SnapPacksApi(config).create(snapPackCreate);
+        } catch (err: any) {
+          console.error(err);
+        }
+      label: TYPESCRIPT
+    - lang: Javascript
+      source: |
+        Lob.snapPacks.create({
+          description: 'Demo Snap Packs job',
+          to: {
+            name: 'Harry Zhang',
+            address_line1: '210 King St',
+            address_city: 'San Francisco',
+            address_state: 'CA',
+            address_zip: '94107'
+          },
+          from: 'adr_210a8d4b0b76d77b',
+          inside: '<html style="padding: 1in; font-size: 50;">Inside HTML for {{name}}</html>',
+          outside: '<html style="padding: 1in; font-size: 20;">Outside HTML for {{name}}</html>',
+          merge_variables: {
+            name: 'Harry'
+          },
+          use_type: 'marketing'
+          fsc: false
+        }, function (err, res) {
+          console.log(err, res);
+        });
+      label: NODE
+    - lang: Ruby
+      source: |
+        snapPackCreate = SnapPackEditable.new({
+          description: "Demo Snap Pack job",
+          from: "adr_210a8d4b0b76d77b",
+          inside: "<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>",
+          outside: "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>",
+          to: AddressEditable.new({
+            name: "Harry Zhang",
+            address_line1: "210 King St",
+            address_line2: "# 6100",
+            address_city: "San Francisco",
+            address_state: "CA",
+            address_zip: "94107",
+          }),
+          merge_variables: {
+            name: "Harry"
+          },
+          use_type: 'marketing',
+          fsc: true
+        });
+
+        snapPackApi = SnapPacksApi.new(config)
+
+        begin
+          createdSnapPack = snapPackApi.create(snapPackCreate)
+        rescue => err
+          p err.message
+        end
+      label: RUBY
+    - lang: Python
+      source: |
+        snap_pack_editable = SnapPackEditable(
+          description = "Demo Snap Pack job",
+          _from = "adr_210a8d4b0b76d77b",
+          inside = "<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>",
+          outside = "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>",
+          to = AddressEditable(
+            name = "Harry Zhang",
+            address_line1 = "210 King St",
+            address_line2 = "# 6100",
+            address_city = "San Francisco",
+            address_state = "CA",
+            address_zip = "94107",
+          ),
+          merge_variables = MergeVariables(
+            name = "Harry",
+          ),
+          use_type = "marketing",
+          fsc = true
+        )
+
+        with ApiClient(configuration) as api_client:
+          api = SnapPacksApi(api_client)
+
+        try:
+          created_snap_pack = api.create(snap_pack_editable)
+        except ApiException as e:
+          print(e)
+      label: PYTHON
+    - lang: PHP
+      source: |
+        $to = new OpenAPI\Client\Model\AddressEditable(
+          array(
+            "name"     => "Harry Zhang",
+            "address_line1"     => "210 King St",
+            "address_line2"     => "# 6100",
+            "address_city"     => "San Francisco",
+            "address_state"     => "CA",
+            "address_zip"     => "94107",
+          )
+        );
+
+        $merge_variables = new stdClass;
+        $merge_variables->name = "Harry";
+
+        $use_type = "marketing";
+        $fsc = true;
+
+        $apiInstance = new OpenAPI\Client\Api\SnapPacksApi($config, new GuzzleHttp\Client());
+        $snap_pack_editable = new OpenAPI\Client\Model\SnapPackEditable(
+          array(
+            "description"     => "Demo Snap Pack job",
+            "from"     => "adr_210a8d4b0b76d77b",
+            "inside"     => "<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>",
+            "outside"     => "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>",
+            "to"     => $to,
+            "merge_variables"     => $merge_variables,
+            "use_type"    => $use_type,
+            "fsc"  => $fsc
+          )
+        );
+
+        try {
+            $result = $apiInstance->create($snap_pack_editable);
+        } catch (Exception $e) {
+            echo $e->getMessage(), PHP_EOL;
+        }
+    - lang: Java
+      source: |
+        Map<String, String> merge_variables = new HashMap<String, String>();
+        merge_variables.put("name", "Harry");
+
+        SnapPacksApi apiInstance = new SnapPacksApi(config);
+
+        AddressEditable to = new AddressEditable();
+        to.setName("Harry Zhang");
+        to.setAddressLine1("210 King St");
+        to.setAddressLine2("# 6100");
+        to.setAddressCity("San Francisco");
+        to.setAddressState("CA");
+        to.setAddressZip("94107");
+
+        try {
+          SnapPackEditable SnapPackEditable = new SnapPackEditable();
+          SnapPackEditable.setDescription("Demo Snap Pack job");
+          SnapPackEditable.setFrom("adr_210a8d4b0b76d77b");
+          SnapPackEditable.setInside("<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>");
+          SnapPackEditable.setOutside("<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>");
+          SnapPackEditable.setTo(to);
+          SnapPackEditable.setMergeVariables(merge_variables);
+          SnapPackEditable.setUseType("marketing");
+          SnapPackEditable.setFsc(true);
+
+
+          SnapPack result = apiInstance.create(SnapPackEditable, null);
+        } catch (ApiException e) {
+          e.printStackTrace();
+        }
+      label: JAVA
+    - lang: Elixir
+      source: |
+        Lob.SnapPack.create(%{
+          description: "Demo Snap Pack job",
+          to: %{
+            name: "Harry Zhang",
+            address_line1: "210 King St",
+            address_city: "San Francisco",
+            address_state: "CA",
+            address_zip: "94107"
+          },
+          from: "adr_210a8d4b0b76d77b",
+          inside: "<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>",
+          outside: "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>",
+          merge_variables: %{
+            name: "Harry"
+          },
+          use_type: "marketing",
+          fsc: true
+        })
+      label: ELIXIR
+    - lang: CSharp
+      source: |
+        Dictionary<string, string> mergeVariables = new Dictionary<string, string>();
+        mergeVariables.Add("name", "Harry");
+
+        SnapPacksApi api = new SnapPacksApi(config);
+
+        AddressEditable to = new AddressEditable(
+          "210 King St",  // addressLine1
+          "# 6100",  // addressLine2
+          "San Francisco",  // addressCity
+          "CA",  // addressState
+          "94107",  // addressZip
+          default(CountryExtended),  // addressCounty
+          null,  // description
+          "Harry Zhang" // name
+        );
+
+        Fsc fsc = new Fsc(true);
+
+        SnapPackEditable SnapPackEditable = new SnapPackEditable(
+          to.ToJson(),  // to
+          "adr_249af768103d2810",  // from
+          default(SnapPacksize),  // size
+          "Demo Snap Pack Job",  // description
+          default(Dictionary<string, string>),  // metadata
+          default(MailType),  // mailType
+          mergeVariables,  // mergeVariables
+          default(DateTime),  // sendDate
+          "<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>",  // inside
+          "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>", // outside
+          "marketing", // use_type
+          fsc
+        );
+
+        try {
+          SnapPack result = api.create(SnapPackEditable, null);
+        } catch (ApiException e) {
+          Console.WriteLine(e.ToString());
+        }
+      label: CSHARP
+    - lang: Go
+      source: |
+        var context = context.Background()
+        context = context.WithValue(suite.ctx, lob.ContextBasicAuth, lob.BasicAuth{UserName: os.Getenv("<YOUR_API_KEY>")})
+
+        var apiClient = *lob.NewAPIClient(configuration)
+
+        var to = *lob.NewAddressEditable()
+        to.SetAddressLine1("210 King St")
+        to.SetAddressLine2("# 6100")
+        to.SetAddressCity("San Francisco")
+        to.SetAddressState("CA")
+        to.SetAddressZip("94107")
+        to.SetAddressCountry(lob.COUNTRYEXTENDED_US)
+        to.SetDescription("")
+        to.SetName("Harry Zhang")
+
+        var SnapPackCreate = *lob.NewSnapPackEditable()
+        SnapPackCreate.SetDescription("Demo Snap Pack job")
+        SnapPackCreate.SetFrom("adr_210a8d4b0b76d77b")
+        SnapPackCreate.SetInside("<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>")
+        SnapPackCreate.SetOutside("<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>")
+        SnapPackCreate.SetTo(to)
+        SnapPackCreate.SetFsc(true)
+
+
+        createdSnapPack, _, err := apiClient.SnapPacksApi.Create(context).SnapPackEditable(SnapPackCreate).Execute()
+
+        if err != nil {
+            return err
+        }
+      label: GO

--- a/shared/attributes/campaign_id.yml
+++ b/shared/attributes/campaign_id.yml
@@ -1,5 +1,5 @@
 title: campaign_id
 description: Denotes resources created by the provided campaign id, prefixed with `cmp_`.
 type: string
-pattern: "^cmp_[a-zA-Z0-9]+$"
+pattern: "^(cmp|camp)_[a-zA-Z0-9]+$"
 nullable: true

--- a/shared/attributes/campaign_id.yml
+++ b/shared/attributes/campaign_id.yml
@@ -1,5 +1,5 @@
 title: campaign_id
-description: Denotes resources created by the provided campaign id, prefixed with `cmp_`.
+description: Denotes resources created by the provided campaign id, prefixed with `cmp_`. In the case of snap packs and letters with size `us_legal`, the campaign id is prefixed with `camp_` instead of `cmp_`.
 type: string
 pattern: "^(cmp|camp)_[a-zA-Z0-9]+$"
 nullable: true

--- a/shared/attributes/signed_link.yml
+++ b/shared/attributes/signed_link.yml
@@ -5,4 +5,4 @@ description: >-
   to prevent mis-sharing. Each time a GET request is initiated, a new signed URL
   will be generated.
 
-pattern: "^https://lob-assets.com/(letters|postcards|bank-accounts|checks|self-mailers|cards)/[a-z]{3,4}_[a-z0-9]{15,16}('|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+"
+pattern: "^https://lob-assets.com/(letters|postcards|bank-accounts|checks|self-mailers|cards|order-creatives)/([a-z]{3,4}_[a-z0-9]{15,16}|[a-z]{3}_[a-z0-9]{26}_[a-z]{4}_[a-z0-9]{26})('|_signature)(.pdf|_thumb_[a-z]+_[0-9]+.png|.png)?(version=[a-z0-9]*&)expires=[0-9]{10}&signature=[a-zA-Z0-9-_]+"

--- a/shared/models/qr_code.yml
+++ b/shared/models/qr_code.yml
@@ -1,5 +1,5 @@
 type: object
-description: Customize and place a QR code on the creative at the required position. Not available for `us_legal` letter size.
+description: Customize and place a QR code on the creative at the required position. Not available for `us_legal` letter size and snap packs.
 required:
   - position
   - redirect_url

--- a/shared/resources/tracking_events/models/tracking_event_normal.yml
+++ b/shared/resources/tracking_events/models/tracking_event_normal.yml
@@ -9,7 +9,7 @@ allOf:
 
     properties:
       type:
-        description: non-Certified postcards, self mailers, letters, and checks
+        description: non-Certified postcards, self mailers, letters, checks and snap packs
         type: string
         enum:
           - normal
@@ -26,7 +26,7 @@ allOf:
           - Returned to Sender
           - International Exit
         description: >
-          Name of tracking event (for normal postcards, self mailers, letters, and checks):
+          Name of tracking event (for normal postcards, self mailers, letters, checks and snap packs):
 
             * `Mailed` - The mailpiece has been handed off to and accepted by USPS
               and is en route. <a href="https://help.lob.com/print-and-mail/getting-data-and-results/tracking-your-mail#mailed-tracking-events-4" target="_blank">More about


### PR DESCRIPTION
Fixes #\<https://lobsters.atlassian.net/browse/CMB-435\>

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

- Adds snap packs to the public docs - CREATE only
- Updates the campaign id pattern prefix and the description
- Updates the signed link pattern to account for CMB urls (they are slightly different to lob-api signed links)
- Updates the description on qr codes and tracking events pertaining to snap packs

## Areas of Concern (optional)

I'd recommend the reviewers take a close look at the `docs/index.html` to take a closer look at how the docs render. Please call out any issues you notice (I've taken a few looks - because the change is big, there's a possibility that I may have missed a few things).
