### PR TITLE
RC-1145 - fix version discrepancy

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.33
+  version: 1.19.34
   description: >
     The Lob API is organized around REST. Our API is designed to have
     predictable, resource-oriented URLs and uses HTTP response codes to indicate

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.33
+  version: 1.19.34
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.33",
+  "version": "1.19.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.33",
+  "version": "1.19.34",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"


### PR DESCRIPTION

## Checklist

- [x] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect

## Changes

Aligns package version `1.19.34` with next release version `1.19.34`
