### PR TITLE
CMB-683: update the text for Lob-Version header

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.38
+  version: 1.19.39
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.38",
+  "version": "1.19.39",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.38",
+  "version": "1.19.39",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/shared/parameters/lob_version.yml
+++ b/shared/parameters/lob_version.yml
@@ -6,8 +6,9 @@ lob-version:
   required: false
 
   description: >
-    A string representing the version of the API being used. For more information on versioning,
-    refer to our [Versioning and Changelog](#tag/Versioning-and-Changelog) documentation.
+    A string representing the version of the API being used. Specifically for letters, if this header is set to `2024-01-01` and above,
+    the `size` property is automatically included with the default value of `us_letter`. Refer to `size` for all possible values.
+    For more information on versioning, refer to our [Versioning and Changelog](#tag/Versioning-and-Changelog) documentation.
 
   schema:
     type: string


### PR DESCRIPTION
Fixes [CMB-683](https://lobsters.atlassian.net/browse/CMB-683)

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

Update the text around the `Lob-Version` header under letters create

## Areas of Concern (optional)


[CMB-683]: https://lobsters.atlassian.net/browse/CMB-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ