### PR TITLE
#BGSTB-23: change check amount to 64 bit double instead of 32 bit float

### DIFF
--- a/resources/checks/models/check.yml
+++ b/resources/checks/models/check.yml
@@ -22,7 +22,7 @@ allOf:
       amount:
         description: The payment amount to be sent in US dollars.
         type: number
-        format: float
+        format: double
         multipleOf: 0.01
         maximum: 999999.99
 

--- a/resources/checks/models/check_editable_props.yml
+++ b/resources/checks/models/check_editable_props.yml
@@ -32,7 +32,7 @@ allOf:
           The payment amount to be sent in US dollars. Amounts will be rounded
           to two decimal places.
         type: number
-        format: float
+        format: double
         maximum: 999999.99
 
       logo:


### PR DESCRIPTION
https://lobsters.atlassian.net/browse/BGSTB-23

- relevant thread: https://lob.slack.com/archives/C089US1RCSF/p1739900672985209
- need to change check amount to 64 bit double instead of 32 bit float to improve accuracy of sdk