### PR TITLE
[BGSTB-505] Add informed delivery events

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -564,6 +564,21 @@ tags:
           <td style="white-space: nowrap"><code>false</code></td>
           <td style="white-space: nowrap">A postcard QR code or URL was scanned or viewed by the recipient. </td>
         </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>postcard.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>postcard.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>postcard.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
+        </tr>
       </table>
 
       <h3>Self Mailers</h3>
@@ -649,6 +664,21 @@ tags:
           <td style="white-space: nowrap"><code>self_mailer.viewed</code></td>
           <td style="white-space: nowrap"><code>false</code></td>
           <td style="white-space: nowrap">A self_mailer's QR code or URL was scanned or viewed by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>self_mailer.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>self_mailer.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>self_mailer.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
         </tr>
       </table>
 
@@ -812,6 +842,21 @@ tags:
           <td style="white-space: nowrap"><code>true</code></td>
           <td style="white-space: nowrap">A return envelope receives a "Returned to Sender" <a href='#operation/tracking_event'>tracking event</a>.</td>
         </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>letter.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>letter.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>letter.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
+        </tr>
       </table>
 
       <h3>Checks</h3>
@@ -886,6 +931,21 @@ tags:
           <td style="white-space: nowrap"><code>check.returned_to_sender</code></td>
           <td style="white-space: nowrap"><code>true</code></td>
           <td style="white-space: nowrap">A check receives a "Returned to Sender" <a href='#operation/tracking_event'>tracking event</a>.</td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>check.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>check.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>check.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
         </tr>
       </table>
 

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.20.8
+  version: 1.20.9
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:
@@ -562,6 +562,21 @@ tags:
           <td style="white-space: nowrap"><code>false</code></td>
           <td style="white-space: nowrap">A postcard QR code or URL was scanned or viewed by the recipient. </td>
         </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>postcard.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>postcard.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>postcard.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
+        </tr>
       </table>
 
       <h3>Self Mailers</h3>
@@ -647,6 +662,21 @@ tags:
           <td style="white-space: nowrap"><code>self_mailer.viewed</code></td>
           <td style="white-space: nowrap"><code>false</code></td>
           <td style="white-space: nowrap">A self_mailer's QR code or URL was scanned or viewed by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>self_mailer.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>self_mailer.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>self_mailer.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
         </tr>
       </table>
 
@@ -810,6 +840,21 @@ tags:
           <td style="white-space: nowrap"><code>true</code></td>
           <td style="white-space: nowrap">A return envelope receives a "Returned to Sender" <a href='#operation/tracking_event'>tracking event</a>.</td>
         </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>letter.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>letter.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>letter.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
+        </tr>
       </table>
 
       <h3>Checks</h3>
@@ -884,6 +929,21 @@ tags:
           <td style="white-space: nowrap"><code>check.returned_to_sender</code></td>
           <td style="white-space: nowrap"><code>true</code></td>
           <td style="white-space: nowrap">A check receives a "Returned to Sender" <a href='#operation/tracking_event'>tracking event</a>.</td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>check.informed_delivery.email_sent</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was sent to the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>check.informed_delivery.email_opened</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">An informed delivery email was opened by the recipient. </td>
+        </tr>
+        <tr>
+          <td style="white-space: nowrap"><code>check.informed_delivery.email_clicked_through</code></td>
+          <td style="white-space: nowrap"><code>true</code></td>
+          <td style="white-space: nowrap">The link in an informed delivery email was clicked on. </td>
         </tr>
       </table>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.8",
+  "version": "1.20.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/openapi",
-      "version": "1.20.8",
+      "version": "1.20.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.8",
+  "version": "1.20.9",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"


### PR DESCRIPTION
Fixes #\<INSERT ISSUE NUMBER HERE\>

## Checklist

- [x] Up to date with `main`
- [x] All the tests are passing
  - [x] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect

## Changes
Add `informed_delivery` events (taken from [signal](https://github.com/lob/signal/blob/main/lib/libraries/event-types/types.json#L472-L486)) to docs

## Areas of Concern (optional)
