### PR TITLE
CMB-712: add source_material property

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.37
+  version: 1.19.38
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.37",
+  "version": "1.19.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.37",
+  "version": "1.19.38",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/resources/booklets/attributes/booklet_source_material.yml
+++ b/resources/booklets/attributes/booklet_source_material.yml
@@ -1,0 +1,11 @@
+type: string
+
+enum:
+  - 60# Gloss Text
+
+description: >-
+  Defines the material used to create the mail piece, specifically for booklets. 
+  This property is directly tied to the size of the booklet, ensuring that the appropriate material is selected based on the booklet's dimensions.
+  For booklets with `size` equal to `8.375x5.375` inches, the default source material is `60# Gloss Text`.
+
+default: 60# Gloss Text

--- a/resources/booklets/models/booklet_editable.yml
+++ b/resources/booklets/models/booklet_editable.yml
@@ -40,3 +40,6 @@ allOf:
 
       pages:
         $ref: "../attributes/booklet_pages.yml"
+
+      source_material:
+        $ref: "../attributes/booklet_source_material.yml"

--- a/resources/booklets/models/booklet_generated_base.yml
+++ b/resources/booklets/models/booklet_generated_base.yml
@@ -47,6 +47,9 @@ allOf:
       status:
         $ref: "../../../shared/attributes/status.yml"
 
+      source_material:
+        $ref: "../attributes/booklet_source_material.yml"
+
       failure_reason:
         allOf:
           - $ref: "../../../shared/models/failure_reason/failure_reason.yml"

--- a/resources/booklets/responses/all_booklets.yml
+++ b/resources/booklets/responses/all_booklets.yml
@@ -74,6 +74,7 @@ content:
             name: Harry
           size: 8.375x5.375
           pages: 8
+          source_material: 60# Gloss Text
           expected_delivery_date: "2021-03-24"
           date_created: "2021-03-16T18:40:40.504Z"
           date_modified: "2021-03-16T18:40:40.504Z"
@@ -132,6 +133,7 @@ content:
             name: Harry
           size: 8.375x5.375
           pages: 8
+          source_material: 60# Gloss Text
           expected_delivery_date: "2021-03-24"
           date_created: "2021-03-16T18:40:40.504Z"
           date_modified: "2021-03-16T18:40:40.504Z"

--- a/resources/booklets/responses/booklet.yml
+++ b/resources/booklets/responses/booklet.yml
@@ -54,6 +54,7 @@ application/json:
       name: Harry
     size: 8.375x5.375
     pages: 8
+    source_material: 60# Gloss Text
     expected_delivery_date: "2021-03-24"
     date_created: "2021-03-16T18:40:40.504Z"
     date_modified: "2021-03-16T18:40:40.504Z"


### PR DESCRIPTION
Fixes [CMB-712](https://lobsters.atlassian.net/browse/CMB-712)
## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

Adds the `source_material` property to booklets.

## Areas of Concern (optional)


[CMB-712]: https://lobsters.atlassian.net/browse/CMB-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ