### PR TITLE
CMB-708: add pages property to booklet docs

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.36
+  version: 1.19.37
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.36",
+  "version": "1.19.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.36",
+  "version": "1.19.37",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/resources/booklets/attributes/booklet_pages.yml
+++ b/resources/booklets/attributes/booklet_pages.yml
@@ -1,0 +1,6 @@
+description: >-
+  Pages specifies the total number of pages in a booklet, where four pages make up one sheet.
+  Pages must always be in increments of four to maintain booklet integrity.
+  For a booklet with dimensions of 8.375x5.375 inches, we allow for 8, 12, 16, 20, 24, 28, or 32 pages.
+
+type: integer

--- a/resources/booklets/attributes/booklet_size.yml
+++ b/resources/booklets/attributes/booklet_size.yml
@@ -1,10 +1,9 @@
 type: string
 
 enum:
-  - 9x6
   - 8.375x5.375
 
 description: >
   Specifies the size of the booklet.
 
-default: 9x6
+default: 8.375x5.375

--- a/resources/booklets/booklets.yml
+++ b/resources/booklets/booklets.yml
@@ -94,7 +94,7 @@ post:
             right: "2"
             pages: "1-2,4-5"
           fsc: true
-          size: "9x6"
+          size: "8.375x5.375"
 
       application/x-www-form-urlencoded:
         schema:
@@ -136,7 +136,7 @@ post:
             right: "2"
             pages: "1-2,4-5"
           fsc: true
-          size: "9x6"
+          size: "8.375x5.375"
 
       multipart/form-data:
         schema:
@@ -178,7 +178,7 @@ post:
             right: "2"
             pages: "1-2,4-5"
           fsc: true
-          size: "9x6"
+          size: "8.375x5.375"
 
   responses:
     "200":

--- a/resources/booklets/models/booklet_editable.yml
+++ b/resources/booklets/models/booklet_editable.yml
@@ -11,6 +11,8 @@ allOf:
       - from
       - file
       - use_type
+      - pages
+      - size
 
     properties:
       file:
@@ -35,3 +37,6 @@ allOf:
 
       size:
         $ref: "../attributes/booklet_size.yml"
+
+      pages:
+        $ref: "../attributes/booklet_pages.yml"

--- a/resources/booklets/models/booklet_generated_base.yml
+++ b/resources/booklets/models/booklet_generated_base.yml
@@ -33,6 +33,12 @@ allOf:
       use_type:
         $ref: "../attributes/booklet_use_type.yml"
 
+      size:
+        $ref: "../attributes/booklet_size.yml"
+
+      pages:
+        $ref: "../attributes/booklet_pages.yml"
+
       fsc: # Forest Stewardship Council
         type: boolean
         description: This is in beta. Contact support@lob.com or your account contact to learn more.

--- a/resources/booklets/responses/all_booklets.yml
+++ b/resources/booklets/responses/all_booklets.yml
@@ -72,7 +72,8 @@ content:
               large: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg
           merge_variables:
             name: Harry
-          size: 9x6
+          size: 8.375x5.375
+          pages: 8
           expected_delivery_date: "2021-03-24"
           date_created: "2021-03-16T18:40:40.504Z"
           date_modified: "2021-03-16T18:40:40.504Z"
@@ -129,7 +130,8 @@ content:
               large: https://lob-assets.com/order-creatives/ord_851100000f31bb1a872f794cee_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg
           merge_variables:
             name: Harry
-          size: 9x6
+          size: 8.375x5.375
+          pages: 8
           expected_delivery_date: "2021-03-24"
           date_created: "2021-03-16T18:40:40.504Z"
           date_modified: "2021-03-16T18:40:40.504Z"

--- a/resources/booklets/responses/booklet.yml
+++ b/resources/booklets/responses/booklet.yml
@@ -52,7 +52,8 @@ application/json:
         large: https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg
     merge_variables:
       name: Harry
-    size: 9x6
+    size: 8.375x5.375
+    pages: 8
     expected_delivery_date: "2021-03-24"
     date_created: "2021-03-16T18:40:40.504Z"
     date_modified: "2021-03-16T18:40:40.504Z"


### PR DESCRIPTION
Fixes [CMB-708](https://lobsters.atlassian.net/browse/CMB-708)

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

- Adds the `pages` property to the booklet docs per the description in https://lobsters.atlassian.net/browse/CMB-708
- Removes / Disables the `9x6` size (thereby setting `8.375x5.375` as the default value) per https://lobsters.atlassian.net/browse/CMB-711
- Includes the `size` and `pages` property in the GET and LIST response schema which were missing earlier.


[CMB-708]: https://lobsters.atlassian.net/browse/CMB-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ