### PR TITLE
#SUP-1202(chore) - hide rapid print speed from public documentation

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.20.7
+  version: 1.20.8
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:
@@ -17127,13 +17127,9 @@ components:
       type: string
       enum:
         - core
-        - rapid
       description: |
         A string designating the mail speed type:
         * `core` - 2 production business days
-        * `rapid` - 1 production business day
-
-        **Note:** This field is feature-flagged. It is only available to customers who have been approved for the feature.
       default: core
       nullable: true
     editable:

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.20.7
+  version: 1.20.8
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.7",
+  "version": "1.20.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/openapi",
-      "version": "1.20.7",
+      "version": "1.20.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.7",
+  "version": "1.20.8",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/shared/attributes/print_speed.yml
+++ b/shared/attributes/print_speed.yml
@@ -2,14 +2,10 @@ type: string
 
 enum:
   - core
-  - rapid
 
 description: |
   A string designating the mail speed type:
   * `core` - 2 production business days
-  * `rapid` - 1 production business day
-
-  **Note:** This field is feature-flagged. It is only available to customers who have been approved for the feature.
 
 default: core
 nullable: true


### PR DESCRIPTION
- Remove 'rapid' option from print_speed enum in shared/attributes/print_speed.yml
- Bump version to 1.20.8
- Update bundled spec and generated documentation

This temporarily hides the rapid print speed feature from public API docs while keeping all code intact for the closed beta program.

Slack Thread - https://lob.slack.com/archives/C08MEQXDCH3/p1757102103651009

## Checklist

- [ ] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [ ] Prettier
- [ ] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

## Areas of Concern (optional)
