### PR TITLE
CMB-732: update file size limit for remote file urls

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.19.39
+  version: 1.19.40
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.39",
+  "version": "1.19.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.19.39",
+  "version": "1.19.40",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/shared/attributes/remote_file_url.yml
+++ b/shared/attributes/remote_file_url.yml
@@ -1,7 +1,7 @@
 type: string
 
 description: >
-  The location of a remote file. Remote URLs have a 20 MB file size limit and
+  The location of a remote file. Remote URLs have a 5 MB file size limit and
   must be downloaded within 40 seconds.
 
 pattern: "^https://[-a-zA-Z0-9@:%._+~#=/]{1,256}.(html?|pdf|png|jpg)$"


### PR DESCRIPTION
Fixes [CMB-732](https://lobsters.atlassian.net/browse/CMB-732)

Context: https://lob.slack.com/archives/C01T3E4DR4J/p1721430948993349

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

Update the file size limit to be 5MB when files are being uploaded via a `remote_file_url`. A global change which impacts all resource types.

![Screenshot 2024-07-24 at 2 12 04 PM](https://github.com/user-attachments/assets/1a05da48-fc3b-4ff5-8859-c468dbdb75a5)
![Screenshot 2024-07-24 at 2 12 30 PM](https://github.com/user-attachments/assets/d3b3be4d-6ae1-4db8-a2a3-bd168d2274ba)
<img width="1101" alt="Screenshot 2024-07-24 at 2 17 23 PM" src="https://github.com/user-attachments/assets/237c1bea-4545-42da-8061-e3f323ce6b2f">


[CMB-732]: https://lobsters.atlassian.net/browse/CMB-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ