### PR TITLE
#SUP-935(feat): add print_speed to docs

### DIFF
--- a/cypress/e2e/links_test.cy.js
+++ b/cypress/e2e/links_test.cy.js
@@ -145,8 +145,13 @@ describe("ensures introduction links and text are valid", () => {
   });
 
   it("contains the right intro text", () => {
+    // Check for key parts of the intro text instead of the exact string
+    // The text is rendered with line breaks in the HTML, so we check for segments
+    cy.contains("Lob's Print & Mail and Address Verification APIs");
     cy.contains(
-      "Lob’s Print & Mail and Address Verification APIs help companies transform outdated, manual print-and-mail processes; save 1,000s of hours in processing time by sending mail much more quickly; and increase ROI on offline communications."
+      "help companies transform outdated, manual print-and-mail processes"
     );
+    cy.contains("save 1,000s of hours in processing time");
+    cy.contains("increase ROI on offline communications");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11518,6 +11518,15 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/redoc-cli/node_modules/@types/node": {
       "version": "15.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",

--- a/resources/booklets/booklets.yml
+++ b/resources/booklets/booklets.yml
@@ -95,6 +95,7 @@ post:
             pages: "1-2,4-5"
           fsc: true
           size: "8.375x5.375"
+          print_speed: core
 
       application/x-www-form-urlencoded:
         schema:
@@ -137,6 +138,7 @@ post:
             pages: "1-2,4-5"
           fsc: true
           size: "8.375x5.375"
+          print_speed: core
 
       multipart/form-data:
         schema:
@@ -179,6 +181,7 @@ post:
             pages: "1-2,4-5"
           fsc: true
           size: "8.375x5.375"
+          print_speed: core
 
   responses:
     "200":
@@ -208,7 +211,8 @@ post:
           -d 'qr_code[bottom]=2' \
           -d 'qr_code[left]=2' \
           -d 'qr_code[pages]=3,4-5' \
-          -d 'fsc=true'
+          -d 'fsc=true' \
+          -d 'print_speed=core'
       label: CURL
   #   - lang: Typescript
   #     source: |

--- a/resources/booklets/models/booklet_editable.yml
+++ b/resources/booklets/models/booklet_editable.yml
@@ -43,3 +43,6 @@ allOf:
 
       source_material:
         $ref: "../attributes/booklet_source_material.yml"
+
+      print_speed:
+        $ref: "../../../shared/attributes/print_speed.yml"

--- a/resources/booklets/responses/booklet.yml
+++ b/resources/booklets/responses/booklet.yml
@@ -61,4 +61,5 @@ application/json:
     send_date: "2021-03-16T18:45:40.493Z"
     use_type: marketing
     fsc: false
+    sla: "2"
     object: booklet

--- a/resources/campaigns/campaigns.yml
+++ b/resources/campaigns/campaigns.yml
@@ -61,6 +61,7 @@ post:
           name: My Demo Campaign
           description: My Campaign's description
           schedule_type: immediate
+          print_speed: core
 
       application/x-www-form-urlencoded:
         schema:
@@ -73,6 +74,7 @@ post:
           name: My Demo Campaign
           description: My Campaign's description
           schedule_type: immediate
+          print_speed: core
 
       multipart/form-data:
         schema:
@@ -81,6 +83,7 @@ post:
           name: My Demo Campaign
           description: My Campaign's description
           schedule_type: immediate
+          print_speed: core
 
   responses:
     "200":
@@ -97,13 +100,15 @@ post:
         curl https://api.lob.com/v1/campaigns \
           -u <YOUR API KEY>: \
           -d "name=My First Campaign" \
-          -d "schedule_type=immediate"
+          -d "schedule_type=immediate" \
+          -d "print_speed=core"
       label: CURL
     - lang: Ruby
       source: |
         campaignCreate = CampaignWritable.new({
           name: "My First Campaign",
           schedule_type: "immediate",
+          print_speed: "core",
         });
 
         campaignApi = CampaignsApi.new(config)

--- a/resources/campaigns/models/campaign_writable.yml
+++ b/resources/campaigns/models/campaign_writable.yml
@@ -39,3 +39,5 @@ properties:
   auto_cancel_if_ncoa:
     description: Whether or not a mail piece should be automatically canceled and not sent if the address is updated via NCOA.
     type: boolean
+  print_speed:
+    $ref: "../../../shared/attributes/print_speed.yml"

--- a/resources/checks/checks.yml
+++ b/resources/checks/checks.yml
@@ -205,6 +205,7 @@ post:
           use_type: operational
           mail_type: usps_first_class
           check_number: 10001
+          print_speed: core
 
       application/x-www-form-urlencoded:
         schema:
@@ -243,6 +244,7 @@ post:
           send_date: "2017-11-01T00:00:00.000Z"
           mail_type: usps_first_class
           check_number: 10001
+          print_speed: core
         encoding:
           to:
             style: deepObject
@@ -295,6 +297,7 @@ post:
           use_type: operational
           mail_type: usps_first_class
           check_number: 10001
+          print_speed: core
         encoding:
           logo:
             contentType: image/png, image/jpeg
@@ -325,7 +328,8 @@ post:
           -d 'memo=rent' \
           --data-urlencode 'logo=https://s3-us-west-2.amazonaws.com/public.lob.com/assets/check_logo.png' \
           --data-urlencode 'check_bottom=<h1 style="padding-top:4in;">Demo Check for {{name}}</h1>' \
-          -d 'merge_variables[name]=Harry'
+          -d 'merge_variables[name]=Harry' \
+          -d 'print_speed=core'
       label: CURL
     - lang: Typescript
       source: |
@@ -341,7 +345,8 @@ post:
         from: 'adr_xxxx',
         bank_account: 'bank_xxxx',
         amount: 100,
-        use_type: 'operational'
+        use_type: 'operational',
+        print_speed: 'core'
         });
 
         try {
@@ -371,7 +376,8 @@ post:
           check_bottom: '<h1 style="padding-top:4in;">Demo Check for {{name}}</h1>',
           merge_variables: {
             name: 'Harry'
-          }
+          },
+          print_speed: 'core'
         }, function (err, res) {
           console.log(err, res);
         });
@@ -397,7 +403,8 @@ post:
           merge_variables: {
             name: "Harry"
           },
-          use_type: "operational"
+          use_type: "operational",
+          print_speed: "core"
         });
 
         checkApi = ChecksApi.new(config)
@@ -429,7 +436,8 @@ post:
           merge_variables = MergeVariables(
             name = "Harry",
           ),
-          use_type = "operational"
+          use_type = "operational",
+          print_speed = "core"
         )
 
         with ApiClient(configuration) as api_client:
@@ -470,7 +478,8 @@ post:
             "from"     => "adr_210a8d4b0b76d77b",
             "to"     => $to,
             "merge_variables"     => $merge_variables,
-            "use_type" => $use_type
+            "use_type" => $use_type,
+            "print_speed" => "core"
           )
         );
 
@@ -506,6 +515,7 @@ post:
           checkEditable.setTo(to);
           checkEditable.setMergeVariables(merge_variables);
           checkEditable.setUseType("operational");
+          checkEditable.setPrintSpeed("core");
 
           Check result = apiInstance.create(checkEditable, null);
         } catch (ApiException e) {
@@ -533,7 +543,8 @@ post:
           merge_variables: %{
             name: 'Harry'
           },
-          use_type: 'operational'
+          use_type: 'operational',
+          print_speed: 'core'
         })
       label: ELIXIR
     - lang: CSharp
@@ -568,7 +579,8 @@ post:
           default(DateTime),  // sendDate
           CheckEditable.MailTypeEnum.UspsFirstClass,  // mailType
           "rent", // memo
-          "operational" // use_type
+          "operational", // use_type
+          "core" // print_speed
         );
 
         try {
@@ -603,6 +615,7 @@ post:
         checkCreate.SetCheckBottom("<h1 style='padding-top:4in;'>Demo Check for {{name}}</h1>")
         checkCreate.SetFrom("adr_210a8d4b0b76d77b")
         checkCreate.SetTo(to)
+        checkCreate.SetPrintSpeed("core")
 
 
         createdcheck, _, err := apiClient.ChecksApi.Create(context).CheckEditable(checkCreate).Execute()

--- a/resources/checks/models/check_editable_props.yml
+++ b/resources/checks/models/check_editable_props.yml
@@ -97,3 +97,6 @@ allOf:
 
       use_type:
         $ref: "../attributes/chk_use_type.yml"
+
+      print_speed:
+        $ref: "../../../shared/attributes/print_speed.yml"

--- a/resources/checks/responses/check.yml
+++ b/resources/checks/responses/check.yml
@@ -74,4 +74,5 @@ application/json:
     check_bottom_template_version_id: vrsn_a
     attachment_template_version_id: vrsn_a
     use_type: operational
+    sla: "2"
     deleted: true

--- a/resources/letters/letters.yml
+++ b/resources/letters/letters.yml
@@ -226,6 +226,7 @@ post:
             right: "2"
             pages: "1-2,4-5"
           fsc: true
+          print_speed: core
 
       application/x-www-form-urlencoded:
         schema:
@@ -276,6 +277,7 @@ post:
             right: "2"
             pages: "1,4"
           fsc: true
+          print_speed: core
         encoding:
           to:
             style: deepObject
@@ -338,7 +340,8 @@ post:
             bottom: "2"
             left: "2"
             pages: "1,3-5"
-          fsc: true
+          fsc: true,
+          print_speed: core
 
   responses:
     "200":
@@ -370,7 +373,8 @@ post:
           -d 'qr_code[bottom]=2' \
           -d 'qr_code[left]=2' \
           -d 'qr_code[pages]=3,4-5' \
-          -d 'fsc=true'
+          -d 'fsc=true' \
+          -d 'print_speed=core'
       label: CURL
     - lang: Typescript
       source: |
@@ -396,7 +400,8 @@ post:
             left: '2',
             pages: '2,5'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         });
 
         try {
@@ -433,7 +438,8 @@ post:
             left: '2',
             pages: '2,4-5'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         }, function (err, res) {
           console.log(err, res);
         });
@@ -460,7 +466,8 @@ post:
             "card_c51ae96f5cebf3e",
           ],
           use_type: "marketing",
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         });
 
         letterApi = LettersApi.new(config)
@@ -501,7 +508,8 @@ post:
             "left" : "2",
             "pages" : "1,3"
           },
-          fsc = true
+          fsc = true,
+          print_speed = 'core'
         )
 
         with ApiClient(configuration) as api_client:
@@ -541,6 +549,7 @@ post:
 
         $use_type = "marketing";
         $fsc = true;
+        $print_speed = 'core';
 
         $apiInstance = new OpenAPI\Client\Api\LettersApi($config, new GuzzleHttp\Client());
         $letter_editable = new OpenAPI\Client\Model\LetterEditable(
@@ -558,6 +567,7 @@ post:
             "use_type" => $use_type;
             "qr_code"   => $qr_code,
             "fsc" => $fsc,
+            "print_speed" => $print_speed,
           )
         );
 
@@ -605,6 +615,7 @@ post:
           letterEditable.setUseType("operational");
           letterEditable.setQRCode(qrCode);
           letterEditable.setFsc(true);
+          letterEditable.setPrintSpeed("core");
 
           Letter result = apiInstance.create(letterEditable, null);
         } catch (ApiException e) {
@@ -639,7 +650,8 @@ post:
             left: '2',
             pages: '1-2,5'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         })
       label: ELIXIR
     - lang: CSharp
@@ -672,6 +684,7 @@ post:
         );
 
         Fsc fsc = new Fsc(true);
+        PrintSpeed printSpeed = new PrintSpeed("core");
 
         List<String> cards = new List<String>();
         cards.Add("card_c51ae96f5cebf3e");
@@ -695,7 +708,8 @@ post:
           cards, // cards
           usetype,
           qrCode,
-          fsc
+          fsc,
+          printSpeed
         );
 
         try {
@@ -728,7 +742,7 @@ post:
         letterCreate.SetColor("true")
         letterCreate.SetTo(to)
         letterCreate.SetFsc(true)
-
+        letterCreate.SetPrintSpeed("core")
 
         createdletter, _, err := apiClient.LettersApi.Create(context).LetterEditable(letterCreate).Execute()
 

--- a/resources/letters/models/letter_editable.yml
+++ b/resources/letters/models/letter_editable.yml
@@ -74,3 +74,6 @@ allOf:
 
       size:
         $ref: "../attributes/ltr_size.yml"
+
+      print_speed:
+        $ref: "../../../shared/attributes/print_speed.yml"

--- a/resources/letters/responses/letter.yml
+++ b/resources/letters/responses/letter.yml
@@ -93,4 +93,5 @@ application/json:
         object: "card"
     use_type: marketing
     fsc: false
+    sla: "2"
     object: letter

--- a/resources/postcards/models/postcard_editable.yml
+++ b/resources/postcards/models/postcard_editable.yml
@@ -31,3 +31,6 @@ allOf:
         type: boolean
         description: This is in beta. Contact support@lob.com or your account contact to learn more. Not available for `4x6` or `A5` postcard sizes.
         default: false
+
+      print_speed:
+        $ref: "../../../shared/attributes/print_speed.yml"

--- a/resources/postcards/postcards.yml
+++ b/resources/postcards/postcards.yml
@@ -227,6 +227,7 @@ post:
             right: "2.5"
             pages: "front,back"
           fsc: true
+          print_speed: core
 
       application/x-www-form-urlencoded:
         schema:
@@ -275,6 +276,7 @@ post:
             right: "2.5"
             pages: "back"
           fsc: true
+          print_speed: core
         encoding:
           to:
             style: deepObject
@@ -336,6 +338,7 @@ post:
             left: "2.5"
             pages: "front"
           fsc: true
+          print_speed: core
 
   responses:
     "200":
@@ -367,7 +370,8 @@ post:
           -d 'qr_code[bottom]=2.5' \
           -d 'qr_code[left]=2.5' \
           -d 'qr_code[pages]=front,back' \
-          -d 'fsc=true'
+          -d 'fsc=true' \
+          -d 'print_speed=core'
       label: CURL
     - lang: Typescript
       source: |
@@ -393,7 +397,8 @@ post:
           left: '2.5',
           pages: 'front'
         },
-        fsc: true
+        fsc: true,
+        print_speed: 'core'
         });
 
         try {
@@ -429,7 +434,8 @@ post:
             left: '2.5',
             pages: 'back'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         }, function (err, res) {
           console.log(err, res);
         });
@@ -452,7 +458,8 @@ post:
           merge_variables: {
             name: "Harry"
           },
-          fsc: true
+          fsc: true,
+          print_speed: "core"
         });
 
         postcardApi = PostcardsApi.new(config)
@@ -490,7 +497,8 @@ post:
             "left" : "2.5",
             "pages" : "front"
           },
-          fsc = true
+          fsc = true,
+          print_speed = "core"
         )
 
         with ApiClient(configuration) as api_client:
@@ -530,6 +538,7 @@ post:
         );
 
         $fsc = true;
+        $print_speed = 'core';
 
         $apiInstance = new OpenAPI\Client\Api\PostcardsApi($config, new GuzzleHttp\Client());
         $postcard_editable = new OpenAPI\Client\Model\PostcardEditable(
@@ -542,7 +551,8 @@ post:
             "merge_variables"   => $merge_variables,
             "use_type" => $use_type,
             "qr_code"   => $qr_code,
-            "fsc" => $fsc
+            "fsc" => $fsc,
+            "print_speed" => "core"
           )
         );
 
@@ -585,6 +595,7 @@ post:
           postcardEditable.setUseType("operational");
           postcardEditable.setQRCode(qrCode);
           postcardEditable.setFsc(true);
+          postcardEditable.setPrintSpeed("core");
 
           Postcard result = apiInstance.create(postcardEditable, null);
         } catch (ApiException e) {
@@ -618,7 +629,8 @@ post:
             left: '2',
             pages: 'front,back'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         })
       label: ELIXIR
     - lang: CSharp
@@ -651,6 +663,7 @@ post:
         );
 
         Fsc fsc = new Fsc(true);
+        PrintSpeed printSpeed = new PrintSpeed("core");
 
         PostcardEditable postcardEditable = new PostcardEditable(
           to.ToJson(),  // to
@@ -665,7 +678,8 @@ post:
           "<html style='padding: 1in; font-size: 20;'>Back HTML for {{name}}</html>", // back
           usetype,
           qrCode,
-          fsc
+          fsc,
+          "core"  // printSpeed
         );
 
         try {
@@ -698,6 +712,7 @@ post:
         postcardCreate.SetBack("<html style='padding: 1in; font-size: 20;'>Back HTML for {{name}}</html>")
         postcardCreate.SetTo(to)
         postcardCreate.SetFsc(true)
+        postcardCreate.SetPrintSpeed("core")
 
 
         createdpostcard, _, err := apiClient.PostcardsApi.Create(context).PostcardEditable(postcardCreate).Execute()

--- a/resources/postcards/responses/postcard.yml
+++ b/resources/postcards/responses/postcard.yml
@@ -34,6 +34,7 @@ application/json:
         send_date: "2021-03-24T22:51:42.838Z"
         use_type: marketing
         fsc: false
+        sla: "2"
         object: "postcard"
     full:
       value:
@@ -95,4 +96,6 @@ application/json:
         send_date: "2021-03-24T22:51:42.838Z"
         use_type: marketing
         fsc: false
+        print_speed: core
+        sla: "2"
         object: "postcard"

--- a/resources/self_mailers/models/self_mailer_editable.yml
+++ b/resources/self_mailers/models/self_mailer_editable.yml
@@ -71,3 +71,6 @@ allOf:
         type: boolean
         description: This is in beta. Contact support@lob.com or your account contact to learn more. Not available for `11x9_bifold` self-mailer size.
         default: false
+
+      print_speed:
+        $ref: "../../../shared/attributes/print_speed.yml"

--- a/resources/self_mailers/responses/self_mailer.yml
+++ b/resources/self_mailers/responses/self_mailer.yml
@@ -65,4 +65,5 @@ application/json:
     send_date: "2021-03-16T18:45:40.493Z"
     use_type: marketing
     fsc: false
+    sla: "2"
     object: self_mailer

--- a/resources/self_mailers/self_mailers.yml
+++ b/resources/self_mailers/self_mailers.yml
@@ -203,6 +203,7 @@ post:
             right: "2.5"
             pages: "inside,outside"
           fsc: true
+          print_speed: core
 
       application/x-www-form-urlencoded:
         schema:
@@ -229,6 +230,7 @@ post:
             right: "2.5"
             pages: "inside,outside"
           fsc: true
+          print_speed: core
         encoding:
           merge_variables:
             style: deepObject
@@ -262,6 +264,7 @@ post:
             right: "2.5"
             pages: "inside,outside"
           fsc: true
+          print_speed: core
 
   responses:
     "200":
@@ -292,7 +295,8 @@ post:
           --data-urlencode "inside=<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>" \
           --data-urlencode "outside=<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>" \
           -d "merge_variables[name]=Harry" \
-          -d 'fsc=true'
+          -d 'fsc=true' \
+          -d 'print_speed=core'
       label: CURL
     - lang: Typescript
       source: |
@@ -319,7 +323,8 @@ post:
             left: '2.5',
             pages: 'inside'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         });
 
         try {
@@ -354,7 +359,8 @@ post:
             left: '2.5',
             pages: 'inside'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         }, function (err, res) {
           console.log(err, res);
         });
@@ -386,7 +392,8 @@ post:
             left: '2.5',
             pages: 'inside'
           },
-          fsc: true
+          fsc: true,
+          print_speed: "core"
         });
 
         selfMailerApi = SelfMailersApi.new(config)
@@ -424,7 +431,8 @@ post:
             left: "2.5",
             pages: "inside"
           },
-          fsc = true
+          fsc = true,
+          print_speed = "core"
         )
 
         with ApiClient(configuration) as api_client:
@@ -453,6 +461,7 @@ post:
 
         $use_type = "marketing";
         $fsc = true;
+        $print_speed = 'core';
 
         $qr_code = new OpenAPI\Client\Model\QRCode(
           array(
@@ -476,7 +485,8 @@ post:
             "merge_variables"     => $merge_variables,
             "use_type"    => $use_type,
             "qr_code"   => $qr_code,
-            "fsc"  => $fsc
+            "fsc"  => $fsc,
+            "print_speed" => "core"
           )
         );
 
@@ -519,6 +529,7 @@ post:
           selfMailerEditable.setUseType("marketing");
           selfMailerEditable.setQRCode(qrCode);
           selfMailerEditable.setFsc(true);
+          selfMailerEditable.setPrintSpeed("core");
 
 
           SelfMailer result = apiInstance.create(selfMailerEditable, null);
@@ -552,7 +563,8 @@ post:
             left: '2',
             pages: 'inside,outside'
           },
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         })
       label: ELIXIR
     - lang: CSharp
@@ -583,6 +595,7 @@ post:
         );
 
         Fsc fsc = new Fsc(true);
+        PrintSpeed printSpeed = new PrintSpeed("core");
 
         SelfMailerEditable selfMailerEditable = new SelfMailerEditable(
           to.ToJson(),  // to
@@ -597,7 +610,8 @@ post:
           "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>", // outside
           "marketing", // use_type 
           qrCode,
-          fsc
+          fsc,
+          "core" // print_speed
         );
 
         try {
@@ -630,6 +644,7 @@ post:
         selfMailerCreate.SetOutside("<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>")
         selfMailerCreate.SetTo(to)
         selfMailerCreate.SetFsc(true)
+        selfMailerCreate.SetPrintSpeed("core")
 
 
         createdselfMailer, _, err := apiClient.SelfMailersApi.Create(context).SelfMailerEditable(selfMailerCreate).Execute()

--- a/resources/snap_packs/models/snap_pack_editable.yml
+++ b/resources/snap_packs/models/snap_pack_editable.yml
@@ -72,4 +72,3 @@ allOf:
 
       print_speed:
         $ref: "../../../shared/attributes/print_speed.yml"
-

--- a/resources/snap_packs/models/snap_pack_editable.yml
+++ b/resources/snap_packs/models/snap_pack_editable.yml
@@ -69,3 +69,7 @@ allOf:
 
       qr_code:
         $ref: "../../../shared/models/qr_code.yml"
+
+      print_speed:
+        $ref: "../../../shared/attributes/print_speed.yml"
+

--- a/resources/snap_packs/responses/snap_pack.yml
+++ b/resources/snap_packs/responses/snap_pack.yml
@@ -65,4 +65,5 @@ application/json:
     use_type: marketing
     fsc: false
     color: false
+    sla: "2"
     object: snap_pack

--- a/resources/snap_packs/snap_packs.yml
+++ b/resources/snap_packs/snap_packs.yml
@@ -186,6 +186,7 @@ post:
             name: Harry
           send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
+          print_speed: core
 
       multipart/form-data:
         schema:
@@ -204,6 +205,7 @@ post:
             name: Harry
           send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
+          print_speed: core
 
   responses:
     "200":
@@ -228,7 +230,8 @@ post:
           --data-urlencode "inside=<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>" \
           --data-urlencode "outside=<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>" \
           -d "merge_variables[name]=Harry" \
-          -d 'fsc=false'
+          -d 'fsc=false' \
+          -d 'print_speed=core'
       label: CURL
     - lang: Typescript
       source: |
@@ -247,7 +250,8 @@ post:
           outside:
           'https://s3.us-west-2.amazonaws.com/public.lob.com/assets/8.5x11_Snappack_template_address.pdf',
           use_type: 'marketing'
-          fsc: false
+          fsc: false,
+          print_speed: 'core'
         });
 
         try {
@@ -274,7 +278,8 @@ post:
             name: 'Harry'
           },
           use_type: 'marketing'
-          fsc: false
+          fsc: false,
+          print_speed: 'core'
         }, function (err, res) {
           console.log(err, res);
         });
@@ -298,7 +303,8 @@ post:
             name: "Harry"
           },
           use_type: 'marketing',
-          fsc: true
+          fsc: true,
+          print_speed: "core"
         });
 
         snapPackApi = SnapPacksApi.new(config)
@@ -328,7 +334,8 @@ post:
             name = "Harry",
           ),
           use_type = "marketing",
-          fsc = true
+          fsc = true,
+          print_speed = "core"
         )
 
         with ApiClient(configuration) as api_client:
@@ -357,6 +364,7 @@ post:
 
         $use_type = "marketing";
         $fsc = true;
+        $print_speed = 'core';
 
         $apiInstance = new OpenAPI\Client\Api\SnapPacksApi($config, new GuzzleHttp\Client());
         $snap_pack_editable = new OpenAPI\Client\Model\SnapPackEditable(
@@ -368,7 +376,8 @@ post:
             "to"     => $to,
             "merge_variables"     => $merge_variables,
             "use_type"    => $use_type,
-            "fsc"  => $fsc
+            "fsc"  => $fsc,
+            "print_speed" => "core"
           )
         );
 
@@ -402,6 +411,7 @@ post:
           SnapPackEditable.setMergeVariables(merge_variables);
           SnapPackEditable.setUseType("marketing");
           SnapPackEditable.setFsc(true);
+          SnapPackEditable.setPrintSpeed("core");
 
 
           SnapPack result = apiInstance.create(SnapPackEditable, null);
@@ -427,7 +437,8 @@ post:
             name: "Harry"
           },
           use_type: "marketing",
-          fsc: true
+          fsc: true,
+          print_speed: 'core'
         })
       label: ELIXIR
     - lang: CSharp
@@ -449,6 +460,7 @@ post:
         );
 
         Fsc fsc = new Fsc(true);
+        PrintSpeed printSpeed = new PrintSpeed("core");
 
         SnapPackEditable SnapPackEditable = new SnapPackEditable(
           to.ToJson(),  // to
@@ -462,7 +474,8 @@ post:
           "<html style='padding: 1in; font-size: 50;'>Inside HTML for {{name}}</html>",  // inside
           "<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>", // outside
           "marketing", // use_type
-          fsc
+          fsc,
+          "core" // print_speed
         );
 
         try {
@@ -495,6 +508,7 @@ post:
         SnapPackCreate.SetOutside("<html style='padding: 1in; font-size: 20;'>Outside HTML for {{name}}</html>")
         SnapPackCreate.SetTo(to)
         SnapPackCreate.SetFsc(true)
+        SnapPackCreate.SetPrintSpeed("core")
 
 
         createdSnapPack, _, err := apiClient.SnapPacksApi.Create(context).SnapPackEditable(SnapPackCreate).Execute()

--- a/shared/attributes/print_speed.yml
+++ b/shared/attributes/print_speed.yml
@@ -1,0 +1,15 @@
+type: string
+
+enum:
+  - core
+  - rapid
+
+description: |
+  A string designating the mail speed type:
+  * `core` - 2 production business days
+  * `rapid` - 1 production business day
+
+  **Note:** This field is feature-flagged. It is only available to customers who have been approved for the feature.
+
+default: core
+nullable: true

--- a/shared/models/form_factor/editable.yml
+++ b/shared/models/form_factor/editable.yml
@@ -18,4 +18,3 @@ properties:
 
   print_speed:
     $ref: "../../attributes/print_speed.yml"
-

--- a/shared/models/form_factor/editable.yml
+++ b/shared/models/form_factor/editable.yml
@@ -15,3 +15,7 @@ properties:
 
   send_date:
     $ref: "../../attributes/send_date.yml"
+
+  print_speed:
+    $ref: "../../attributes/print_speed.yml"
+


### PR DESCRIPTION
https://lobsters.atlassian.net/browse/SUP-935

This PR adds `print_speed` to Lob docs. It is feature flagged as mentioned in the documentation. 

<img width="1347" height="466" alt="image" src="https://github.com/user-attachments/assets/ab81201c-ebd1-4f8f-b172-2f50ece7a283" />



## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

## Areas of Concern (optional)
