### PR TITLE
BGSND-92: remove beamer link from changelog

### DIFF
--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.20.5
+  version: 1.20.6
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:
@@ -1033,7 +1033,7 @@ tags:
   - name: Introduction
     x-traitTag: true
     description: |
-      Lob’s Print & Mail and Address Verification APIs help companies transform outdated,
+      Lob's Print & Mail and Address Verification APIs help companies transform outdated,
       manual print-and-mail processes; save 1,000s of hours in processing time by sending mail much more
       quickly; and increase ROI on offline communications.
 
@@ -2314,7 +2314,7 @@ tags:
 
 
       ### Changelog
-       <a href="https://app.getbeamer.com/lob/en?all" target="_blank">View our Changelog here.</a>
+       We are in the process of renovating our changelog, and will link it here shortly.
   - name: Webhooks
     x-traitTag: true
     description: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.5",
+  "version": "1.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/openapi",
-      "version": "1.20.5",
+      "version": "1.20.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.5",
+  "version": "1.20.6",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"


### PR DESCRIPTION
### Description

Remove's the beamer link from changelog. 

_We've deprecated our account with Beamer now that we have redundant tooling with Pendo so the link doesn't work anymore. Product is going to migrate our old changelog into Pendo this month. In the meantime, we'd like to add messaging to say "We are in the process of renovating our changelog, and will link it here shortly"._

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [ ] Delete all resources created in tests
- [x] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Areas of Concern (optional)
