### PR TITLE
FD-164: Add Resource Proofs API documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lob/growth-and-core-experience @BennyKitchell
+* @lob/sync-engineers

--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.20.8
+  version: 1.20.9
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:
@@ -1495,6 +1495,10 @@ tags:
         true
         --------------------------7015ebe79c0a5f8c--
       ```
+      <div class="back-to-top" ><a href="#" onclick="toTopLink()">back to top</a></div>
+  - name: Resource Proofs
+    description: |
+      The resource proofs endpoint allows you to create a final rendering of any template. This is best practice to ensure that you are visually validating your creative before any mail pieces use the template. The API provides endpoints for creating, updating, and retrieving template proofs.
       <div class="back-to-top" ><a href="#" onclick="toTopLink()">back to top</a></div>
   - name: Reverse Geocode Lookups
     description: |
@@ -11143,6 +11147,133 @@ paths:
                 return err
             }
           label: GO
+  /resource_proofs/{res_prf_id}:
+    parameters:
+      - in: path
+        name: res_prf_id
+        description: id of the resource proof
+        required: true
+        schema:
+          $ref: '#/components/schemas/res_prf_id'
+    get:
+      operationId: resource_proof_retrieve
+      summary: Retrieve
+      description: Retrieves the details of an existing resource proof. You need only supply the unique resource proof identifier.
+      tags:
+        - Resource Proofs
+      responses:
+        '200':
+          description: Returns a resource proof object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource_proof'
+              example:
+                id: res_prf_example123
+                template_id: null
+                resource_type: postcard
+                status: completed
+                thumbnails:
+                  - small: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_small_1.png
+                    medium: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_medium_1.png
+                    large: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_large_1.png
+                url: https://lob-assets.com/resource-proofs/res_prf_example123.pdf
+                errors: []
+                date_created: '2017-11-07T22:56:10.962Z'
+                date_modified: '2017-11-07T22:56:10.962Z'
+                object: resource_proof
+        default:
+          $ref: '#/components/responses/mailpiece_error'
+      x-codeSamples:
+        - lang: Shell
+          source: |
+            curl https://api.lob.com/v1/resource_proofs/res_prf_example123 \
+              -u <YOUR API KEY>:
+          label: CURL
+    patch:
+      operationId: resource_proof_update
+      summary: Update
+      description: Updates the specified resource proof.
+      tags:
+        - Resource Proofs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/resource_proof_updatable'
+            example:
+              template_id: tmpl_a1234dddg
+      responses:
+        '200':
+          description: Returns an updated resource proof object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource_proof'
+              example:
+                id: res_prf_example123
+                template_id: null
+                resource_type: postcard
+                status: completed
+                thumbnails:
+                  - small: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_small_1.png
+                    medium: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_medium_1.png
+                    large: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_large_1.png
+                url: https://lob-assets.com/resource-proofs/res_prf_example123.pdf
+                errors: []
+                date_created: '2017-11-07T22:56:10.962Z'
+                date_modified: '2017-11-07T22:56:10.962Z'
+                object: resource_proof
+        default:
+          $ref: '#/components/responses/mailpiece_error'
+      x-codeSamples:
+        - lang: Shell
+          source: |
+            curl -X PATCH https://api.lob.com/v1/resource_proofs/res_prf_example123 \
+              -u <YOUR API KEY>: \
+              -H "Content-Type: application/json" \
+              -d '{"template_id": "tmpl_a1234dddg"}'
+          label: CURL
+  /resource_proofs:
+    post:
+      operationId: resource_proof_create
+      summary: Create
+      description: Creates a new resource proof with the provided properties.
+      tags:
+        - Resource Proofs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/resource_proof_editable'
+            example:
+              resource_type: postcard
+              resource_parameters:
+                front: tmpl_a1234dddg
+                back: tmpl_a1234dddg
+                to: adr_a1234dddg
+      responses:
+        '201':
+          $ref: '#/components/responses/post_resource_proof'
+        default:
+          $ref: '#/components/responses/mailpiece_error'
+      x-codeSamples:
+        - lang: Shell
+          source: |
+            curl https://api.lob.com/v1/resource_proofs \
+              -u <YOUR API KEY>: \
+              -H "Content-Type: application/json" \
+              -d '{
+                "resource_type": "postcard",
+                "resource_parameters": {
+                  "front": "tmpl_a1234dddg",
+                  "back": "tmpl_a1234dddg",
+                  "to": "adr_a1234dddg"
+                }
+              }'
+          label: CURL
   /self_mailers/{sfm_id}:
     parameters:
       - in: path
@@ -15621,6 +15752,51 @@ components:
       type: http
       scheme: basic
   schemas:
+    '0':
+      title: Postcard Resource Proof
+      type: object
+      properties:
+        template_id:
+          type: string
+          nullable: true
+          description: The template ID to associate with the resource proof.
+        resource_type:
+          type: string
+          enum:
+            - postcard
+          description: The type of resource to generate a proof for.
+        resource_parameters:
+          $ref: '#/components/schemas/postcard_resource_parameters'
+    '1':
+      title: Letter Resource Proof
+      type: object
+      properties:
+        template_id:
+          type: string
+          nullable: true
+          description: The template ID to associate with the resource proof.
+        resource_type:
+          type: string
+          enum:
+            - letter
+          description: The type of resource to generate a proof for.
+        resource_parameters:
+          $ref: '#/components/schemas/letter_resource_parameters'
+    '2':
+      title: Self Mailer Resource Proof
+      type: object
+      properties:
+        template_id:
+          type: string
+          nullable: true
+          description: The template ID to associate with the resource proof.
+        resource_type:
+          type: string
+          enum:
+            - self_mailer
+          description: The type of resource to generate a proof for.
+        resource_parameters:
+          $ref: '#/components/schemas/self_mailer_resource_parameters'
     lob_credits_balance:
       type: object
       required:
@@ -21090,6 +21266,240 @@ components:
           type: string
         metadata:
           $ref: '#/components/schemas/metadata'
+    res_prf_id:
+      type: string
+      description: Unique identifier prefixed with `res_prf_`.
+      pattern: ^res_prf_[a-zA-Z0-9]+$
+    res_prf_resource_type:
+      type: string
+      description: The type of resource to generate a proof for.
+      enum:
+        - postcard
+        - letter
+        - self_mailer
+    res_prf_status:
+      type: string
+      description: The processing status of the resource proof.
+      enum:
+        - processing
+        - completed
+        - failed
+    issue_entry:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: A machine-readable error code.
+        message:
+          type: string
+          description: A human-readable description of the issue.
+        urls:
+          type: array
+          description: Relevant URLs for more information.
+          items:
+            type: string
+    resource_proof_base:
+      type: object
+      properties:
+        template_id:
+          type: string
+          nullable: true
+          description: The template ID associated with the resource proof, if any.
+        resource_type:
+          $ref: '#/components/schemas/res_prf_resource_type'
+        status:
+          $ref: '#/components/schemas/res_prf_status'
+        thumbnails:
+          type: array
+          description: Thumbnail images of the resource proof.
+          items:
+            $ref: '#/components/schemas/thumbnail'
+        url:
+          type: string
+          nullable: true
+          description: A URL to the resource proof PDF.
+        errors:
+          type: array
+          description: Errors encountered during processing.
+          items:
+            $ref: '#/components/schemas/issue_entry'
+    resource_proof:
+      allOf:
+        - $ref: '#/components/schemas/resource_proof_base'
+        - type: object
+          required:
+            - id
+            - resource_type
+            - status
+            - thumbnails
+            - errors
+            - date_created
+            - date_modified
+            - object
+          properties:
+            id:
+              $ref: '#/components/schemas/res_prf_id'
+            date_created:
+              $ref: '#/components/schemas/date_created'
+            date_modified:
+              $ref: '#/components/schemas/date_modified'
+            object:
+              type: string
+              description: Value is resource type.
+              default: resource_proof
+    resource_proof_updatable:
+      type: object
+      properties:
+        template_id:
+          type: string
+          nullable: true
+          description: The template ID to associate with the resource proof.
+    postcard_resource_parameters:
+      allOf:
+        - $ref: '#/components/schemas/input_to'
+        - $ref: '#/components/schemas/input_from_us'
+        - type: object
+          required:
+            - to
+            - front
+            - back
+          properties:
+            size:
+              $ref: '#/components/schemas/postcard_size'
+            merge_variables:
+              $ref: '#/components/schemas/merge_variables'
+            front:
+              $ref: '#/components/schemas/psc_front'
+            back:
+              $ref: '#/components/schemas/psc_back'
+    letter_resource_parameters:
+      allOf:
+        - $ref: '#/components/schemas/input_to'
+        - $ref: '#/components/schemas/input_from'
+        - type: object
+          required:
+            - to
+            - from
+            - file
+            - color
+          properties:
+            merge_variables:
+              $ref: '#/components/schemas/merge_variables'
+            file:
+              $ref: '#/components/schemas/ltr_file'
+            color:
+              allOf:
+                - $ref: '#/components/schemas/color'
+                - default: false
+            double_sided:
+              $ref: '#/components/schemas/double_sided'
+            address_placement:
+              $ref: '#/components/schemas/address_placement'
+            size:
+              $ref: '#/components/schemas/ltr_size'
+    self_mailer_resource_parameters:
+      allOf:
+        - $ref: '#/components/schemas/input_to'
+        - $ref: '#/components/schemas/input_from_us'
+        - type: object
+          required:
+            - to
+            - inside
+            - outside
+          properties:
+            size:
+              $ref: '#/components/schemas/self_mailer_size'
+            merge_variables:
+              $ref: '#/components/schemas/merge_variables'
+            inside:
+              description: |
+                The artwork to use as the inside of your self mailer.
+
+                Notes:
+                - HTML merge variables should not include delimiting whitespace.
+                - PDF, PNG, and JPGs must be sized at 6"x18" at 300 DPI, while supplied HTML will be rendered to the specified `size`.
+                - Be sure to leave room for address and postage information by following the templates provided here:
+                  - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_bifold_template.pdf" target="_blank">6x18 bifold template</a>
+                  - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/12x9_sfm_bifold_template.pdf" target="_blank">12x9 bifold template</a>
+                  - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/17_75x9_trifold_sfm_template.pdf" target="_blank">17.75x9 trifold template</a>
+
+
+                See [here](#section/HTML-Examples) for HTML examples.
+              oneOf:
+                - $ref: '#/components/schemas/html_string'
+                - $ref: '#/components/schemas/tmpl_id'
+                - $ref: '#/components/schemas/remote_file_url'
+                - $ref: '#/components/schemas/local_file_path'
+            outside:
+              description: |
+                The artwork to use as the outside of your self mailer.
+
+                Notes:
+                - HTML merge variables should not include delimiting whitespace.
+                - PDF, PNG, and JPGs must be sized at 6"x18" at 300 DPI, while supplied HTML will be rendered to the specified `size`.
+
+                See [here](#section/HTML-Examples) for HTML examples.
+              oneOf:
+                - $ref: '#/components/schemas/html_string'
+                - $ref: '#/components/schemas/tmpl_id'
+                - $ref: '#/components/schemas/remote_file_url'
+                - $ref: '#/components/schemas/local_file_path'
+    resource_proof_editable:
+      required:
+        - resource_type
+        - resource_parameters
+      oneOf:
+        - title: Postcard Resource Proof
+          type: object
+          properties:
+            template_id:
+              type: string
+              nullable: true
+              description: The template ID to associate with the resource proof.
+            resource_type:
+              type: string
+              enum:
+                - postcard
+              description: The type of resource to generate a proof for.
+            resource_parameters:
+              $ref: '#/components/schemas/postcard_resource_parameters'
+        - title: Letter Resource Proof
+          type: object
+          properties:
+            template_id:
+              type: string
+              nullable: true
+              description: The template ID to associate with the resource proof.
+            resource_type:
+              type: string
+              enum:
+                - letter
+              description: The type of resource to generate a proof for.
+            resource_parameters:
+              $ref: '#/components/schemas/letter_resource_parameters'
+        - title: Self Mailer Resource Proof
+          type: object
+          properties:
+            template_id:
+              type: string
+              nullable: true
+              description: The template ID to associate with the resource proof.
+            resource_type:
+              type: string
+              enum:
+                - self_mailer
+              description: The type of resource to generate a proof for.
+            resource_parameters:
+              $ref: '#/components/schemas/self_mailer_resource_parameters'
+      discriminator:
+        propertyName: resource_type
+        mapping:
+          postcard: '#/components/schemas/0'
+          letter: '#/components/schemas/1'
+          self_mailer: '#/components/schemas/2'
     sfm_id:
       type: string
       description: Unique identifier prefixed with `sfm_`.
@@ -23921,6 +24331,33 @@ components:
                 print_speed: core
                 sla: '2'
                 object: postcard
+    post_resource_proof:
+      description: Returns a resource proof object
+      headers:
+        ratelimit-limit:
+          $ref: '#/components/headers/ratelimit-limit'
+        ratelimit-remaining:
+          $ref: '#/components/headers/ratelimit-remaining'
+        ratelimit-reset:
+          $ref: '#/components/headers/ratelimit-reset'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/resource_proof'
+          example:
+            id: res_prf_example123
+            template_id: null
+            resource_type: postcard
+            status: completed
+            thumbnails:
+              - small: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_small_1.png
+                medium: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_medium_1.png
+                large: https://lob-assets.com/resource-proofs/res_prf_example123_thumb_large_1.png
+            url: https://lob-assets.com/resource-proofs/res_prf_example123.pdf
+            errors: []
+            date_created: '2017-11-07T22:56:10.962Z'
+            date_modified: '2017-11-07T22:56:10.962Z'
+            object: resource_proof
     self_mailer_deleted:
       description: Deleted
       content:
@@ -25093,6 +25530,7 @@ x-tagGroups:
       - Booklets
       - Bank Accounts
       - Templates
+      - Resource Proofs
       - Template Versions
       - Template Design
       - Manage Mail

--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.20.9
+  version: 1.21.0
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/dist/lob-api-postman.json
+++ b/dist/lob-api-postman.json
@@ -1,7 +1,7 @@
 {
     "item": [
         {
-            "id": "9966bc8d-1a94-403b-9d10-d468524068d0",
+            "id": "87534a7d-508c-4535-913b-8c09aedec16b",
             "name": "Addresses",
             "description": {
                 "content": "To add an address to your address book, you create a new address object. You can retrieve and delete individual\naddresses as well as get a list of addresses. Addresses are identified by a unique random ID.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -9,7 +9,7 @@
             },
             "item": [
                 {
-                    "id": "5e4302a4-a198-4fd7-b2e5-32779857b0ae",
+                    "id": "7f41b1f7-4010-4593-b840-c422c08e0de5",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -57,19 +57,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -87,7 +81,7 @@
                     },
                     "response": [
                         {
-                            "id": "c60c1018-229d-4b01-8e1a-1d5be5f061d0",
+                            "id": "6f6375a7-5f1a-423f-b6ac-7f9c91720266",
                             "name": "A dictionary with a data property that contains an array of up to `limit` addresses. Each entry in the array is a separate address object. The previous and next page of address entries can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more addresses are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -119,7 +113,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -151,7 +149,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e115d4f6-3f29-43c3-8151-ee76c0ddebfb",
+                            "id": "13d70001-88a0-45ec-8d3d-c4f274f26441",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -183,7 +181,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -218,7 +220,7 @@
                     "event": []
                 },
                 {
-                    "id": "1d640cf0-a8cd-4a28-b55c-9f824bec38d4",
+                    "id": "4a2d215a-d203-4db8-b691-3a815b94e689",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -281,7 +283,7 @@
                     },
                     "response": [
                         {
-                            "id": "d5ae0080-d12b-4544-9d98-70654e7f698a",
+                            "id": "b618f5e9-e348-41fe-bcd4-83bf65afe0b9",
                             "name": "Echos the writable fields of a newly created address object.",
                             "originalRequest": {
                                 "url": {
@@ -397,7 +399,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ac38fb9b-ff91-4c59-ae70-5a5ed0d9dc1a",
+                            "id": "55f74130-e715-4710-869c-c2fa3b7691b9",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -501,7 +503,7 @@
                     }
                 },
                 {
-                    "id": "f9772808-9f36-4408-b694-93b3250284d9",
+                    "id": "093cec24-ed43-4389-ade7-e905cd7c1393",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -539,7 +541,7 @@
                     },
                     "response": [
                         {
-                            "id": "f88c76dc-c685-453e-9763-e939483c8508",
+                            "id": "169078db-327d-4c26-a6b0-d90b16fe011c",
                             "name": "Returns an address object if a valid identifier was provided.",
                             "originalRequest": {
                                 "url": {
@@ -587,7 +589,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "332123e8-1b26-4a81-a99c-db7b127c28c7",
+                            "id": "8eacba7b-10c3-4bfe-a504-2c4770233537",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -638,7 +640,7 @@
                     "event": []
                 },
                 {
-                    "id": "702fbef1-c083-4e4e-afb5-d1324f4c846c",
+                    "id": "5760645e-97e7-4e45-a262-4c6ee2d28e5d",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -676,7 +678,7 @@
                     },
                     "response": [
                         {
-                            "id": "667ec896-3fcd-4046-b496-cd2ee23e3f40",
+                            "id": "243d8e6f-7689-4be5-b5ee-fab304fe3974",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -724,7 +726,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5c4f88a6-831b-4fc0-9e71-e570e4b06227",
+                            "id": "b891b88b-d28f-4959-a3ef-d6f9c8531655",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -778,7 +780,7 @@
             "event": []
         },
         {
-            "id": "a872098b-87be-40b1-adc6-1e472df519e8",
+            "id": "167af346-53a9-44b6-a1b7-8169bb41d582",
             "name": "Authentication",
             "description": {
                 "content": "Requests made to the API are protected with <a href=\"https://en.wikipedia.org/wiki/Basic_access_authentication\" target=\"_blank\">HTTP Basic authentication</a>.\nIn order to properly authenticate with the API you must use your API key as the username\nwhile leaving the password blank. Requests not properly authenticated will return a `401`\n[error code](#tag/Errors). You can find your account's API keys\nin your <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Dashboard Settings</a>.\n### Example Request\ncurl uses the -u flag to pass basic auth credentials (adding a colon after your API key will prevent it from asking you for a\npassword). One of our test API keys has been filled into all the examples on the page, so you can test out any example right away.\n```bash\ncurl https://api.lob.com/v1/addresses \\\n  -u test_0dc8dXXXXXXXXXXXXXXXXXXXXXX5b0cc:\n```\n## API Keys\n  Lob authenticates your API requests using your account's API keys.\n  If you do not include your key when making an API request, or use\n  one that is incorrect or outdated, Lob returns an error with a `401`\n  HTTP response code. You can find all API keys in your dashboard\n  under <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Settings</a>.\n  There are two types of API keys: *secret* and *publishable*.\n  - **Secret API keys** should be kept confidential and only stored on your own servers.\n  Your account's secret API key can perform any API request to Lob without restriction.\n  - **Publishable API keys** are limited to US verifications, international verifications,\n  and US autocomplete requests. For maximum security, we encourage you to not expose your \n  secret key. You can include the publishable keys in JavaScript code or in an Android or iPhone app\n  without exposing your Lob Print and Mail account services or your secret key. Publishable keys are always\n  prefixed with `[environment]_pub`.\n  Every type comes with a pair of keys: one for the testing environment and one for the\n  live environment. We recommend reading [Test and Live Environments](#tag/Test-and-Live-Environments)\n  for more information.\n  <br><br>\n  <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -788,7 +790,7 @@
             "event": []
         },
         {
-            "id": "f5182b3f-f4d1-4528-bfcc-ec72162489db",
+            "id": "579cd0d7-6385-4425-b7f8-967730535e41",
             "name": "Bank Accounts",
             "description": {
                 "content": "Bank Accounts allow you to store your bank account securely in our system. The API provides\nendpoints for creating bank accounts, deleting bank accounts, verifying bank accounts,\nretrieving individual bank accounts, and retrieving a list of bank accounts.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -796,7 +798,7 @@
             },
             "item": [
                 {
-                    "id": "f9ccc493-672a-4b18-9744-9d7eee2350e0",
+                    "id": "87559f62-af8b-4c77-90d6-8fd21721542a",
                     "name": "Verify",
                     "request": {
                         "name": "Verify",
@@ -856,7 +858,7 @@
                     },
                     "response": [
                         {
-                            "id": "df01f735-9739-4c80-ac32-c4c448997daa",
+                            "id": "843c75c0-74c5-4211-b387-bcfaabbe941b",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -945,7 +947,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "882ace4d-b918-4add-a436-9ab6f6588c32",
+                            "id": "dfa3d92f-25c0-49d9-a8e6-434d474bbf96",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1022,7 +1024,7 @@
                     }
                 },
                 {
-                    "id": "d524ad63-c42e-4c5f-8107-6c98e3c2d74d",
+                    "id": "5d367cb0-2312-4ecb-983b-2acc32496760",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -1060,7 +1062,7 @@
                     },
                     "response": [
                         {
-                            "id": "921384d5-b3e0-45f3-8285-f3753d06a66b",
+                            "id": "e24bfe89-9cfd-48dc-b984-8f4f208169c0",
                             "name": "Returns a bank account object",
                             "originalRequest": {
                                 "url": {
@@ -1108,7 +1110,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ef42861a-832e-44f9-9884-8e9335e666e4",
+                            "id": "e629aea7-5a51-4168-bdd2-bc3040ac00a9",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1159,7 +1161,7 @@
                     "event": []
                 },
                 {
-                    "id": "6d7e8f5f-56e5-480b-8964-41fc007c4c6b",
+                    "id": "b6253335-4d7e-4950-85c4-e64ece5fc397",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -1197,7 +1199,7 @@
                     },
                     "response": [
                         {
-                            "id": "49d49a99-2605-4a39-9abd-67a7baf1bc8b",
+                            "id": "fd0c6df9-0175-48f9-8e7f-8243f61b9193",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -1245,7 +1247,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ca871fdc-5516-4a6d-ad4f-b442cad7344d",
+                            "id": "3a45895b-9f3b-4f26-b048-61dfc6477f15",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1296,7 +1298,7 @@
                     "event": []
                 },
                 {
-                    "id": "5fb083fd-25d5-446e-a362-639225fb91bb",
+                    "id": "07d5930f-4852-41a4-806e-68b30e449326",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -1344,19 +1346,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -1374,7 +1370,7 @@
                     },
                     "response": [
                         {
-                            "id": "fd6688e2-02b0-48c9-9821-601838bc7edf",
+                            "id": "4cb623ff-47e6-40ad-8180-43ca027173b8",
                             "name": "A dictionary with a data property that contains an array of up to `limit` bank_accounts. Each entry in the array is a separate bank_account. The previous and next page of bank_accounts can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more bank_accounts are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -1406,7 +1402,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -1438,7 +1438,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "04d7c97d-8382-42ea-82a4-bf492c9f5713",
+                            "id": "9fa674d9-2784-49fa-8437-4f0f59989160",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1470,7 +1470,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -1505,7 +1509,7 @@
                     "event": []
                 },
                 {
-                    "id": "ceae2059-b095-4e13-abf1-b4a854ce252b",
+                    "id": "3d92e91e-db76-4659-89c6-20690a1d4c06",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -1602,7 +1606,7 @@
                     },
                     "response": [
                         {
-                            "id": "754ad6c4-0dbe-4210-9933-6d16fd0a0f19",
+                            "id": "63445db7-0c71-493a-a43c-c9fc6acc1669",
                             "name": "Returns a bank_account object",
                             "originalRequest": {
                                 "url": {
@@ -1709,7 +1713,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "656ba0c4-4ac7-4bea-a4d8-9fe5ed360fcb",
+                            "id": "2a59e310-4074-4024-be89-1305a42d7640",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1807,7 +1811,7 @@
             "event": []
         },
         {
-            "id": "2f59e6f5-536e-4219-bf2a-51f23baa4d2d",
+            "id": "854577e7-bf1f-485d-90bf-d1df4619a891",
             "name": "Beta Program",
             "description": {
                 "content": "At Lob, we pride ourselves on building high quality platform capabilities rapidly\nand iteratively, so we can constantly be delivering additional value to our customers.\nWhen evaluating a new product or feature from Lob, you may see that it has been released in Beta.\n\nTypically, something in Beta means that the feature is early in its lifecycle here at\nLob. While we fully stand behind the quality of everything we release in Beta, we do\nanticipate receiving a higher level of customer feedback on Beta features, as well as a\nfaster pace of changes from our engineering team in response to that feedback.\n\nBy participating in a Lob Beta program, you will have the opportunity to get early access\nto a new product capability, as well as having a unique opportunity to influence the product's\ndirection with your feedback.\n\nYou should also anticipate that features in Beta may have functional or design limitations,\nand might change rapidly as we receive customer feedback and make improvements. In particular,\nnew APIs in Beta may also go through more frequent versioning and version deprecation cycles\nthan our more mature APIs.\n\nIf you are participating in a Beta program and want to provide feedback, please feel free to\n<a href=\"https://lob.com/support#contact\" target=\"_blank\">contact us</a>!\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -1817,7 +1821,7 @@
             "event": []
         },
         {
-            "id": "dde5c57c-66e1-4b46-b044-c9dc260260e2",
+            "id": "e3b54dad-2290-4543-b817-75e9649028d9",
             "name": "Billing Groups",
             "description": {
                 "content": "The Billing Groups API allows you to create and view labels that can be attached to certain consumption-based\nusages of Letters, Checks, Postcards and Self-Mailers to customize your bill. Please check each\nresource API section to learn more about how to access the Billing Groups API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -1825,7 +1829,7 @@
             },
             "item": [
                 {
-                    "id": "a719bbdc-f78d-4947-b728-d5e2b4c5b2c7",
+                    "id": "469c6158-3e4c-48a9-8323-dc35f3999644",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -1863,7 +1867,7 @@
                     },
                     "response": [
                         {
-                            "id": "60612335-b7de-44b5-a5ba-dbc0fc11681d",
+                            "id": "6057243e-c0b3-475b-9ab4-ec43870d5d06",
                             "name": "Returns a billing_group object.",
                             "originalRequest": {
                                 "url": {
@@ -1911,7 +1915,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3d0faf31-4d34-42c4-af3f-72bb46ae3965",
+                            "id": "18d7be04-1ccb-4854-aa35-35587bdfdacd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -1962,7 +1966,7 @@
                     "event": []
                 },
                 {
-                    "id": "6dfd43c8-886b-4293-8f66-cd38ae06acf4",
+                    "id": "d449ad41-047a-4c68-9a2d-d7753d8bfa74",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -2019,7 +2023,7 @@
                     },
                     "response": [
                         {
-                            "id": "5c0bb42c-eb23-417d-8365-0f4c37d5caf3",
+                            "id": "ceee5ed0-d0ec-4be1-9b57-ee46def46044",
                             "name": "Returns a billing group object",
                             "originalRequest": {
                                 "url": {
@@ -2099,7 +2103,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5c990b0c-056c-4632-b85b-84374f1b5744",
+                            "id": "b0581f08-cd95-43ec-a47a-31d9199b3f29",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2167,7 +2171,7 @@
                     }
                 },
                 {
-                    "id": "11126ace-f01b-435f-96a2-4ff81f4d003a",
+                    "id": "26ad3533-3890-4b42-8172-9996c8a4c31f",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -2209,37 +2213,25 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[dolor2]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_modified[Duis_d65]",
+                                    "key": "date_modified[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_modified[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_modified[dolor2]",
+                                    "key": "date_modified[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date modified. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -2269,7 +2261,7 @@
                     },
                     "response": [
                         {
-                            "id": "8b366396-821e-4702-a99e-597b3883f267",
+                            "id": "403baecd-5f96-4513-a7c6-cc342646e52c",
                             "name": "Returns a list of billing_groups.",
                             "originalRequest": {
                                 "url": {
@@ -2297,11 +2289,19 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_modified[et_b08]",
+                                            "key": "date_created[culpa_0]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_modified[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_modified[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -2341,7 +2341,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ffb70e78-e6b7-4b05-b983-3bb25c227ef2",
+                            "id": "282a9b43-b52e-4c77-9453-b7abf7bf6caa",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2369,11 +2369,19 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_modified[et_b08]",
+                                            "key": "date_created[culpa_0]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_modified[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_modified[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -2416,7 +2424,7 @@
                     "event": []
                 },
                 {
-                    "id": "c62d74e8-ee50-46f7-aa72-6a317640b550",
+                    "id": "29541f67-37ab-4d5b-827b-62d15c1b594f",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -2464,7 +2472,7 @@
                     },
                     "response": [
                         {
-                            "id": "403005a5-33b0-4547-9b60-7c7c531ec48d",
+                            "id": "16121f25-9825-4fbe-aa84-fd9ab5b408fd",
                             "name": "Returns a billing group object",
                             "originalRequest": {
                                 "url": {
@@ -2535,7 +2543,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3a006b61-ad94-468e-b3ef-e8b002174a55",
+                            "id": "97eb3468-6dfc-4de4-afb3-7a49b7f21f55",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2597,7 +2605,7 @@
             "event": []
         },
         {
-            "id": "7fb48240-dc30-4b4c-8bcb-b58331d15483",
+            "id": "f36821c6-a676-4a42-94d7-e40aa3f90ad5",
             "name": "Buckslip Orders",
             "description": {
                 "content": "The Buckslip Orders endpoint allows you to easily create buckslip orders for existing buckslips.\nThe API provides endpoints for creating buckslip orders and listing buckslip orders for a given buckslip.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -2605,7 +2613,7 @@
             },
             "item": [
                 {
-                    "id": "0adb7593-f013-429b-8ec6-fdae38eeb931",
+                    "id": "9a2178cc-ecbf-4f29-9f3d-9012c0e208f2",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -2657,7 +2665,7 @@
                     },
                     "response": [
                         {
-                            "id": "cd0d1e6b-5566-4adb-b1c6-b6be5b5ce453",
+                            "id": "07bff6a4-4171-4d95-99d7-19e264a35491",
                             "name": "Returns the buckslip orders associated with the given buckslip id",
                             "originalRequest": {
                                 "url": {
@@ -2715,7 +2723,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9c55acd5-904e-40ea-8e93-eb70d68c1169",
+                            "id": "60da768a-5a7c-4903-9e0f-3e4e3f7057a9",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2776,7 +2784,7 @@
                     "event": []
                 },
                 {
-                    "id": "8d05e6a3-d36c-4597-a86e-8c6b79f4d53b",
+                    "id": "3d793515-1f62-4839-8f8b-1989eefde3d5",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -2830,7 +2838,7 @@
                     },
                     "response": [
                         {
-                            "id": "5d0f6333-88b9-4f48-9c0e-84972d639b24",
+                            "id": "9420c3ee-5dd1-4277-8415-b75d4b23a529",
                             "name": "Buckslip order created successfully",
                             "originalRequest": {
                                 "url": {
@@ -2892,7 +2900,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "39c3f8e4-c04d-449f-af4b-3074d8ecfcf4",
+                            "id": "eb742a33-b0e5-4427-9e26-f0d6ed47173f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -2963,7 +2971,7 @@
             "event": []
         },
         {
-            "id": "a0abf342-4b81-4a60-86f4-dfa782b3c832",
+            "id": "6435c8ce-d926-4b80-9dfb-1a722517dc2c",
             "name": "Buckslips",
             "description": {
                 "content": "The Buckslips endpoint allows you to easily create buckslips that can later be used as add-ons for Letters Campaigns. Note that a Letter Campaign with Buckslip add-on requires a minimum send quantity of 5,000 letters.\nThe API provides endpoints for creating buckslips, retrieving individual buckslips, creating buckslip orders, and retrieving a list of buckslips.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -2971,7 +2979,7 @@
             },
             "item": [
                 {
-                    "id": "e1fb6b96-71d9-400d-a392-7b028045aa33",
+                    "id": "af63c88f-fa50-4129-8162-8ef14fa0ae13",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -3031,7 +3039,7 @@
                     },
                     "response": [
                         {
-                            "id": "b1504f81-29af-4352-b364-aa54f6d83cd1",
+                            "id": "3608e6cd-0067-4eaf-a44b-3c623c60a759",
                             "name": "Returns a list of buckslip objects",
                             "originalRequest": {
                                 "url": {
@@ -3091,7 +3099,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "27d01539-c3e3-49b6-9d97-46aa980922c9",
+                            "id": "75da01b0-95da-4f88-a411-29b8ba4d486c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3154,7 +3162,7 @@
                     "event": []
                 },
                 {
-                    "id": "bdb04caa-3136-4b27-8118-98725eef6072",
+                    "id": "b57b80a7-1c48-4c48-82ba-48bb28a10efd",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -3212,7 +3220,7 @@
                     },
                     "response": [
                         {
-                            "id": "34ce13b3-6c32-4108-9b50-881a430d9748",
+                            "id": "1bf0b9dc-4f86-46f0-aa9b-27397d8a3cd4",
                             "name": "Buckslip created successfully",
                             "originalRequest": {
                                 "url": {
@@ -3270,7 +3278,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "53b8cc18-d885-4051-b98e-fd536a3ec536",
+                            "id": "e8fc4c5d-0d2d-46c4-b716-9219c1636ce0",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3334,7 +3342,7 @@
                     }
                 },
                 {
-                    "id": "2ecaa3e8-4c29-4a91-8fa6-1b526a954e16",
+                    "id": "172dfbcd-2a29-4723-84e5-a78c3aa27458",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -3372,7 +3380,7 @@
                     },
                     "response": [
                         {
-                            "id": "bbf82d16-c246-436a-9f7a-ae9a92fca9b7",
+                            "id": "7818916b-6115-45a7-89dd-7fbe43d062d9",
                             "name": "Returns a buckslip object",
                             "originalRequest": {
                                 "url": {
@@ -3420,7 +3428,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "487552bb-b74b-4908-961b-c5ab997334fb",
+                            "id": "63527640-9c97-40e6-b996-54bbf0ec8f24",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3471,7 +3479,7 @@
                     "event": []
                 },
                 {
-                    "id": "587d321f-f8d7-4b9a-bc33-83a41e921fc5",
+                    "id": "7187dcd5-4a23-4eef-9f46-81f63a467402",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -3535,7 +3543,7 @@
                     },
                     "response": [
                         {
-                            "id": "b467c2df-aa49-456d-b3be-5be3f3cd0b14",
+                            "id": "302ff6a1-6a8a-4248-a82a-62ab90ed2cfb",
                             "name": "Returns a buckslip object",
                             "originalRequest": {
                                 "url": {
@@ -3601,7 +3609,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "10fdefa8-114f-449b-9159-feffe324d0e9",
+                            "id": "0a8763d0-ce6c-4dfa-96f9-7583fe1db29d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3673,7 +3681,7 @@
                     }
                 },
                 {
-                    "id": "920ca5d4-de48-456c-8739-8e1c5cec4816",
+                    "id": "a99bdee4-4672-4bcc-9041-7cf1858010f1",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -3711,7 +3719,7 @@
                     },
                     "response": [
                         {
-                            "id": "83b260a9-f3d9-4bf7-88ca-5344d889aa59",
+                            "id": "fa6414f8-4c7e-47bc-b3c5-8954be8f7e2b",
                             "name": "Deleted the buckslip",
                             "originalRequest": {
                                 "url": {
@@ -3759,7 +3767,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "256325bb-c67c-496e-8371-c2f0b6c54a04",
+                            "id": "5ebc6161-8f4a-41ec-b974-f6631a522937",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -3813,7 +3821,7 @@
             "event": []
         },
         {
-            "id": "a9a8b659-9dba-419b-aad5-01f4c1a93f8c",
+            "id": "612c0d41-1e08-41ae-b4fd-3ea92a4d70ac",
             "name": "Bulk Intl Verifications",
             "description": {
                 "content": "Verify a list of non-US addresses.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -3823,7 +3831,7 @@
             "event": []
         },
         {
-            "id": "151dbd06-e730-4b92-a48c-c483978bfce0",
+            "id": "2984febd-9fc2-494f-b0fd-c09dcfd03407",
             "name": "Bulk US Verifications",
             "description": {
                 "content": "Verify a list of US addresses.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -3833,7 +3841,7 @@
             "event": []
         },
         {
-            "id": "5b8197ac-5f39-4917-bfc9-225753bd82b6",
+            "id": "0aaf04b3-fba5-4139-b803-3604c91c3310",
             "name": "Campaigns",
             "description": {
                 "content": "The campaigns endpoint allows you to create and view campaigns that can be used to send multiple letters or postcards.\nThe API provides endpoints for creating campaigns, updating campaigns, retrieving individual campaigns, listing campaigns, and deleting\ncampaigns.\n",
@@ -3841,7 +3849,7 @@
             },
             "item": [
                 {
-                    "id": "f5b9ec19-9695-4028-82bd-1ce32996e312",
+                    "id": "008ed343-0af4-4c8a-aa2a-56456a8f95fb",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -3901,7 +3909,7 @@
                     },
                     "response": [
                         {
-                            "id": "e8279e80-1a99-4fc6-808a-307d052b0e13",
+                            "id": "44266f84-4188-44fb-8372-5b7c278b5e01",
                             "name": "A dictionary with a data property that contains an array of up to `limit` campaigns. Each entry in the array is a separate campaign. The previous and next page of campaigns can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more campaigns are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -3964,7 +3972,7 @@
                     "event": []
                 },
                 {
-                    "id": "6a833988-3038-4e30-89f3-1e2a2e7f8a74",
+                    "id": "28fc02a5-776f-46e1-a5d1-8330148004a1",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -4053,20 +4061,25 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "b^Us)a}u~Ii3)2XV8i_is PJ{ DCLS(R>,+_^m*, w4RDa[9ys_^<W8Pol5<!JvP0z~Zv{%a(ay2SDQjKjdyN-(H6j&?sHU@XiAZg ^d&FR>2xZduRLk[nTh!xv2'GCDLv9UsY^yIT^S.cprTs_u1-lOCwr%QZ75dy%N}_jD}lI!b'<N8M|)pa1?^F{M>41zR8Oa{~KfA?,MEgBA+,q&QfM@--tB7_+=5ga;XZz(K[rLIrJ|-O;!Q*ajgH9;Wd8Ny/^o n/z={0SHne}0Jl0vpag52FEw+i~+x3gGxnUb$Pu>f3#bqYdg_s+G)=L:Z.m~CH',fxzw5WlZK/0BTCfonxhmi#FS` _Uy3{XJaSq'eS5ImcjYM?2|8*cA><)G$qHGn1Nd(nM+}smDuae]9q61~AKVqE97)q|,sEpf@SQ<'HtE*fsSYg6R-1-Ae@j`M%2#Dy[B{.Il9]iI-"
+                                    "value": "VxCe';~k.xrLVQR4j`cLv.[$~b^R`$a4w]0YV=;uYeVG'{E5*gE#BSiJGU6v(I85>y3fj%WgII0Wix7@5>F<s0QI=:Y0l})i#cl7rfn&X{9xeD~m=&j?d4c`YXC<B]i9Xv5fCjA%JM_{fDfPVF PMvycx6,L?ca!i3c_Ise&Zn`T|C?T6!c$3ozH{M%XA57j/S7.BHHoPV)N4z ?^]% njHkZ|l*cs%M27OSh- =N.(zsG5GB5/m[]9E{D*+fC/oApFT3o_EIy+}#QWBc^~t:,<k3bCoxaamrWZ}0~85?7QvY&21]t+w56BbdP*Ns[rp<EfwyKOYM&2~V09'^mXa~zH^B<L0Aq(w)W$^(2U${h.(d|lp-1cJoCf#JSu:"
                                 },
                                 {
                                     "disabled": false,
                                     "key": "auto_cancel_if_ncoa",
                                     "value": "<boolean>",
                                     "description": "Whether or not a mail piece should be automatically canceled and not sent if the address is updated via NCOA."
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "print_speed",
+                                    "value": "core"
                                 }
                             ]
                         }
                     },
                     "response": [
                         {
-                            "id": "7212a30a-bf02-4fce-bfb4-dec2545e6ae6",
+                            "id": "1a7eb728-3c0e-472b-8b6c-c3cb1f16592d",
                             "name": "Campaign created successfully",
                             "originalRequest": {
                                 "url": {
@@ -4121,6 +4134,11 @@
                                             },
                                             "key": "schedule_type",
                                             "value": "immediate"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -4138,7 +4156,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "24ac3e17-75af-41bf-872e-9bf8e2b474ca",
+                            "id": "8c5d932e-a234-477b-926b-e2db31f2129a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4193,6 +4211,11 @@
                                             },
                                             "key": "schedule_type",
                                             "value": "immediate"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -4216,7 +4239,7 @@
                     }
                 },
                 {
-                    "id": "66a73c85-f4fd-402d-9fa2-50a92e32b9b2",
+                    "id": "5bbe3e60-b109-4ed2-b1ef-5ae7ed7ffc77",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -4254,7 +4277,7 @@
                     },
                     "response": [
                         {
-                            "id": "ea3a1e41-9118-4e12-bc56-ee0265586ace",
+                            "id": "17333ab0-1fc2-4478-bb54-732e3ca0e110",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4302,7 +4325,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9a4a5c97-8593-4aed-865e-94c8df282194",
+                            "id": "3cbafab5-8085-487c-b381-38e347149e80",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4353,7 +4376,7 @@
                     "event": []
                 },
                 {
-                    "id": "3386be23-90e8-48d6-9885-407ddeebb681",
+                    "id": "1d7f0af5-1ab3-4432-a143-d404522b3b35",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -4431,7 +4454,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "#'~BvQJQ~U?)-4XBC VQ+[B58xOcqV$HhJi.P%}4:*6},O@7ok:w>4e8`)a~}[XH(i<vw?HX^;YvDw|87)b,P`62hRmmPe@!U;uQEF%@Kc69GkB&lu&D!O^Yj;uD%n}EuBjv!Fm-/zvb}TT6Xiu6I0%fx|^U3`uDl%O3<ETc8vNh1EOJKN&wUMuxPpnw&O2x5gK!Pmid*wBV0B[$D5aM[^XC2kfUcXMIF_$|{6xZcE~[k2>o*B)T}wOL10&uLVr[Wc-wp k2TrBC$b;g--Tz7u6,61Gx_fbL]NC*S9RO#luHUHj|+rnacAE$ZY~skrXUGTRE{X']/v~u'!~WcfQ9!Ol`{oeD*/yhU9sl|&@R|q7W'Z+pB:Vg8$BP9}}/N^G!)N:P^QIF9OKr2j84V(C&=d;l!(qCNDt VYO:4/M`qYORiqcQ{xm,>W&Xi6?y|Zo,'FIk,r!PMHkP8cgn~PWb8z&O8.!<Tjo&Oz"
+                                    "value": "'2*R3r]H!AfRPjp{uI&-Wr[[dRd~~(:Dhb(.pm;E+`2/u|:IgG/xseHj##OE1'<vmYIvyk8#@wDSI$o3c`,"
                                 },
                                 {
                                     "disabled": false,
@@ -4455,7 +4478,7 @@
                     },
                     "response": [
                         {
-                            "id": "e112bf25-c05b-4d5c-bebd-fd973aaf7db1",
+                            "id": "8904dc56-bafb-4538-85bc-130ca1dfb770",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4512,7 +4535,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "88a94448-80dc-44cc-aa17-853d523094ee",
+                            "id": "fc16ce3c-e111-4939-a976-3cb459254671",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4575,7 +4598,7 @@
                     }
                 },
                 {
-                    "id": "de9313f0-cbce-432b-94e8-ce4e16ec6604",
+                    "id": "4fe0e075-afb0-4b5c-923e-56151bd47b7b",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -4613,7 +4636,7 @@
                     },
                     "response": [
                         {
-                            "id": "ba0e6425-568c-4a3f-9acc-58f3917cfb24",
+                            "id": "c9cfba44-f63a-4fd7-9db0-2575307eb5b6",
                             "name": "Deleted the campaign.",
                             "originalRequest": {
                                 "url": {
@@ -4661,7 +4684,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9a0242f6-3d0a-4375-b525-4aa7ec7ca6cf",
+                            "id": "77cd2df9-0cd3-4c03-a3b5-4533e452112e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4712,7 +4735,7 @@
                     "event": []
                 },
                 {
-                    "id": "0bdf97fa-6f93-431d-9810-86be0b520f33",
+                    "id": "264605e6-8e34-499c-becd-b57ab345f4f5",
                     "name": "Send Campaign",
                     "request": {
                         "name": "Send Campaign",
@@ -4751,7 +4774,7 @@
                     },
                     "response": [
                         {
-                            "id": "65e7fbd2-1fd2-4d6b-8bdd-0853b065aacd",
+                            "id": "8e9a5d21-0902-41f9-b1ca-d3167ec4b799",
                             "name": "Returns a campaign object",
                             "originalRequest": {
                                 "url": {
@@ -4800,7 +4823,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7b839f1e-5480-4511-b049-83d1120e3a9e",
+                            "id": "121cd591-346f-4521-a472-601aa356116d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -4855,7 +4878,7 @@
             "event": []
         },
         {
-            "id": "2bee590a-d635-4a0d-894b-c9a8891e0e6d",
+            "id": "da4c6536-149c-4fa3-aedd-256e0a147a0b",
             "name": "Card Orders",
             "description": {
                 "content": "The card orders endpoint allows you to easily create card orders for existing cards.\nThe API provides endpoints for creating card orders and listing card orders for a given card.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -4863,7 +4886,7 @@
             },
             "item": [
                 {
-                    "id": "ae0a09d0-73d9-47ba-88db-d503d30c1343",
+                    "id": "6f8fd83f-cdb8-4b29-9ba7-a5e82c344f20",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -4915,7 +4938,7 @@
                     },
                     "response": [
                         {
-                            "id": "911bcfeb-ba61-4bde-9d68-691e3d904a68",
+                            "id": "34a0fbec-5db7-4c7e-9a51-7774a72e2df6",
                             "name": "Returns the card orders associated with the given card id",
                             "originalRequest": {
                                 "url": {
@@ -4973,7 +4996,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "26202c16-85cf-4484-acd0-f0e9c69112b8",
+                            "id": "a8211d1b-713e-42b0-bed4-789ccf9f3006",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5034,7 +5057,7 @@
                     "event": []
                 },
                 {
-                    "id": "ba85629f-5d6a-45f9-8608-9689194d4267",
+                    "id": "5ad65e0e-65fa-4954-855b-ed76442fa102",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -5088,7 +5111,7 @@
                     },
                     "response": [
                         {
-                            "id": "6746db90-48fb-468e-8f50-88c2cc17ad33",
+                            "id": "34f65722-398f-405f-bbcb-c430920c2c28",
                             "name": "Card order created successfully",
                             "originalRequest": {
                                 "url": {
@@ -5150,7 +5173,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "49750b34-19ef-4e7c-970c-2171b6fe78d0",
+                            "id": "4fe7b1ee-45d1-482c-9d3b-42ae9f02e523",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5221,7 +5244,7 @@
             "event": []
         },
         {
-            "id": "58d30abe-ddd2-49b4-b14c-7c33b8f58139",
+            "id": "278d1405-0ccc-41ea-85b2-eb2966b8c1ea",
             "name": "Cards",
             "description": {
                 "content": "The cards endpoint allows you to easily create cards that can later be affixed to Letters.\nThe API provides endpoints for creating cards, retrieving individual cards, creating card orders, and retrieving a list of cards.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -5229,7 +5252,7 @@
             },
             "item": [
                 {
-                    "id": "7608a795-ea3b-4016-8a5d-62ba8de6dd06",
+                    "id": "77b441fe-4723-4173-a389-9262451338d8",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -5289,7 +5312,7 @@
                     },
                     "response": [
                         {
-                            "id": "f8ddc132-404c-4cbb-9b0e-e2243417cbee",
+                            "id": "d42ec740-f0d5-43ae-b2cf-1fe658bca922",
                             "name": "Returns a list of card objects",
                             "originalRequest": {
                                 "url": {
@@ -5349,7 +5372,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c23b743b-7e62-4d6e-a5df-4d766e00d902",
+                            "id": "b0d1e652-102e-4cae-9781-ab9a497e3211",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5412,7 +5435,7 @@
                     "event": []
                 },
                 {
-                    "id": "e2a7c3ac-179e-476b-b306-fd0e9a0255ea",
+                    "id": "32405c83-fb6b-4d04-8bf7-ec72671eeb7c",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -5470,7 +5493,7 @@
                     },
                     "response": [
                         {
-                            "id": "64179031-440b-4b71-afc7-bb8d5a7a5592",
+                            "id": "4f8ebb8a-2b14-45b4-9785-37604c934468",
                             "name": "Card created successfully",
                             "originalRequest": {
                                 "url": {
@@ -5533,7 +5556,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "106c48b8-2a1d-4e2e-8225-fa6e41080032",
+                            "id": "4a6f1ff2-8a70-4446-8946-b996a865d407",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5602,7 +5625,7 @@
                     }
                 },
                 {
-                    "id": "a1ea2740-827f-4ec3-ae76-d31120795158",
+                    "id": "7ac9abc4-e816-4185-a2b1-71a5316cc848",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -5640,7 +5663,7 @@
                     },
                     "response": [
                         {
-                            "id": "07b333bf-557b-4009-b735-7835c5b9a9e6",
+                            "id": "9e000b50-9dd7-46d8-9b1f-41d1b2e01efa",
                             "name": "Returns a card object",
                             "originalRequest": {
                                 "url": {
@@ -5688,7 +5711,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a040df47-0ed8-49b5-96c9-cfded13715f5",
+                            "id": "14f619ea-2487-4679-8941-561482ad0908",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5739,7 +5762,7 @@
                     "event": []
                 },
                 {
-                    "id": "b377a649-8cde-4bc2-9615-023be07ff1a9",
+                    "id": "dda3d567-3f3d-4937-b3a2-278c36d75089",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -5803,7 +5826,7 @@
                     },
                     "response": [
                         {
-                            "id": "167f58ce-9de2-47e9-a1aa-b5d4df419b9c",
+                            "id": "f12c6257-53a4-4661-9532-3480bef3229e",
                             "name": "Returns a card object",
                             "originalRequest": {
                                 "url": {
@@ -5869,7 +5892,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e9030665-46c6-46cb-9801-de3ba687fed5",
+                            "id": "0f8dbdaa-51e3-4773-a43d-9a9396bdb1ac",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -5941,7 +5964,7 @@
                     }
                 },
                 {
-                    "id": "bc92d8c3-077b-484c-8bb9-af8b164c69fb",
+                    "id": "41650b00-514c-4236-a7ce-b4645b7f52f9",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -5979,7 +6002,7 @@
                     },
                     "response": [
                         {
-                            "id": "fdf1952f-8559-4bda-b646-3d23bd4b8aa4",
+                            "id": "3f326601-11b3-4d77-9aae-ad835f329987",
                             "name": "Deleted the card",
                             "originalRequest": {
                                 "url": {
@@ -6027,7 +6050,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "69f4978b-8472-4c6e-8a1f-546f87d4719c",
+                            "id": "4c5c531d-caa9-41fd-91bb-c92da6a5f0b2",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6081,7 +6104,7 @@
             "event": []
         },
         {
-            "id": "5866802e-87e5-4a7f-9441-b8782b6b835a",
+            "id": "57be2133-5919-47f8-865d-184223d7afff",
             "name": "Checks",
             "description": {
                 "content": "Checks allow you to send payments via physical checks. The API provides endpoints\nfor creating checks, retrieving individual checks, canceling checks, and retrieving a list of checks.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -6089,7 +6112,7 @@
             },
             "item": [
                 {
-                    "id": "1975bae7-95de-49cf-a92a-068779507750",
+                    "id": "65775f12-1919-424d-bce9-6fd04c0d0cab",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -6137,19 +6160,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -6197,7 +6214,7 @@
                     },
                     "response": [
                         {
-                            "id": "e93aff80-540c-46bb-826f-c17c1b3cb2bf",
+                            "id": "e5fc7c28-e258-4f23-9334-e4eb85805539",
                             "name": "A dictionary with a data property that contains an array of up to `limit` checks. Each entry in the array is a separate check. The previous and next page of checks can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more checks are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -6229,7 +6246,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -6281,7 +6302,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b2851922-643a-45b2-8fd3-529c725d01b6",
+                            "id": "7f0d202b-983c-41fd-b938-b99897cdd3b3",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6313,7 +6334,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -6368,7 +6393,7 @@
                     "event": []
                 },
                 {
-                    "id": "82aac27b-37f5-45e0-8e48-2647fd55bae7",
+                    "id": "ce4c8f9a-0b09-4dfc-8233-1208841a6a3c",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -6453,13 +6478,18 @@
                                     "disabled": false,
                                     "key": "value",
                                     "value": "<Error: Too many levels of nesting to fake this schema>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "value",
+                                    "value": "<Error: Too many levels of nesting to fake this schema>"
                                 }
                             ]
                         }
                     },
                     "response": [
                         {
-                            "id": "f3275abe-0d24-4998-9c02-b55b3426f9bb",
+                            "id": "2f78c218-ccce-4370-b859-ab4456df6eac",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -6641,6 +6671,11 @@
                                             "disabled": false,
                                             "key": "check_number",
                                             "value": "10001"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -6671,12 +6706,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"chk_534f10783683daa0\",\n  \"description\": \"Demo Check\",\n  \"metadata\": {},\n  \"check_number\": 10062,\n  \"memo\": \"rent\",\n  \"amount\": 22.5,\n  \"url\": \"https://lob-assets.com/checks/chk_534f10783683daa0.pdf?expires=1540372221&signature=Ty3IV2bGPEoQfrdraYHlNYTaarnHLXb\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": \"Harry - Office\",\n    \"name\": \"HARRY ZHANG\",\n    \"company\": \"LOB\",\n    \"email\": \"harry@lob.com\",\n    \"phone\": \"5555555555\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": \"\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:08:43.446Z\",\n    \"date_modified\": \"2018-12-08T03:08:43.446Z\",\n    \"object\": \"address\",\n    \"recipient_moved\": false\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"name\": \"LEORE AVIDAR\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"object\": \"address\"\n  },\n  \"bank_account\": {\n    \"id\": \"bank_8cad8df5354d33f\",\n    \"description\": \"Test Bank Account\",\n    \"metadata\": {},\n    \"routing_number\": \"322271627\",\n    \"account_number\": \"123456789\",\n    \"signatory\": \"John Doe\",\n    \"bank_name\": \"J.P. MORGAN CHASE BANK, N.A.\",\n    \"verified\": true,\n    \"account_type\": \"company\",\n    \"date_created\": \"2015-11-06T19:24:24.440Z\",\n    \"date_modified\": \"2015-11-06T19:41:28.312Z\",\n    \"object\": \"bank_account\",\n    \"signature_url\": \"https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf\"\n  },\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_small_1.png?expires=1540372221&signature=ShhPpH74wYkNiAj7Il9B6q8ZKkzlGd4\",\n      \"medium\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_medium_1.png?expires=1540372221&signature=tmIOq6aAyKgzAECp7STj1rvJuMS5Svd\",\n      \"large\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_large_1.png?expires=1540372221&signature=04nLEwE9d2qgQJNgJYWSOgPnU0FZbEv\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"mail_type\": \"usps_first_class\",\n  \"date_created\": \"2017-09-05T17:47:53.896Z\",\n  \"date_modified\": \"2017-09-05T17:47:53.896Z\",\n  \"send_date\": \"2017-09-05T17:47:53.896Z\",\n  \"object\": \"check\",\n  \"message\": \"pancakes are good\",\n  \"check_bottom_template_id\": \"tmpl_a\",\n  \"attachment_template_id\": \"tmpl_a\",\n  \"check_bottom_template_version_id\": \"vrsn_a\",\n  \"attachment_template_version_id\": \"vrsn_a\",\n  \"use_type\": \"operational\",\n  \"deleted\": true\n}",
+                            "body": "{\n  \"id\": \"chk_534f10783683daa0\",\n  \"description\": \"Demo Check\",\n  \"metadata\": {},\n  \"check_number\": 10062,\n  \"memo\": \"rent\",\n  \"amount\": 22.5,\n  \"url\": \"https://lob-assets.com/checks/chk_534f10783683daa0.pdf?expires=1540372221&signature=Ty3IV2bGPEoQfrdraYHlNYTaarnHLXb\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": \"Harry - Office\",\n    \"name\": \"HARRY ZHANG\",\n    \"company\": \"LOB\",\n    \"email\": \"harry@lob.com\",\n    \"phone\": \"5555555555\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": \"\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:08:43.446Z\",\n    \"date_modified\": \"2018-12-08T03:08:43.446Z\",\n    \"object\": \"address\",\n    \"recipient_moved\": false\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"name\": \"LEORE AVIDAR\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"object\": \"address\"\n  },\n  \"bank_account\": {\n    \"id\": \"bank_8cad8df5354d33f\",\n    \"description\": \"Test Bank Account\",\n    \"metadata\": {},\n    \"routing_number\": \"322271627\",\n    \"account_number\": \"123456789\",\n    \"signatory\": \"John Doe\",\n    \"bank_name\": \"J.P. MORGAN CHASE BANK, N.A.\",\n    \"verified\": true,\n    \"account_type\": \"company\",\n    \"date_created\": \"2015-11-06T19:24:24.440Z\",\n    \"date_modified\": \"2015-11-06T19:41:28.312Z\",\n    \"object\": \"bank_account\",\n    \"signature_url\": \"https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf\"\n  },\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_small_1.png?expires=1540372221&signature=ShhPpH74wYkNiAj7Il9B6q8ZKkzlGd4\",\n      \"medium\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_medium_1.png?expires=1540372221&signature=tmIOq6aAyKgzAECp7STj1rvJuMS5Svd\",\n      \"large\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_large_1.png?expires=1540372221&signature=04nLEwE9d2qgQJNgJYWSOgPnU0FZbEv\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"mail_type\": \"usps_first_class\",\n  \"date_created\": \"2017-09-05T17:47:53.896Z\",\n  \"date_modified\": \"2017-09-05T17:47:53.896Z\",\n  \"send_date\": \"2017-09-05T17:47:53.896Z\",\n  \"object\": \"check\",\n  \"message\": \"pancakes are good\",\n  \"check_bottom_template_id\": \"tmpl_a\",\n  \"attachment_template_id\": \"tmpl_a\",\n  \"check_bottom_template_version_id\": \"vrsn_a\",\n  \"attachment_template_version_id\": \"vrsn_a\",\n  \"use_type\": \"operational\",\n  \"sla\": \"2\",\n  \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "686c72fd-376a-43b8-b7bc-b097ce7dc06b",
+                            "id": "4551c84a-4b85-43a4-b554-d56acfacee89",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -6858,6 +6893,11 @@
                                             "disabled": false,
                                             "key": "check_number",
                                             "value": "10001"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -6881,7 +6921,7 @@
                     }
                 },
                 {
-                    "id": "79303a5e-8238-42c8-b84c-156d8d1c3dec",
+                    "id": "7216ba76-8d56-40eb-913c-7fc61229f9ff",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -6919,7 +6959,7 @@
                     },
                     "response": [
                         {
-                            "id": "244add7e-114d-4306-9c34-ce3db6ad6cae",
+                            "id": "30f7c79d-0b29-492a-b50b-27c31a12faa6",
                             "name": "Returns a check object",
                             "originalRequest": {
                                 "url": {
@@ -6962,12 +7002,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"chk_534f10783683daa0\",\n  \"description\": \"Demo Check\",\n  \"metadata\": {},\n  \"check_number\": 10062,\n  \"memo\": \"rent\",\n  \"amount\": 22.5,\n  \"url\": \"https://lob-assets.com/checks/chk_534f10783683daa0.pdf?expires=1540372221&signature=Ty3IV2bGPEoQfrdraYHlNYTaarnHLXb\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": \"Harry - Office\",\n    \"name\": \"HARRY ZHANG\",\n    \"company\": \"LOB\",\n    \"email\": \"harry@lob.com\",\n    \"phone\": \"5555555555\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": \"\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:08:43.446Z\",\n    \"date_modified\": \"2018-12-08T03:08:43.446Z\",\n    \"object\": \"address\",\n    \"recipient_moved\": false\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"name\": \"LEORE AVIDAR\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"object\": \"address\"\n  },\n  \"bank_account\": {\n    \"id\": \"bank_8cad8df5354d33f\",\n    \"description\": \"Test Bank Account\",\n    \"metadata\": {},\n    \"routing_number\": \"322271627\",\n    \"account_number\": \"123456789\",\n    \"signatory\": \"John Doe\",\n    \"bank_name\": \"J.P. MORGAN CHASE BANK, N.A.\",\n    \"verified\": true,\n    \"account_type\": \"company\",\n    \"date_created\": \"2015-11-06T19:24:24.440Z\",\n    \"date_modified\": \"2015-11-06T19:41:28.312Z\",\n    \"object\": \"bank_account\",\n    \"signature_url\": \"https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf\"\n  },\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_small_1.png?expires=1540372221&signature=ShhPpH74wYkNiAj7Il9B6q8ZKkzlGd4\",\n      \"medium\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_medium_1.png?expires=1540372221&signature=tmIOq6aAyKgzAECp7STj1rvJuMS5Svd\",\n      \"large\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_large_1.png?expires=1540372221&signature=04nLEwE9d2qgQJNgJYWSOgPnU0FZbEv\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"mail_type\": \"usps_first_class\",\n  \"date_created\": \"2017-09-05T17:47:53.896Z\",\n  \"date_modified\": \"2017-09-05T17:47:53.896Z\",\n  \"send_date\": \"2017-09-05T17:47:53.896Z\",\n  \"object\": \"check\",\n  \"message\": \"pancakes are good\",\n  \"check_bottom_template_id\": \"tmpl_a\",\n  \"attachment_template_id\": \"tmpl_a\",\n  \"check_bottom_template_version_id\": \"vrsn_a\",\n  \"attachment_template_version_id\": \"vrsn_a\",\n  \"use_type\": \"operational\",\n  \"deleted\": true\n}",
+                            "body": "{\n  \"id\": \"chk_534f10783683daa0\",\n  \"description\": \"Demo Check\",\n  \"metadata\": {},\n  \"check_number\": 10062,\n  \"memo\": \"rent\",\n  \"amount\": 22.5,\n  \"url\": \"https://lob-assets.com/checks/chk_534f10783683daa0.pdf?expires=1540372221&signature=Ty3IV2bGPEoQfrdraYHlNYTaarnHLXb\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": \"Harry - Office\",\n    \"name\": \"HARRY ZHANG\",\n    \"company\": \"LOB\",\n    \"email\": \"harry@lob.com\",\n    \"phone\": \"5555555555\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": \"\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:08:43.446Z\",\n    \"date_modified\": \"2018-12-08T03:08:43.446Z\",\n    \"object\": \"address\",\n    \"recipient_moved\": false\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"name\": \"LEORE AVIDAR\",\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"object\": \"address\"\n  },\n  \"bank_account\": {\n    \"id\": \"bank_8cad8df5354d33f\",\n    \"description\": \"Test Bank Account\",\n    \"metadata\": {},\n    \"routing_number\": \"322271627\",\n    \"account_number\": \"123456789\",\n    \"signatory\": \"John Doe\",\n    \"bank_name\": \"J.P. MORGAN CHASE BANK, N.A.\",\n    \"verified\": true,\n    \"account_type\": \"company\",\n    \"date_created\": \"2015-11-06T19:24:24.440Z\",\n    \"date_modified\": \"2015-11-06T19:41:28.312Z\",\n    \"object\": \"bank_account\",\n    \"signature_url\": \"https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf\"\n  },\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_small_1.png?expires=1540372221&signature=ShhPpH74wYkNiAj7Il9B6q8ZKkzlGd4\",\n      \"medium\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_medium_1.png?expires=1540372221&signature=tmIOq6aAyKgzAECp7STj1rvJuMS5Svd\",\n      \"large\": \"https://lob-assets.com/checks/chk_534f10783683daa0_thumb_large_1.png?expires=1540372221&signature=04nLEwE9d2qgQJNgJYWSOgPnU0FZbEv\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"mail_type\": \"usps_first_class\",\n  \"date_created\": \"2017-09-05T17:47:53.896Z\",\n  \"date_modified\": \"2017-09-05T17:47:53.896Z\",\n  \"send_date\": \"2017-09-05T17:47:53.896Z\",\n  \"object\": \"check\",\n  \"message\": \"pancakes are good\",\n  \"check_bottom_template_id\": \"tmpl_a\",\n  \"attachment_template_id\": \"tmpl_a\",\n  \"check_bottom_template_version_id\": \"vrsn_a\",\n  \"attachment_template_version_id\": \"vrsn_a\",\n  \"use_type\": \"operational\",\n  \"sla\": \"2\",\n  \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "63b042c3-1d28-498b-9588-57e3f8061941",
+                            "id": "4913246e-12bc-421d-b3f4-effae9135f68",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7018,7 +7058,7 @@
                     "event": []
                 },
                 {
-                    "id": "41280d37-e004-4590-85f6-edcf0f109630",
+                    "id": "227b9b92-62ec-43c7-8d62-0f93ee9f4e29",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -7056,7 +7096,7 @@
                     },
                     "response": [
                         {
-                            "id": "16903d4b-d141-4b53-b94c-138ab510d266",
+                            "id": "a33ff46c-807e-4d73-9f77-fe68967301fe",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -7104,7 +7144,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fd24681b-514b-48fd-97be-dea354f750a8",
+                            "id": "dfc838fc-69d6-4f9e-8851-ced04c0d3dfc",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7158,7 +7198,7 @@
             "event": []
         },
         {
-            "id": "3c029e6c-8e1e-422b-be81-d490c754e34b",
+            "id": "5245efd1-1509-4051-9ab0-481ffc20b189",
             "name": "Creatives",
             "description": {
                 "content": "The creatives endpoint allows you to create and view creatives. Creatives are used to create\nreusable letter and postcard templates. The API provides endpoints for creating creatives, updating creatives,\nretrieving individual creatives, and deleting creatives.\n",
@@ -7166,7 +7206,7 @@
             },
             "item": [
                 {
-                    "id": "b400a2e3-64e0-431b-b5ec-81029c51b092",
+                    "id": "c94a6647-fe11-469c-b1fc-c732d3191c5e",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -7260,7 +7300,7 @@
                     },
                     "response": [
                         {
-                            "id": "82add4ab-be6d-47d7-9250-a38ffdd90f2c",
+                            "id": "6ea0e9c9-7baf-4b5b-baa8-1adf60c3eb7e",
                             "name": "Creative created successfully",
                             "originalRequest": {
                                 "url": {
@@ -7324,7 +7364,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "33d65b72-b8c2-46d5-923d-ccb8e33a018b",
+                            "id": "917376c6-225c-41fc-b081-ba51a3c1acb6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7394,7 +7434,7 @@
                     }
                 },
                 {
-                    "id": "504db15c-82c9-4cfe-89d6-d859d64bd4e9",
+                    "id": "8c731391-b9c5-4547-bf30-2b4c5788ca4c",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -7432,7 +7472,7 @@
                     },
                     "response": [
                         {
-                            "id": "fbd30d30-9ba8-46c8-9254-f9558502704d",
+                            "id": "4e43f30f-4647-4bf5-b6c3-4072c3234b12",
                             "name": "Returns a creative object",
                             "originalRequest": {
                                 "url": {
@@ -7480,7 +7520,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b5d0d99c-6385-484a-8420-c385dd61654f",
+                            "id": "4b744275-5a36-43b9-9c8c-2b95128bf53d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7531,7 +7571,7 @@
                     "event": []
                 },
                 {
-                    "id": "14bcca1f-eaa8-4243-9d64-ee8a1db48144",
+                    "id": "0a3f0036-490c-4d5f-ae6a-3300ca4fa43d",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -7586,14 +7626,14 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "Dg]%l$*~Ja1+m{2IuCkt7Pn5T K.8xj;_zDJT3-2hTDgL9;*69W%jkLq}}VmlEaL_sQrWZ/$p~S*!3ma0f;zU =@D-&cGj8d[i/)<Y`rYs<]BcXDU=4C<rH33vLjc,P_)GhPTQDd|fMR[!*BtQ},,`Ch|ubsw;#]Yh=cwBR&gM<<JDBGJy:+NO_jfXQpI f))q@5sN@z| KzH`za5vr&_0^z[Gay4g?}GBYn3aO8z+#~Ut^_%iCWkD23yc+aC~S*=<wL=|$>7S-xUNLu04^$va9<HR'6`Q2/,BgUw*;kc}*,ett5}dCeeq4wA!w"
+                                    "value": "$+,L<Uk,QDIHwc-@&|F8r22cY 1f>9*sq]8+l@l9*B,WF5gk~F:MK?Xqivv>[BiPD}807Cl$9[Wwt<aFcs4]=3&B:A+nWnw[lE^sh! !R+*Y$PC'8nn8,q`ME3X&`dd;yhjMR{5@76C;uS[!$U8@cRI;).:'. PJImQA])x1]T*A=PqD0c?jC8`K:Y=`V<S+ F*4&U'_yWDQ#|,'Po(- +v1aM~rw4Fy[-5(I[%qme`ax1j;;NaQyvkxpfY:qk6+^2O<kUyI;1OGv^2<ceQTLE/#ei|s)lgccT)O~v#VD~kfa1J6S&xPA/=!;M`)@e2ODxv@'-Gn5]2<aX:M)>yoCKU<[?o~9uQ'%r$vswebQ$NB<'DRi+y0[s2j$zg9GoNy'oc%r~P-ph{?jjb+@*6N%+eF/c7x*8{6]ZW$<SzXS%xw85Iu4o,n,H?yXny75QnFlP;Wv*yu0p_`A$l96;-%A6;I:d|XO?7X~"
                                 }
                             ]
                         }
                     },
                     "response": [
                         {
-                            "id": "5eae9a5e-7877-4e19-8da0-6c58a6ed2b71",
+                            "id": "761fe76b-b9fd-4322-960e-d9ce791405eb",
                             "name": "Returns a creative object",
                             "originalRequest": {
                                 "url": {
@@ -7650,7 +7690,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "93a957df-7f7f-457e-9473-85f780a15433",
+                            "id": "5c077079-26a7-4da9-a9d4-4ec78016f1f1",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -7716,7 +7756,7 @@
             "event": []
         },
         {
-            "id": "a5c62b7e-ad07-4eb6-8420-cf9b9ce5eec0",
+            "id": "dd7e2282-20ee-4b50-8b9d-7d4d8540ad2c",
             "name": "Errors",
             "description": {
                 "content": "Lob uses RESTful HTTP response codes to indicate success or failure of an API request - read below for more information. In general, 2xx indicates success, 4xx indicate an input error, and 5xx indicates an error on Lob's end.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">ATTRIBUTE</th>\n    <th style=\"white-space: nowrap\">DESCRIPTION</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>code</code></td>\n    <td style=\"white-space: nowrap\">A consistent machine-keyable string identifying the error</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>status_code</code></td>\n    <td style=\"white-space: nowrap\">A conventional HTTP status code</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>message</code></td>\n    <td style=\"white-space: nowrap\">A human-readable, subject-to-change message with more details about the error</td>\n  </tr>\n</table>\n\n### HTTP Status Code Summary\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>200</code></td>\n    <td style=\"white-space: nowrap\">SUCCESS</td>\n    <td style=\"white-space: nowrap\">Successful API request</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED</td>\n    <td style=\"white-space: nowrap\">Authorization error with your API key or account</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">FORBIDDEN</td>\n    <td style=\"white-space: nowrap\">Forbidden error with your API key or account</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">NOT FOUND</td>\n    <td style=\"white-space: nowrap\">The requested item does not exist</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BAD REQUEST</td>\n    <td style=\"white-space: nowrap\">The query or body parameters did not pass validation</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>429</code></td>\n    <td style=\"white-space: nowrap\">TOO MANY REQUESTS</td>\n    <td style=\"white-space: nowrap\">Too many requests have been sent with an API key in a given amount of time</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>500</code></td>\n    <td style=\"white-space: nowrap\">SERVER ERROR</td>\n    <td style=\"white-space: nowrap\">An internal server error occurred, please contact support@lob.com</td>\n  </tr>\n</table>\n\n### Error Codes - Generic\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BAD_REQUEST</td>\n    <td style=\"white-space: nowrap\">An invalid request was made. See error message for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>409/422</code></td>\n    <td style=\"white-space: nowrap\">CONFLICT</td>\n    <td style=\"white-space: nowrap\">This operation would leave data in a conflicted state.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">FEATURE_LIMIT_REACHED</td>\n    <td style=\"white-space: nowrap\">The account has reached its resource limit and requires upgrading to add more.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>500</code></td>\n    <td style=\"white-space: nowrap\">INTERNAL_SERVER_ERROR</td>\n    <td style=\"white-space: nowrap\">An error has occured on Lob's servers. Please try request again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID</td>\n    <td style=\"white-space: nowrap\">An invalid request was made. See error message for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">NOT_DELETABLE</td>\n    <td style=\"white-space: nowrap\">An attempt was made to delete a resource, but the resource cannot be deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">NOT_FOUND</td>\n    <td style=\"white-space: nowrap\">The requested resource was not found.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>408</code></td>\n    <td style=\"white-space: nowrap\">REQUEST_TIMEOUT</td>\n    <td style=\"white-space: nowrap\">The request took too long. Please try again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>503</code></td>\n    <td style=\"white-space: nowrap\">SERVICE_UNAVAILABLE</td>\n    <td style=\"white-space: nowrap\">The Lob servers are temporarily unavailable. Please try again.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">UNRECOGNIZED_ENDPOINT</td>\n    <td style=\"white-space: nowrap\">The requested endpoint doesn't exist.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">UNSUPPORTED_LOB_VERSION</td>\n    <td style=\"white-space: nowrap\">An unsupported Lob API version was requested.</td>\n  </tr>\n</table>\n\n### Error Codes - Authentication\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">EMAIL_REQUIRED</td>\n    <td style=\"white-space: nowrap\">Account must have a verified email address before creating live resources.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED</td>\n    <td style=\"white-space: nowrap\">The request isn't authorized.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">UNAUTHORIZED_TOKEN</td>\n    <td style=\"white-space: nowrap\">Token isn't authorized.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401/403</code></td>\n    <td style=\"white-space: nowrap\">INVALID_API_KEY</td>\n    <td style=\"white-space: nowrap\">The API key is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">PUBLISHABLE_KEY_NOT_ALLOWED</td>\n    <td style=\"white-space: nowrap\">The requested operation needs a secret key, not a publishable key. See [API Keys](#tag/API-Keys) for more information.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>429</code></td>\n    <td style=\"white-space: nowrap\">RATE_LIMIT_EXCEEDED</td>\n    <td style=\"white-space: nowrap\">Requests were sent too quickly and must be slowed down.</td>\n  </tr>\n</table>\n\n ### Error Codes - Advanced\n\n <table>\n  <tr>\n    <th style=\"white-space: nowrap\">STATUS_CODE</th>\n    <th style=\"white-space: nowrap\">CODE</th>\n    <th style=\"white-space: nowrap\">MESSAGE</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>401</code></td>\n    <td style=\"white-space: nowrap\">PAYMENT_METHOD_UNVERIFIED</td>\n    <td style=\"white-space: nowrap\">You must have a verified bank account or credit card to submit live requests.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>404</code></td>\n    <td style=\"white-space: nowrap\">DELETED_BANK_ACCOUNT</td>\n    <td style=\"white-space: nowrap\">Checks cannot be created with a deleted bank account.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">ADDRESS_LENGTH_EXCEEDS_LIMIT</td>\n    <td style=\"white-space: nowrap\">The sum of to.address_line1 and to.address_line2 cannot surpass 50 characters.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BANK_ACCOUNT_ALREADY_VERIFIED</td>\n    <td style=\"white-space: nowrap\">The bank account has already been verified.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">BANK_ERROR</td>\n    <td style=\"white-space: nowrap\">There's an issue with the bank account.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>403</code></td>\n    <td style=\"white-space: nowrap\">BILLING_ADDRESS_REQUIRED</td>\n    <td style=\"white-space: nowrap\">In order to create a live mail piece, your account needs to set up a billing address.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">CUSTOM_ENVELOPE_INVENTORY_DEPLETED</td>\n    <td style=\"white-space: nowrap\">Custom envelope inventory is depleted, and more will need to be ordered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FAILED_DELIVERABILITY_STRICTNESS</td>\n    <td style=\"white-space: nowrap\">The to address doesn't meet strictness requirements.\n    See <a href=\"https://dashboard.lob.com/#/settings/account\" target=\"_blank\">Account Settings</a> to configure strictness.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_PAGES_BELOW_MIN</td>\n    <td style=\"white-space: nowrap\">Not enough pages.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_PAGES_EXCEED_MAX</td>\n    <td style=\"white-space: nowrap\">Too many pages.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FILE_SIZE_EXCEEDS_LIMIT</td>\n    <td style=\"white-space: nowrap\">The file size is too large. See description for details.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">FOREIGN_RETURN_ADDRESS</td>\n    <td style=\"white-space: nowrap\">The 'from' address must be a US address.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INCONSISTENT_PAGE_DIMENSIONS</td>\n    <td style=\"white-space: nowrap\">All pages of the input file must have the same dimensions.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_BANK_ACCOUNT</td>\n    <td style=\"white-space: nowrap\">The provided bank routing number is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_BANK_ACCOUNT_VERIFICATION</td>\n    <td style=\"white-space: nowrap\">Verification amounts do not match.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_CHECK_INTERNATIONAL</td>\n    <td style=\"white-space: nowrap\">Checks cannot be sent internationally.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_COUNTRY_COVID</td>\n    <td style=\"white-space: nowrap\">The postal service in the specified country is currently unable to process the request due to COVID-19 restrictions.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE</td>\n    <td style=\"white-space: nowrap\">The file is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_DIMENSIONS</td>\n    <td style=\"white-space: nowrap\">File dimensions are incorrect for the selected mail type.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_DOWNLOAD_TIME</td>\n    <td style=\"white-space: nowrap\">File download from remote server took too long.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_FILE_URL</td>\n    <td style=\"white-space: nowrap\">The file URL when creating a resource is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_IMAGE_DPI</td>\n    <td style=\"white-space: nowrap\">DPI must be at least 300.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_INTERNATIONAL_FEATURE</td>\n    <td style=\"white-space: nowrap\">The specified product cannot be sent to the destination.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_PERFORATION_RETURN_ENVELOPE</td>\n    <td style=\"white-space: nowrap\">Both `return_envelope` and `perforation` must be used together.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">INVALID_TEMPLATE_HTML</td>\n    <td style=\"white-space: nowrap\">The provided HTML is invalid.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MAIL_USE_TYPE_CAN_NOT_BE_NULL</td>\n    <td style=\"white-space: nowrap\">`use_type` must be one of \"marketing\" or \"operational\". Alternatively, an admin can set the account default use type in Account Settings.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MERGE_VARIABLE_REQUIRED</td>\n    <td style=\"white-space: nowrap\">A required merge variable is missing.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">MERGE_VARIABLE_WHITESPACE</td>\n    <td style=\"white-space: nowrap\">Merge variable names cannot contain whitespace.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">PDF_ENCRYPTED</td>\n    <td style=\"white-space: nowrap\">An encrypted PDF was provided.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">SPECIAL_CHARACTERS_RESTRICTED</td>\n    <td style=\"white-space: nowrap\">Cannot use special characters for merge variable names.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>422</code></td>\n    <td style=\"white-space: nowrap\">UNEMBEDDED_FONTS</td>\n    <td style=\"white-space: nowrap\">The provided PDF contains non-standard unembedded fonts. See description for details.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7726,17 +7766,17 @@
             "event": []
         },
         {
-            "id": "d417b268-7de8-49ed-b934-82cfedae3e43",
+            "id": "a61b29df-c9e1-4751-b69c-c7467ebb805b",
             "name": "Events",
             "description": {
-                "content": "When various notable things happen within the Lob architecture, Events will be created. To get these events sent to your server\nautomatically when they occur, you can set up [Webhooks](#tag/Webhooks).\n\n<h3>Postcards</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard was not successfully created (Usually happens when one or more postcards fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n</table>\n\n<h3>Self Mailers</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer was not successfully created (Usually happens when one or more self_mailers fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n</table>\n\n<h3>Letters</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter was not successfully created (Usually happens when one or more letters fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.pickup_available</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Pickup Available\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.issue</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"Issue\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A return envelope is created (occurs simultaneously with letter creation).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Checks</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check was not successfully created (Usually happens when one or more checks fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n</table>\n\n<h3>Addresses</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully deleted.</td>\n  </tr>\n</table>\n\n<h3>Bank Accounts</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.verified</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully verified.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
+                "content": "When various notable things happen within the Lob architecture, Events will be created. To get these events sent to your server\nautomatically when they occur, you can set up [Webhooks](#tag/Webhooks).\n\n<h3>Postcards</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard was not successfully created (Usually happens when one or more postcards fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A postcard receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A postcard QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.informed_delivery.email_sent</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was sent to the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.informed_delivery.email_opened</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was opened by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>postcard.informed_delivery.email_clicked_through</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">The link in an informed delivery email was clicked on. </td>\n  </tr>\n</table>\n\n<h3>Self Mailers</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer was not successfully created (Usually happens when one or more self_mailers fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer receives an \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A self_mailer's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.informed_delivery.email_sent</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was sent to the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.informed_delivery.email_opened</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was opened by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>self_mailer.informed_delivery.email_clicked_through</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">The link in an informed delivery email was clicked on. </td>\n  </tr>\n</table>\n\n<h3>Letters</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter was not successfully created (Usually happens when one or more letters fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.international_exit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A letter receives a \"International Exit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.viewed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A letter's QR code or URL was scanned or viewed by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain\n    <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.pickup_available</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives a \"Pickup Available\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.certified.issue</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A certified letter receives an \"Issue\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A return envelope is created (occurs simultaneously with letter creation).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.return_envelope.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A return envelope receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.informed_delivery.email_sent</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was sent to the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.informed_delivery.email_opened</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was opened by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>letter.informed_delivery.email_clicked_through</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">The link in an informed delivery email was clicked on. </td>\n  </tr>\n</table>\n\n<h3>Checks</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rejected</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check was not successfully created (Usually happens when one or more checks fail the creation step during a batch request)</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_pdf</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's PDF proof is successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.rendered_thumbnails</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check's thumbnails are successfully rendered.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check is successfully canceled.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.mailed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Mailed\" <a href='#operation/tracking_event'>tracking event</a>. Only enabled for certain <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Editions</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_transit</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Transit\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.in_local_area</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives an \"In Local Area\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.processed_for_delivery</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Processed for Delivery\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.delivered</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Delivered\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.failed</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Failed\" <a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/rendering-errors\">rendering error</a> or <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.re-routed</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Re-Routed\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.returned_to_sender</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">A check receives a \"Returned to Sender\" <a href='#operation/tracking_event'>tracking event</a>.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.informed_delivery.email_sent</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was sent to the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.informed_delivery.email_opened</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">An informed delivery email was opened by the recipient. </td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>check.informed_delivery.email_clicked_through</code></td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n    <td style=\"white-space: nowrap\">The link in an informed delivery email was clicked on. </td>\n  </tr>\n</table>\n\n<h3>Addresses</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>address.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">An address is successfully deleted.</td>\n  </tr>\n</table>\n\n<h3>Bank Accounts</h3>\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">EVENT TYPE</th>\n    <th style=\"white-space: nowrap\">LIVE-ONLY</th>\n    <th style=\"white-space: nowrap\">WHEN EVENT TYPE OCCURS</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.created</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully created (Lob returns a 200 status code).</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.deleted</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully deleted.</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>bank_account.verified</code></td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n    <td style=\"white-space: nowrap\">A bank account is successfully verified.</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
                 "type": "text/plain"
             },
             "item": [],
             "event": []
         },
         {
-            "id": "6ff41f01-1e80-454e-b072-38aac628148d",
+            "id": "5165ac50-6af1-49d3-9f9b-0396c5f2c794",
             "name": "Getting Started",
             "description": {
                 "content": "### 1. Get Setup\n* Create an account at <a href=\"https://dashboard.lob.com/#/register\" target=\"_blank\">Lob.com</a>\n* Obtain your API keys in the Lob dashboard <a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">settings</a>\n* You'll use the format, `test_*.` for your Test API key and `live_*.` for your Live API key.\n\n### 2. Explore\n* Try out in Postman:\n<div class=\"postman-run-button\"\ndata-postman-action=\"collection/fork\"\ndata-postman-var-1=\"16169677-975ecb9f-ea22-4d8f-a4f9-53a42f2aee03\"\ndata-postman-collection-url=\"entityId=16169677-975ecb9f-ea22-4d8f-a4f9-53a42f2aee03&entityType=collection&workspaceId=5404d3a5-5a84-4df6-b078-a1547e1a68a7\"\nstyle=\"background:#0099d7;color: white;display: flex;justify-content: center;align-items: center;\">\n  Run in Postman\n</div>\n<script type=\"text/javascript\">\n  (function (p,o,s,t,m,a,n) {\n    !p[s] && (p[s] = function () { (p[t] || (p[t] = [])).push(arguments); });\n    !o.getElementById(s+t) && o.getElementsByTagName(\"head\")[0].appendChild((\n      (n = o.createElement(\"script\")),\n      (n.id = s+t), (n.async = 1), (n.src = m), n\n    ));\n  }(window, document, \"_pm\", \"PostmanRunObject\", \"https://run.pstmn.io/button.js\"));\n</script>\n* Launch your terminal and copy/paste a CURL command.\n```bash\ncurl https://api.lob.com/v1/addresses \\\n  -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc:\n```\n* Download a [Lob SDK](#tag/SDKs-and-Tools) into your favorite IDE (integrated development environment)\n\n### 3. Learn more\nTry our quick start (TypeScript, Python, PHP, Java or Ruby):\n* <a href=\"https://help.lob.com/developer-docs/quickstart-guide\" target=\"_blank\">Send your first Postcards</a>\n\nUse Case guides\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/mass-deletion-setup\" target=\"_blank\">Mass Deletion Setup</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/ncoa-restrictions\" target=\"_blank\">NCOA Restrictions</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/override-cancellation-window\" target=\"_blank\">Override Cancellation Window</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/visibility-of-address-changes\" target=\"_blank\">Visibility of Address Changes</a>\n* <a href=\"https://help.lob.com/developer-docs/use-case-guides/ingesting-tracking-events-with-webhooks\" target=\"_blank\">Ingesting Tracking Events with Webhooks</a>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7746,7 +7786,7 @@
             "event": []
         },
         {
-            "id": "f68e3e0a-1c52-4b20-8ff1-d12dcb564056",
+            "id": "7e85657b-1cbc-41d6-a6d4-ae667ebe0b97",
             "name": "Identity Validation",
             "description": {
                 "content": "Validates whether a given name is associated with an address.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -7754,7 +7794,7 @@
             },
             "item": [
                 {
-                    "id": "ed7fbe5b-6161-4458-b61f-c4eaa9c04243",
+                    "id": "7996f190-4fc8-4339-9445-e94c312a3d70",
                     "name": "Identity Validation",
                     "request": {
                         "name": "Identity Validation",
@@ -7827,7 +7867,7 @@
                     },
                     "response": [
                         {
-                            "id": "88b037fc-c191-4454-8340-ab8c9138b331",
+                            "id": "82c06fc4-faa4-45d3-b192-e1c4f23c87a5",
                             "name": "Returns the likelihood a given name is associated with an address.",
                             "originalRequest": {
                                 "url": {
@@ -7918,7 +7958,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "70e431d2-e062-4f29-8421-8bfe13ccb253",
+                            "id": "0a2024ee-3100-4b1b-b4cd-8206a2ef3865",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8000,7 +8040,7 @@
             "event": []
         },
         {
-            "id": "d153af43-accc-43d8-bf3c-dd1064f23f60",
+            "id": "8e9184c6-9553-485d-9067-174fe7e88b04",
             "name": "Informed Delivery Campaign",
             "description": {
                 "content": "The Informed Delivery campaigns API allows you to create and view Informed Delivery campaigns.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -8008,7 +8048,7 @@
             },
             "item": [
                 {
-                    "id": "c684d816-0052-456a-ba04-b5faebea3a46",
+                    "id": "9bc44a66-30b6-4c7d-b888-3520de21dc5d",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -8037,7 +8077,7 @@
                     },
                     "response": [
                         {
-                            "id": "7c2822b4-ce36-4492-bdbd-ade966d0b465",
+                            "id": "3b7e55c2-7149-40c1-ba4a-7a2d8b66510b",
                             "name": "A dictionary with a data property that contains an array of up to `limit` Informed Delivery campaigns. Each entry in the array is a separate campaign. The previous and next page of campaigns can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more campaigns are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -8079,7 +8119,7 @@
                     "event": []
                 },
                 {
-                    "id": "65377885-2f30-4502-88e6-48920957363d",
+                    "id": "85200b17-8d23-4591-8796-39d6a2076e22",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -8132,7 +8172,7 @@
                                 },
                                 {
                                     "key": "quantity",
-                                    "value": "true",
+                                    "value": "69057983",
                                     "type": "text",
                                     "description": "undefined"
                                 }
@@ -8141,7 +8181,7 @@
                     },
                     "response": [
                         {
-                            "id": "e9ab9f5d-a90b-4619-96da-ea8ca640f588",
+                            "id": "e39d42d1-ca5c-43e1-ae44-01e30144d33d",
                             "name": "Creative created successfully",
                             "originalRequest": {
                                 "url": {
@@ -8201,7 +8241,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "quantity",
-                                            "value": "-30788500.286059335",
+                                            "value": "fugiat in qui do eu",
                                             "type": "text"
                                         }
                                     ]
@@ -8220,7 +8260,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "80cd3eb3-a338-45f7-929b-19c24c559e28",
+                            "id": "b6570323-f4b3-46fc-90bc-497214258b6c",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8280,7 +8320,7 @@
                                                 "type": "text/plain"
                                             },
                                             "key": "quantity",
-                                            "value": "-30788500.286059335",
+                                            "value": "fugiat in qui do eu",
                                             "type": "text"
                                         }
                                     ]
@@ -8305,7 +8345,7 @@
                     }
                 },
                 {
-                    "id": "f0818d2a-cc6e-466a-a63d-a2578deafcdf",
+                    "id": "31f89c46-eccc-4f99-8ea4-5797d9fde457",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -8343,7 +8383,7 @@
                     },
                     "response": [
                         {
-                            "id": "0d4a6bc7-0211-4cc7-92fc-4f625d322baa",
+                            "id": "c4621c53-89b3-49c3-ad59-e544dd968a8e",
                             "name": "Returns a informed delivery campaign object",
                             "originalRequest": {
                                 "url": {
@@ -8391,7 +8431,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bc43fea2-2abf-4e59-b12d-38f40cc6558d",
+                            "id": "d6dcea32-f490-4bcd-9fd5-bb0b2c8d6893",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8442,7 +8482,7 @@
                     "event": []
                 },
                 {
-                    "id": "c4c5ab37-3fd0-4849-9906-558a9232c34b",
+                    "id": "566e8f95-d68f-431f-99fc-9849ef967c65",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -8507,7 +8547,7 @@
                     },
                     "response": [
                         {
-                            "id": "a3250759-2241-4fdf-8440-edc4bd51f14a",
+                            "id": "599f1f2c-96d2-488a-bc2c-576e3f6d0ea6",
                             "name": "Returns an Informed Delivery campaign object",
                             "originalRequest": {
                                 "url": {
@@ -8586,7 +8626,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "262947b8-429c-4ea2-91ab-7d6246dc658b",
+                            "id": "8448011b-39b9-45d5-bd7b-3daa99902ad5",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8665,7 +8705,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d2711845-6e90-4d4e-887b-407dd825a988",
+                            "id": "1c8b6172-852b-4d44-9714-ec6396db87fd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8753,7 +8793,7 @@
             "event": []
         },
         {
-            "id": "29c0d08b-66da-45d8-ae1f-899ab5718f06",
+            "id": "06fce3de-7f35-4711-969c-ad74b59f93b1",
             "name": "Intl Verifications",
             "description": {
                 "content": "Address verification for non-US addresses\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Intl Verifications Test Env\n\nWhen verifying international addresses, you'll likely want to test against\na wide array of addresses to ensure you're handling responses correctly.\nWith your test API key, requests that use specific values for `primary_line`\nlet you explore the responses to many types of addresses:\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">DELIVERABILITY OF SAMPLE RESPONSE</th>\n    <th style=\"white-space: nowrap\">SET <code>primary_line</code> TO</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\">deliverable</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>deliverable_missing_info</code></td>\n    <td style=\"white-space: nowrap\">deliverable missing info</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\">undeliverable</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>no_match</code></td>\n    <td style=\"white-space: nowrap\">no match</td>\n  </tr>\n</table>\n\nSee the `test` request & response examples under [Intl Verification Examples](#operation/intl_verification) within the\n\"Verify an international address section\" in Intl Verifications.\n\nYou can rely on the response from these examples generally matching the response\nyou'd see in the live environment with an address of that type (excluding the `recipient` field).\n\nThe test API key does not perform any verification, automatic correction, or standardization\nfor addresses. If you wish to try these features out, use our <a href=\"https://lob.com/address-verification\" target=\"_blank\">live demo</a>\nor the free plan (see <a href=\"https://lob.com/pricing/address-verification\" target=\"_blank\">our pricing</a> for details).\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -8761,7 +8801,7 @@
             },
             "item": [
                 {
-                    "id": "11eb2ac3-9c11-4ea9-b9ca-a16d63c3a279",
+                    "id": "27c3cf6d-d132-49ca-9d70-061a096e5e8e",
                     "name": "Bulk Verify",
                     "request": {
                         "name": "Bulk Verify",
@@ -8806,7 +8846,7 @@
                     },
                     "response": [
                         {
-                            "id": "ebd8aa65-fb82-4eb5-8978-cae9d3eea295",
+                            "id": "bc54442e-a7da-4c0e-bc33-c12ed5a04838",
                             "name": "Returns an array of international verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -8877,7 +8917,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cc3b6c27-8c16-46c2-bcf1-f78a16cd1541",
+                            "id": "7ae4290c-edbc-4419-8427-86af6bc5b2a4",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -8936,7 +8976,7 @@
                     }
                 },
                 {
-                    "id": "1eed9a5c-67ad-4d55-b7ea-a53504933411",
+                    "id": "615f5d46-7f7c-42e9-86df-39fb99b1ca26",
                     "name": "Single Verify",
                     "request": {
                         "name": "Single Verify",
@@ -9015,7 +9055,7 @@
                     },
                     "response": [
                         {
-                            "id": "bf4df949-de36-4620-87f6-e17df9a60de0",
+                            "id": "59796d90-c20c-4805-aa60-0da5906732c2",
                             "name": "Returns an international verification object.",
                             "originalRequest": {
                                 "url": {
@@ -9117,7 +9157,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0625d015-4121-4cd3-afd1-e548d160ea14",
+                            "id": "07b4294d-4eac-4293-a440-77a32ea143e2",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9210,17 +9250,17 @@
             "event": []
         },
         {
-            "id": "75a6a233-e544-4536-80f1-9afff71bb210",
+            "id": "a70843f9-06e1-4aa9-a57f-27cf12029f59",
             "name": "Introduction",
             "description": {
-                "content": "Lob’s Print & Mail and Address Verification APIs help companies transform outdated,\nmanual print-and-mail processes; save 1,000s of hours in processing time by sending mail much more\nquickly; and increase ROI on offline communications.\n\nAutomate direct mail by triggering on-demand postcards, letters, and checks directly from your\nCRM or customer data systems.\n\nAddress Verification corrects, standardizes, and cleanses address data for assured delivery with\ninstant verification across 240+ countries and territories.\n\nLob's print delivery network eliminates the hassle of vendor management with automated\nproduction and postage across a global network of vetted commercial printers.\n\nTracking & Analytics gives you complete visibility of production and delivery for each piece of\nmail you send to meet compliance requirements and measure campaign performance.\n",
+                "content": "Lob's Print & Mail and Address Verification APIs help companies transform outdated,\nmanual print-and-mail processes; save 1,000s of hours in processing time by sending mail much more\nquickly; and increase ROI on offline communications.\n\nAutomate direct mail by triggering on-demand postcards, letters, and checks directly from your\nCRM or customer data systems.\n\nAddress Verification corrects, standardizes, and cleanses address data for assured delivery with\ninstant verification across 240+ countries and territories.\n\nLob's print delivery network eliminates the hassle of vendor management with automated\nproduction and postage across a global network of vetted commercial printers.\n\nTracking & Analytics gives you complete visibility of production and delivery for each piece of\nmail you send to meet compliance requirements and measure campaign performance.\n",
                 "type": "text/plain"
             },
             "item": [],
             "event": []
         },
         {
-            "id": "b71674b4-2b82-4b9b-99c4-0778603a84ce",
+            "id": "7b2e1292-af4d-49cb-8173-2408f2dc4d40",
             "name": "Letters",
             "description": {
                 "content": "The letters endpoint allows you to easily print and mail letters. The API provides endpoints for\ncreating letters, retrieving individual letters, canceling letters, and retrieving a list of letters.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -9228,7 +9268,7 @@
             },
             "item": [
                 {
-                    "id": "7e24d9ae-333f-44ad-baa3-54cd17afbb4a",
+                    "id": "57372a8f-6ae8-4b19-8e93-b39e37fc9b10",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -9266,7 +9306,7 @@
                     },
                     "response": [
                         {
-                            "id": "6e752193-5ffb-4f1a-b160-6c924a55fe9d",
+                            "id": "cb70463e-dcbd-4006-a3ea-2334c7f9cad4",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -9309,12 +9349,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"ltr_4868c3b754655f90\",\n  \"description\": \"Demo Letter\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"color\": true,\n  \"double_sided\": true,\n  \"address_placement\": \"top_first_page\",\n  \"return_envelope\": false,\n  \"perforated_page\": null,\n  \"custom_envelope\": null,\n  \"extra_service\": null,\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90.pdf?expires=1540372221&signature=8r94fse8uam7wGWmW5baxXulU88X2CA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha\",\n      \"medium\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF\",\n      \"large\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"date_created\": \"2017-09-05T15:54:53.346Z\",\n  \"date_modified\": \"2017-09-05T15:54:53.346Z\",\n  \"send_date\": \"2017-09-05T15:54:53.346Z\",\n  \"cards\": [\n    {\n      \"id\": \"card_c51ae96f5cebf3e\",\n      \"account_id\": \"fa9ea650fc7b31a89f92\",\n      \"description\": null,\n      \"url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e.pdf?version=v1&expires=1636910992&signature=mnsDH2DAxdkN9VibdlLMxJC86sME5WYDqkNtmvGwdNsAaUWfbnv0rJhJ1mR8Ol4uxQq61j5wYZ0r3s-lBkQfDA\",\n      \"size\": \"2.125x3.375\",\n      \"auto_reorder\": false,\n      \"reorder_quantity\": null,\n      \"raw_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"front_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"back_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"thumbnails\": [\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_1.png?version=v1&expires=1636910992&signature=mrv8JDvpZK4I8WUGH0tPdtK-My5oes0Ltj_gL7BDw96SpCTTeZFHkz81SzclyFP9dQRtlsvAsjcuGcTBvCvOCg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_1.png?version=v1&expires=1636910992&signature=VgL_2Ckm_kxKiWGgWtdNoy9HHOn8dGYSVOn7UqyCbwdbVlUtx28TRN4Bo8Iru3n0keKp9He0YhKT1ILotznMDA\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_1.png?version=v1&expires=1636910992&signature=FKSzymA13j-CQ0uk20cGHZTzT3vimzNBYrgp-xifLFg4mMdo1BZALR5O0aF_jVhsX614hKP35ONdYl47TQxXAw\"\n        },\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_2.png?version=v1&expires=1636910992&signature=IWsmPa_ULlv2yyqjX564d_YfHHY_M7i9YxDnw-WXDr2jtOFcArmRZQbnHeE9g_rYxnddJbgosuv8-c2utiu7Cg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_2.png?version=v1&expires=1636910992&signature=zxK7VKGiTvz5Ywrkaydd0v3GcYf58R7A08J4tNfI7-aiNODDcTF3l0MqY13n9Pyc8RXSdD0XVBY-OpbA1VM-Ag\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_2.png?version=v1&expires=1636910992&signature=r0OFUhh315ZwN0raMZdIwJd2oCIEYsz0BABaMxIuO1PKTD0ckGWrhcGdzk2dlWQ6vSvp0CUQ5k1RXGqkIIqkDw\"\n        }\n      ],\n      \"available_quantity\": 10000,\n      \"pending_quantity\": 0,\n      \"countries\": null,\n      \"status\": \"rendered\",\n      \"mode\": \"test\",\n      \"orientation\": \"horizontal\",\n      \"threshold_amount\": 0,\n      \"date_created\": \"2017-08-05T15:54:53.346Z\",\n      \"date_modified\": \"2017-08-05T15:54:53.346Z\",\n      \"object\": \"card\"\n    }\n  ],\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"letter\"\n}",
+                            "body": "{\n  \"id\": \"ltr_4868c3b754655f90\",\n  \"description\": \"Demo Letter\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"color\": true,\n  \"double_sided\": true,\n  \"address_placement\": \"top_first_page\",\n  \"return_envelope\": false,\n  \"perforated_page\": null,\n  \"custom_envelope\": null,\n  \"extra_service\": null,\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90.pdf?expires=1540372221&signature=8r94fse8uam7wGWmW5baxXulU88X2CA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha\",\n      \"medium\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF\",\n      \"large\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"date_created\": \"2017-09-05T15:54:53.346Z\",\n  \"date_modified\": \"2017-09-05T15:54:53.346Z\",\n  \"send_date\": \"2017-09-05T15:54:53.346Z\",\n  \"cards\": [\n    {\n      \"id\": \"card_c51ae96f5cebf3e\",\n      \"account_id\": \"fa9ea650fc7b31a89f92\",\n      \"description\": null,\n      \"url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e.pdf?version=v1&expires=1636910992&signature=mnsDH2DAxdkN9VibdlLMxJC86sME5WYDqkNtmvGwdNsAaUWfbnv0rJhJ1mR8Ol4uxQq61j5wYZ0r3s-lBkQfDA\",\n      \"size\": \"2.125x3.375\",\n      \"auto_reorder\": false,\n      \"reorder_quantity\": null,\n      \"raw_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"front_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"back_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"thumbnails\": [\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_1.png?version=v1&expires=1636910992&signature=mrv8JDvpZK4I8WUGH0tPdtK-My5oes0Ltj_gL7BDw96SpCTTeZFHkz81SzclyFP9dQRtlsvAsjcuGcTBvCvOCg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_1.png?version=v1&expires=1636910992&signature=VgL_2Ckm_kxKiWGgWtdNoy9HHOn8dGYSVOn7UqyCbwdbVlUtx28TRN4Bo8Iru3n0keKp9He0YhKT1ILotznMDA\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_1.png?version=v1&expires=1636910992&signature=FKSzymA13j-CQ0uk20cGHZTzT3vimzNBYrgp-xifLFg4mMdo1BZALR5O0aF_jVhsX614hKP35ONdYl47TQxXAw\"\n        },\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_2.png?version=v1&expires=1636910992&signature=IWsmPa_ULlv2yyqjX564d_YfHHY_M7i9YxDnw-WXDr2jtOFcArmRZQbnHeE9g_rYxnddJbgosuv8-c2utiu7Cg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_2.png?version=v1&expires=1636910992&signature=zxK7VKGiTvz5Ywrkaydd0v3GcYf58R7A08J4tNfI7-aiNODDcTF3l0MqY13n9Pyc8RXSdD0XVBY-OpbA1VM-Ag\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_2.png?version=v1&expires=1636910992&signature=r0OFUhh315ZwN0raMZdIwJd2oCIEYsz0BABaMxIuO1PKTD0ckGWrhcGdzk2dlWQ6vSvp0CUQ5k1RXGqkIIqkDw\"\n        }\n      ],\n      \"available_quantity\": 10000,\n      \"pending_quantity\": 0,\n      \"countries\": null,\n      \"status\": \"rendered\",\n      \"mode\": \"test\",\n      \"orientation\": \"horizontal\",\n      \"threshold_amount\": 0,\n      \"date_created\": \"2017-08-05T15:54:53.346Z\",\n      \"date_modified\": \"2017-08-05T15:54:53.346Z\",\n      \"object\": \"card\"\n    }\n  ],\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"letter\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "dc1db758-027f-4037-9da0-12f11627ab0d",
+                            "id": "b75570ee-d45d-4306-bf0b-0b9c13e09fc7",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9365,7 +9405,7 @@
                     "event": []
                 },
                 {
-                    "id": "562e88ad-617c-4f9b-ad6e-552e83238323",
+                    "id": "886aa1ed-8363-4820-801b-ff1fdc649590",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -9403,7 +9443,7 @@
                     },
                     "response": [
                         {
-                            "id": "80520170-59f7-458d-af77-39480d64a97c",
+                            "id": "4a443e06-c4d1-4756-a4e4-ef27f2e423ec",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -9451,7 +9491,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9bd98005-b5d8-40dd-9acc-b1515821fd60",
+                            "id": "a393913a-a6e4-4d18-a5d1-1037ff58fc46",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9502,7 +9542,7 @@
                     "event": []
                 },
                 {
-                    "id": "8377ecaa-a90e-4897-9752-cbb1363a6473",
+                    "id": "b8585c84-eb39-4fe5-880e-15491620af46",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -9550,19 +9590,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -9622,7 +9656,7 @@
                     },
                     "response": [
                         {
-                            "id": "d1e2cbdb-d0d1-4029-a233-2c4e44777c1a",
+                            "id": "f6a4d71c-5b5b-419b-a732-a5dd952b785d",
                             "name": "A dictionary with a data property that contains an array of up to `limit` letters. Each entry in the array is a separate letter. The previous and next page of letters can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more letters are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -9654,7 +9688,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -9714,7 +9752,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "907e02a0-ee24-4139-8b76-6561664c997e",
+                            "id": "3d045a61-55b4-4f87-8015-c6d894820683",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -9746,7 +9784,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -9809,7 +9851,7 @@
                     "event": []
                 },
                 {
-                    "id": "1118b323-ad7f-483c-8be1-7a2ddcd2efe1",
+                    "id": "c99d57d9-8301-42e7-b6fe-e15e3d981a0d",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -9900,6 +9942,11 @@
                                     "disabled": false,
                                     "key": "value",
                                     "value": "<Error: Too many levels of nesting to fake this schema>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "print_speed",
+                                    "value": "core"
                                 },
                                 {
                                     "disabled": false,
@@ -10006,7 +10053,7 @@
                     },
                     "response": [
                         {
-                            "id": "ccfa3866-20a9-49f6-8195-dc9f5c4a0a5f",
+                            "id": "49374df4-a800-49f2-806f-7ec7b9745bff",
                             "name": "Returns a letter object",
                             "originalRequest": {
                                 "url": {
@@ -10239,6 +10286,11 @@
                                             "disabled": false,
                                             "key": "fsc",
                                             "value": "true"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -10269,12 +10321,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"ltr_4868c3b754655f90\",\n  \"description\": \"Demo Letter\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"color\": true,\n  \"double_sided\": true,\n  \"address_placement\": \"top_first_page\",\n  \"return_envelope\": false,\n  \"perforated_page\": null,\n  \"custom_envelope\": null,\n  \"extra_service\": null,\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90.pdf?expires=1540372221&signature=8r94fse8uam7wGWmW5baxXulU88X2CA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha\",\n      \"medium\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF\",\n      \"large\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"date_created\": \"2017-09-05T15:54:53.346Z\",\n  \"date_modified\": \"2017-09-05T15:54:53.346Z\",\n  \"send_date\": \"2017-09-05T15:54:53.346Z\",\n  \"cards\": [\n    {\n      \"id\": \"card_c51ae96f5cebf3e\",\n      \"account_id\": \"fa9ea650fc7b31a89f92\",\n      \"description\": null,\n      \"url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e.pdf?version=v1&expires=1636910992&signature=mnsDH2DAxdkN9VibdlLMxJC86sME5WYDqkNtmvGwdNsAaUWfbnv0rJhJ1mR8Ol4uxQq61j5wYZ0r3s-lBkQfDA\",\n      \"size\": \"2.125x3.375\",\n      \"auto_reorder\": false,\n      \"reorder_quantity\": null,\n      \"raw_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"front_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"back_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"thumbnails\": [\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_1.png?version=v1&expires=1636910992&signature=mrv8JDvpZK4I8WUGH0tPdtK-My5oes0Ltj_gL7BDw96SpCTTeZFHkz81SzclyFP9dQRtlsvAsjcuGcTBvCvOCg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_1.png?version=v1&expires=1636910992&signature=VgL_2Ckm_kxKiWGgWtdNoy9HHOn8dGYSVOn7UqyCbwdbVlUtx28TRN4Bo8Iru3n0keKp9He0YhKT1ILotznMDA\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_1.png?version=v1&expires=1636910992&signature=FKSzymA13j-CQ0uk20cGHZTzT3vimzNBYrgp-xifLFg4mMdo1BZALR5O0aF_jVhsX614hKP35ONdYl47TQxXAw\"\n        },\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_2.png?version=v1&expires=1636910992&signature=IWsmPa_ULlv2yyqjX564d_YfHHY_M7i9YxDnw-WXDr2jtOFcArmRZQbnHeE9g_rYxnddJbgosuv8-c2utiu7Cg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_2.png?version=v1&expires=1636910992&signature=zxK7VKGiTvz5Ywrkaydd0v3GcYf58R7A08J4tNfI7-aiNODDcTF3l0MqY13n9Pyc8RXSdD0XVBY-OpbA1VM-Ag\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_2.png?version=v1&expires=1636910992&signature=r0OFUhh315ZwN0raMZdIwJd2oCIEYsz0BABaMxIuO1PKTD0ckGWrhcGdzk2dlWQ6vSvp0CUQ5k1RXGqkIIqkDw\"\n        }\n      ],\n      \"available_quantity\": 10000,\n      \"pending_quantity\": 0,\n      \"countries\": null,\n      \"status\": \"rendered\",\n      \"mode\": \"test\",\n      \"orientation\": \"horizontal\",\n      \"threshold_amount\": 0,\n      \"date_created\": \"2017-08-05T15:54:53.346Z\",\n      \"date_modified\": \"2017-08-05T15:54:53.346Z\",\n      \"object\": \"card\"\n    }\n  ],\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"letter\"\n}",
+                            "body": "{\n  \"id\": \"ltr_4868c3b754655f90\",\n  \"description\": \"Demo Letter\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"color\": true,\n  \"double_sided\": true,\n  \"address_placement\": \"top_first_page\",\n  \"return_envelope\": false,\n  \"perforated_page\": null,\n  \"custom_envelope\": null,\n  \"extra_service\": null,\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90.pdf?expires=1540372221&signature=8r94fse8uam7wGWmW5baxXulU88X2CA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_small_1.png?expires=1540372221&signature=a5fRBJ22ZA78Vgpg34M9UfmHWTS3eha\",\n      \"medium\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_medium_1.png?expires=1540372221&signature=bAzL8sv935PY09FWSkpDpWKkyvGSWYF\",\n      \"large\": \"https://lob-assets.com/letters/ltr_4868c3b754655f90_thumb_large_1.png?expires=1540372221&signature=gsKvxXgrm4v4iZD3bOibK7jApNkEMdW\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"expected_delivery_date\": \"2017-09-12\",\n  \"date_created\": \"2017-09-05T15:54:53.346Z\",\n  \"date_modified\": \"2017-09-05T15:54:53.346Z\",\n  \"send_date\": \"2017-09-05T15:54:53.346Z\",\n  \"cards\": [\n    {\n      \"id\": \"card_c51ae96f5cebf3e\",\n      \"account_id\": \"fa9ea650fc7b31a89f92\",\n      \"description\": null,\n      \"url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e.pdf?version=v1&expires=1636910992&signature=mnsDH2DAxdkN9VibdlLMxJC86sME5WYDqkNtmvGwdNsAaUWfbnv0rJhJ1mR8Ol4uxQq61j5wYZ0r3s-lBkQfDA\",\n      \"size\": \"2.125x3.375\",\n      \"auto_reorder\": false,\n      \"reorder_quantity\": null,\n      \"raw_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"front_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"back_original_url\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_raw.pdf?version=v1&expires=1636910992&signature=-bZo31FMAp2vmNaZKyXn_Qa4APqwtNinw76FrQ7uyQejFZw6VBQQYfoiQ642iXh0H2K5i2aOo8_BAkt3UJdVDw\",\n      \"thumbnails\": [\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_1.png?version=v1&expires=1636910992&signature=mrv8JDvpZK4I8WUGH0tPdtK-My5oes0Ltj_gL7BDw96SpCTTeZFHkz81SzclyFP9dQRtlsvAsjcuGcTBvCvOCg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_1.png?version=v1&expires=1636910992&signature=VgL_2Ckm_kxKiWGgWtdNoy9HHOn8dGYSVOn7UqyCbwdbVlUtx28TRN4Bo8Iru3n0keKp9He0YhKT1ILotznMDA\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_1.png?version=v1&expires=1636910992&signature=FKSzymA13j-CQ0uk20cGHZTzT3vimzNBYrgp-xifLFg4mMdo1BZALR5O0aF_jVhsX614hKP35ONdYl47TQxXAw\"\n        },\n        {\n          \"small\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_small_2.png?version=v1&expires=1636910992&signature=IWsmPa_ULlv2yyqjX564d_YfHHY_M7i9YxDnw-WXDr2jtOFcArmRZQbnHeE9g_rYxnddJbgosuv8-c2utiu7Cg\",\n          \"medium\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_medium_2.png?version=v1&expires=1636910992&signature=zxK7VKGiTvz5Ywrkaydd0v3GcYf58R7A08J4tNfI7-aiNODDcTF3l0MqY13n9Pyc8RXSdD0XVBY-OpbA1VM-Ag\",\n          \"large\": \"https://lob-assets.com/cards/card_c51ae96f5cebf3e_thumb_large_2.png?version=v1&expires=1636910992&signature=r0OFUhh315ZwN0raMZdIwJd2oCIEYsz0BABaMxIuO1PKTD0ckGWrhcGdzk2dlWQ6vSvp0CUQ5k1RXGqkIIqkDw\"\n        }\n      ],\n      \"available_quantity\": 10000,\n      \"pending_quantity\": 0,\n      \"countries\": null,\n      \"status\": \"rendered\",\n      \"mode\": \"test\",\n      \"orientation\": \"horizontal\",\n      \"threshold_amount\": 0,\n      \"date_created\": \"2017-08-05T15:54:53.346Z\",\n      \"date_modified\": \"2017-08-05T15:54:53.346Z\",\n      \"object\": \"card\"\n    }\n  ],\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"letter\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f799282e-b837-402e-b1f1-37f04fdadb85",
+                            "id": "389065cd-79f3-4b06-97b6-03a3c2b620f6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10507,6 +10559,11 @@
                                             "disabled": false,
                                             "key": "fsc",
                                             "value": "true"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -10533,7 +10590,7 @@
             "event": []
         },
         {
-            "id": "11b29311-03bf-4123-a358-39f2323ea96a",
+            "id": "66798446-9ddf-464f-aeb2-b52535efa42f",
             "name": "Manage Mail",
             "description": {
                 "content": "## Cancellation Windows\n\nBy default, all new accounts have a 5 minute cancellation window for postcards,\nself mailers, letters, and checks. Within that timeframe, you can cancel\nmailings from production, free of charge. Once the window has passed for a\npostcard, self mailer, letter, or check, the mailing is no longer cancelable.\nIn addition, certain customers can customize their cancellation windows by\nproduct in their <a href=\"https://dashboard.lob.com/#\" target=\"_blank\">Dashboard Settings</a>. Upgrade to\nthe appropriate <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>\nto automatically gain access to this ability. For more details on this feature,\ncheck out our <a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#cancellation-windows-4\" target=\"_blank\">Cancellation Guide</a>.\n\nIf you schedule a postcard, self mailer, letter, or check for up to 180 days\nin the future by supplying the `send_date` parameter, that will override any\ncancellation window you may have for that product.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Scheduled Mailings\n\nPostcards, self mailers, letters, and checks can be scheduled to be sent up\nto 180 days in advance. You can use this feature to:\n- Create automated drip campaigns (e.g. send a postcard at 15, 30, and 60\ndays)\n- Schedule recurring sends\n- Plan your mailing schedule ahead of time\n\nUp until the time a mailing is scheduled for, it can also be canceled.\nIf you use this feature in conjunction with [a cancellation window](\nindex.html#section/Cancellation-Windows), the `send_date` parameter will always\ntake precedence.\n\nFor implementation details, see documentation below for each respective\nendpoint. For more help, see our <a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/choosing-a-delivery-strategy#scheduled-mailings-15\" target=\"_blank\">Scheduled Mailings Guide</a>.\n\nThis feature is exclusive to certain customers. Upgrade to the appropriate\n<a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a> to\ngain access.\n\n### Example Create Request using Send Date\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Future Postcard\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    -d \"front=tmpl_b846a20859ae11a\" \\\n    -d \"back=tmpl_01b0d396a10c268\" \\\n    -d \"merge_variables[name]=Harry\" \\\n    -d \"send_date=2021-07-26\"\n```\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -10543,7 +10600,7 @@
             "event": []
         },
         {
-            "id": "fab8e42f-4200-4926-b895-21477facb0af",
+            "id": "cee3323b-d99c-4f75-a3bb-853330a57284",
             "name": "National Change of Address",
             "description": {
                 "content": "National Change of Address Linkage (NCOALink) is a service offered by the USPS, which allows individuals\nor businesses who have recently moved to have any mail forwarded from their previous address\nto their new address.\n\nAs a CASS-certified Address Verification Provider, Lob also offers NCOALink\nfunctionality to our Print & Mail customers. With the Lob NCOALink feature enabled, Postcards,\nLetters, Checks and Addresses can automatically be corrected to reflect an individual's or business's\nnew address in the case that they have moved (only if they have registered for NCOALink with the USPS).\n\nDue to privacy concerns and USPS constraints, for customers with NCOALink enabled, our API responses\nfor a limited set of endpoints differ slightly in the case when an address has been changed through NCOALink.\n\n**NOTE**: This feature is exclusive to certain customers. Upgrade to the appropriate <a href='https://dashboard.lob.com/#/settings/editions' target=\"_blank\">Print & Mail Editions</a> to gain access.\n\nFor more information, see our <a href=\"https://help.lob.com/print-and-mail/all-about-addresses#national-change-of-address-ncoa-7\" target=\"_blank\">NCOALink guide</a>.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## NCOALink Live Environment\nThough there are no changes to API requests, there are significant changes to our API responses, but\nonly in the event that an address has been changed through NCOALink. If an address has not been changed\nthrough NCOALink, the response would be identical to our standard responses, except the addition of a\n`recipient_moved` field, which is `false` for unchanged addresses.\n\nIf an address has been changed through NCOALink, we are required to suppress the following response\nfields for that address:\n- `address_line1`\n- `address_line2`\n- The +4 portion of the ZIP+4 (5-digit ZIP code will still be present)\n\nSee the `ncoa_us_live` example under [Response samples](#operation/address_create) within the \"Create an Address\" section in Addresses\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## NCOALink Test Environment\n\nIn addition to sending live requests, you may also want to simulate what an NCOALink response might\nlook like so that you can ensure your application behaves as expected. The behavior of NCOALink in\nLob's Test Environment is very similar to our [US Verifications Test Mode](#section/US-Verifications-Test-Env).\n\nTo simulate an NCOALink request, send a POST request to any of the four endpoints below with an `address_line1` field equal to `NCOA`:\n- `POST /v1/addresses`\n- `POST /v1/checks`\n- `POST /v1/letters`\n- `POST /v1/postcards`\n- `POST /v1/self_mailers`\n\nA static address will always be returned, as documented in the `ncoa_us_test` example under [Response samples](#operation/address_create) within the \"Create an Address\"\nsection in Addresses (along with the corresponding request under \"Request samples\").\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -10553,7 +10610,7 @@
             "event": []
         },
         {
-            "id": "4b45795a-85df-4459-9ab6-ffdc9662e130",
+            "id": "a384bd4d-2a0a-4425-bd9a-8ebc22de32b1",
             "name": "Postcards",
             "description": {
                 "content": "The postcards endpoint allows you to easily print and mail postcards. The API provides endpoints for creating postcards,\nretrieving individual postcards, canceling postcards, and retrieving a list of postcards.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -10561,7 +10618,7 @@
             },
             "item": [
                 {
-                    "id": "4c11fac7-61f3-477a-9022-697b9a4d28cb",
+                    "id": "785d710a-58f3-4ec3-9fd9-45484f7d44ed",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -10599,7 +10656,7 @@
                     },
                     "response": [
                         {
-                            "id": "69bfaa17-d8da-4cd4-bb33-dd92e125ec45",
+                            "id": "8e28a14f-2653-41e2-bc00-f5130c79f7b3",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -10642,12 +10699,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"psc_208e45e48d271294\",\n  \"description\": null,\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": null,\n    \"company\": \"LOB\",\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:01:07.651Z\",\n    \"date_modified\": \"2018-12-08T03:01:07.651Z\",\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA\",\n  \"carrier\": \"USPS\",\n  \"front_template_id\": null,\n  \"back_template_id\": null,\n  \"date_created\": \"2021-03-24T22:51:42.838Z\",\n  \"date_modified\": \"2021-03-24T22:51:42.838Z\",\n  \"send_date\": \"2021-03-24T22:51:42.838Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"postcard\"\n}",
+                            "body": "{\n  \"id\": \"psc_208e45e48d271294\",\n  \"description\": null,\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": null,\n    \"company\": \"LOB\",\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:01:07.651Z\",\n    \"date_modified\": \"2018-12-08T03:01:07.651Z\",\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA\",\n  \"carrier\": \"USPS\",\n  \"front_template_id\": null,\n  \"back_template_id\": null,\n  \"date_created\": \"2021-03-24T22:51:42.838Z\",\n  \"date_modified\": \"2021-03-24T22:51:42.838Z\",\n  \"send_date\": \"2021-03-24T22:51:42.838Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"postcard\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1084b592-5dda-414e-aff4-d87ba52e50c1",
+                            "id": "3771306b-8c14-427e-b551-e0d6c14192b1",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10698,7 +10755,7 @@
                     "event": []
                 },
                 {
-                    "id": "597db022-f03a-403f-b561-2142de986780",
+                    "id": "073629de-3ac4-43a4-be37-14165481a7bb",
                     "name": "Cancel",
                     "request": {
                         "name": "Cancel",
@@ -10736,7 +10793,7 @@
                     },
                     "response": [
                         {
-                            "id": "b1d02105-ae48-4b7a-aa06-872b8cae69ff",
+                            "id": "6730fd13-e59b-4027-84bc-579c9914eace",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -10784,7 +10841,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "087a0ccb-9963-4e51-9b63-e061e5da15a5",
+                            "id": "b7ce0378-6ace-4b83-8ec3-c326e7c04261",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -10835,7 +10892,7 @@
                     "event": []
                 },
                 {
-                    "id": "58fdb87e-5554-4499-b934-7597c73fd031",
+                    "id": "0de25447-c581-4d3b-9adc-0868e95a3d31",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -10883,19 +10940,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -10961,7 +11012,7 @@
                     },
                     "response": [
                         {
-                            "id": "cb2ae293-4b3f-4e0d-a4dd-7020b2753de5",
+                            "id": "38eb4849-ef62-4a94-b603-cbb38043818c",
                             "name": "A dictionary with a data property that contains an array of up to `limit` postcards. Each entry in the array is a separate postcard. The previous and next page of postcards can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more postcards are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -10993,7 +11044,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -11057,7 +11112,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f6505dc1-cf91-4fc8-9186-3c3d057481c3",
+                            "id": "b424da43-95f2-4895-9f76-697ad34f1b56",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11089,7 +11144,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -11156,7 +11215,7 @@
                     "event": []
                 },
                 {
-                    "id": "90c73afb-73c2-46d3-9c50-400d8da8ba4b",
+                    "id": "f894e749-804c-41eb-bf80-aad51b2106a5",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -11249,6 +11308,11 @@
                                 },
                                 {
                                     "disabled": false,
+                                    "key": "print_speed",
+                                    "value": "core"
+                                },
+                                {
+                                    "disabled": false,
                                     "key": "value",
                                     "value": "<Error: Too many levels of nesting to fake this schema>"
                                 },
@@ -11322,7 +11386,7 @@
                     },
                     "response": [
                         {
-                            "id": "1544be0c-5089-48d2-90c6-599e12b1db3b",
+                            "id": "692e44ec-ba46-47a5-9bfe-e0719cafdacd",
                             "name": "Returns a postcard object",
                             "originalRequest": {
                                 "url": {
@@ -11549,6 +11613,11 @@
                                             "disabled": false,
                                             "key": "fsc",
                                             "value": "true"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -11579,12 +11648,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"psc_208e45e48d271294\",\n  \"description\": null,\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": null,\n    \"company\": \"LOB\",\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:01:07.651Z\",\n    \"date_modified\": \"2018-12-08T03:01:07.651Z\",\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA\",\n  \"carrier\": \"USPS\",\n  \"front_template_id\": null,\n  \"back_template_id\": null,\n  \"date_created\": \"2021-03-24T22:51:42.838Z\",\n  \"date_modified\": \"2021-03-24T22:51:42.838Z\",\n  \"send_date\": \"2021-03-24T22:51:42.838Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"postcard\"\n}",
+                            "body": "{\n  \"id\": \"psc_208e45e48d271294\",\n  \"description\": null,\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": null,\n    \"company\": \"LOB\",\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2018-12-08T03:01:07.651Z\",\n    \"date_modified\": \"2018-12-08T03:01:07.651Z\",\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/postcards/psc_208e45e48d271294.pdf?version=v1&expires=1619218302&signature=NfHHLBSr5tOHA_Z4kij4dKqZG8f3vMDtwvuFVeeF9pV_lylcjLsVVODhNCE5hR6-2slUr6t9WMNsi429Pj7_DA\",\n  \"carrier\": \"USPS\",\n  \"front_template_id\": null,\n  \"back_template_id\": null,\n  \"date_created\": \"2021-03-24T22:51:42.838Z\",\n  \"date_modified\": \"2021-03-24T22:51:42.838Z\",\n  \"send_date\": \"2021-03-24T22:51:42.838Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"postcard\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "95c767ea-e4a4-412b-9af4-bc38179399e0",
+                            "id": "792c73fd-0ba0-4053-969a-1ffd97dbe47e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -11811,6 +11880,11 @@
                                             "disabled": false,
                                             "key": "fsc",
                                             "value": "true"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -11837,7 +11911,7 @@
             "event": []
         },
         {
-            "id": "8b6daed6-c8a4-4970-8211-8aea65c12718",
+            "id": "b321cc12-f85d-49bc-abed-7fdddbeef783",
             "name": "QR Codes",
             "description": {
                 "content": "\nLob QR codes allow you to generate a QR code that is unique to each mailpiece, thereby allowing each and every customers to receive a personalized link. See the Create endpoint for <a href=\"#tag/Letters/operation/letter_create\">Letters</a>, <a href=\"#tag/Postcards/operation/postcard_create\">Postcards</a> or <a href=\"#tag/Self-Mailers/operation/self_mailer_create\">Self Mailers</a> to learn how to embed a QR code into your mail piece.\n\nWebhooks can be used to integrate Lob QR code scans into your omni channel marketing strategy. See the <a href=\"#tag/Webhooks\">Webhooks</a> section of our documentation to learn how to enable the `letter.viewed`, `postcard.viewed` and `self_mailer.viewed` event notifications for your mail pieces.\n\nFurthermore, our QR code Analytics endpoint can be used to track the impact and engagement rate of your mail sends. Lob can tell you exactly which recipients opened your mailpiece. Our Analytics endpoint allows you to see exactly which recipient scanned a mailpiece, when they scanned it, and more!\n\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -11845,7 +11919,7 @@
             },
             "item": [
                 {
-                    "id": "e0a244af-dd60-4ead-88ac-b4e0564550cd",
+                    "id": "288f83da-c46a-4533-a94b-69d46f841e9d",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -11887,19 +11961,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -11923,7 +11991,7 @@
                     },
                     "response": [
                         {
-                            "id": "02028ec1-adc4-4d1b-81d5-63188e00a962",
+                            "id": "00d25086-79ea-4009-aaed-40ab3b75de6c",
                             "name": "Returns a list of QR Codes and their analytics.",
                             "originalRequest": {
                                 "url": {
@@ -11951,7 +12019,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -11993,7 +12065,7 @@
             "event": []
         },
         {
-            "id": "bcf933c0-a243-4e45-b5a9-b2d3719c5188",
+            "id": "ba4e32f7-eb7a-4e87-8f4c-f77cd2d7359b",
             "name": "Rate Limiting",
             "description": {
                 "content": "To prevent misuse, we enforce a rate limit on an API Key and endpoint basis, similar to the way many other APIs enforce rate limits. By default, all accounts and their corresponding Test and Live API Keys have a rate limit of 150 requests per 5 seconds per endpoint. The `POST /v1/us_verifications` and `POST /v1/us_autocompletions` endpoints have a limit of 300 requests per 5 seconds for all accounts.\n\nWhen your application exceeds the rate limit for a given API endpoint, the Lob API will return an HTTP 429 \"Too Many Requests\" response code instead of the variety of codes you would find across the other API endpoints.\n\n**HTTP Headers**\n\nHTTP headers are returned on each request to a rate limited endpoint. Ensure that you inspect these headers during your requests as they provide relevant data on how many more requests your application is allowed to make for the endpoint you just utilized.\n\nWhile the headers are documented here in titlecase, HTTP headers are case insensitive and certain libraries may transform them to lowercase. Please inspect your headers carefully to see how they will be represented in your chosen development scenario.\n<table>\n  <tbody>\n    <tr>\n      <td>X-Rate-Limit-Limit:</td>\n      <td>the rate limit ceiling for a given request</td>\n    </tr>\n    <tr>\n      <td>X-Rate-Limit-Remaining:</td>\n      <td>the number of requests remaining in this window</td>\n    </tr>\n    <tr>\n      <td>X-Rate-Limit-Reset:</td>\n      <td>the time at which the rate limit window resets (in <a  href=\"https://en.wikipedia.org/wiki/Unix_time\"  target=\"_blank\">UTC epoch seconds</a>)\n    </td>\n    </tr>\n  </tbody>\n</table>\n\n### Example HTTP Headers\n\n```bash\n  X-Rate-Limit-Limit:150\n  X-Rate-Limit-Remaining:100\n  X-Rate-Limit-Reset:1528749846\n```\n\n### Example Response\n\nIf you hit the rate limit on a given endpoint, this is the body of the HTTP 429 message that you will see:\n\n```javascript\n  {\n    \"error\": {\n      \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n      \"code\": \"rate_limit_exceeded\",\n      \"status_code\": 429\n    }\n  }\n``` <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>",
@@ -12003,7 +12075,7 @@
             "event": []
         },
         {
-            "id": "815f8825-96e9-4535-a627-37d4125b015e",
+            "id": "167cceed-dfa1-44cc-a7c5-f5a327af7e1a",
             "name": "Requests and Responses",
             "description": {
                 "content": "## Asset URLs\n\nAll asset URLs returned by the Lob API (postcards, letters, thumbnails,\netc) are signed links served over HTTPS. All links returned will expire in\n30 days to prevent mis-sharing. Each time a GET request is initiated, a\nnew signed URL will be generated.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Query Parameters\n\nQuery parameters which consist of lists of strings require that all elements of\nthe list be double-quoted, as per query filter standards.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Idempotent Requests\n\nLob supports idempotency for safely retrying `POST` requests to create\npostcards, self mailers, letters, and checks without accidentally creating\nduplicates.\n\nFor example, if a request to create a check fails due to a network error,\nyou can safely retry the same request with the same idempotency key and\nguarantee that only one check will ultimately be created and sent. When a\nrequest is sent with an idempotency key for an already created resource,\nthe response object for the existing resource will be returned.\n\nTo perform an idempotent `POST` request to one of the mailpiece product\nendpoints, provide an additional `Idempotency-Key` header or an `idempotency_key`\nquery parameter to the request. If multiple idempotency keys are provided,\nthe request will fail. How you create unique keys is up to you, but we\nsuggest using random values, such as V4 UUIDs. Idempotency keys are intended\nto prevent issues over a short periods of time, therefore keys expire after\n24 hours. Keys are unique by mode (Test vs. Live) as well as by resource\n(postcard vs. letter, etc.).\n\nBy default, all `GET` and `DELETE` requests are idempotent by nature, so\nthey do not require an additional idempotency key.\n\nFor more help integrating idempotency keys, refer to our\n<a href=\"https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#idempotent-requests-12\" target=\"_blank\">implementation guide</a>.\n\n**Headers**\n<table>\n  <tbody>\n    <tr>\n      <td>Idempotency-Key:</td>\n      <td>\n        optional\n        <p style=\"color:#888;margin-top:0px;\">\n          <font size=\"-1\">\n            A string of no longer than 256 characters\n            that uniquely identifies this resource.\n          </font>\n        </p>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n**Query Parameters**\n<table>\n  <tbody>\n    <tr>\n      <td>idempotency-key:</td>\n      <td>\n        optional\n        <p style=\"color:#888;margin-top:0px;\">\n          <font size=\"-1\">\n            A string of no longer than 256 characters\n            that uniquely identifies this resource.\n          </font>\n        </p>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n### Example Request\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -H \"Idempotency-Key: 026e7634-24d7-486c-a0bb-4a17fd0eebc5\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    --data-urlencode \"front=<html style='margin: 130px; font-size: 50;'>Front HTML for {{name}}</html>\" \\\n    --data-urlencode \"back=<html style='margin: 130px; font-size: 50;'>Back HTML</html>\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Metadata\n\nWhen creating any Lob object, you can include a metadata object with up to 20 key-value pairs of\ncustom data. You can use metadata to store information like `metadata[customer_id] = \"987654\"` or\n`metadata[campaign] = \"NEWYORK2015\"`. This is especially useful for filtering and matching to internal\nsystems.\n\nEach metadata key must be less than 40 characters long and values must be less than 500 characters.\nMetadata does not support nested objects.\n\n### Example Create Request with Metadata\n\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Postcard job\" \\\n    -d \"metadata[campaign]=NEWYORK2015\" \\\n    -d \"to=adr_bae820679f3f536b\" \\\n    -d \"from=adr_210a8d4b0b76d77b\" \\\n    --data-urlencode \"front=<html style='margin: 130px; font-size: 50;'>Front HTML for {{name}}</html>\" \\\n    --data-urlencode \"back=<html style='margin: 130px; font-size: 50;'>Back HTML</html>\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n\n### Example List Request with Metadata Filter\n\n```bash\n  curl -g \"https://api.lob.com/v1/postcards?metadata[campaign]=NEWYORK2015&limit=2\" \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc:\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n\n## Request Body\n\nWhen manually sending a POST HTTP request directly to the Lob API, without\nthe use of a library, you may represent the body as either a Form URL\nEncoded request, a JSON document, or a Multipart Form Data request.\n\nHowever, if you're using one of our [SDKs](#tag/SDKs-and-Tools),\nthe generation of the request bodies is done for you automatically and you don't\nneed to worry about the format.\n\nFor fields that are intended to accept only string values, submitting JSON objects in string format (stringified JSON objects) is not supported. \nOur system automatically parses and validates incoming data according to their expected types. \nAs a result, providing a stringified JSON object in a field designated for string input can cause parsing errors or lead to unexpected validation results.\n\n### Form URL Encoded\n\nThis request body encoding is accompanied with the\n`Content-Type: application/x-www-form-urlencoded` header. The content is an\nexample of what the [Verify a US address](index.html#operation/us_verification)\nendpoint accepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  primary_line=210 King Street&city=San Francisco&state=CA&zip_code=94107\n```\n\n### JSON\n\nThis request body encoding is accompanied with the `Content-Type: application/json` header.\nThe content is an example of what the [Verify a US address endpoint](index.html#operation/us_verification)\naccepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  {\n    \"primary_line\": \"210 King Street\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"zip_code\": \"94107\"\n  }\n```\n\n### Multipart Form Data\n\nThis request body encoding is accompanied with the `Content-Type: multipart/form-data`\nheader. This is the only format that can be used for uploading a file to the API. The\ncontent is an example of what the [Create a check](index.html#operation/check_create)\nendpoint accepts. An example of a request body encoded in this format follows.\n\n\n```javascript\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"description\"\n\n  Demo Letter\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"to\"\n\n  adr_bae820679f3f536b\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"from\"\n\n  adr_210a8d4b0b76d77b\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"file\"; filename=\"file.pdf\"\n  Content-Type: application/pdf\n\n  <FILE CONTENT>\n  --------------------------7015ebe79c0a5f8c\n  Content-Disposition: form-data; name=\"color\"\n\n  true\n  --------------------------7015ebe79c0a5f8c--\n```\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12013,7 +12085,484 @@
             "event": []
         },
         {
-            "id": "7e44d9bb-2c9f-4844-bcc0-28b0347cf3ba",
+            "id": "aeefdf69-8d1e-4a40-a0f1-feb1e249aa72",
+            "name": "Resource Proofs",
+            "description": {
+                "content": "The resource proofs endpoint allows you to create a final rendering of any template. This is best practice to ensure that you are visually validating your creative before any mail pieces use the template. The API provides endpoints for creating, updating, and retrieving template proofs.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
+                "type": "text/plain"
+            },
+            "item": [
+                {
+                    "id": "a03063ac-464a-40b4-a922-4fa0062d0f71",
+                    "name": "Retrieve",
+                    "request": {
+                        "name": "Retrieve",
+                        "description": {
+                            "content": "Retrieves the details of an existing resource proof. You need only supply the unique resource proof identifier.",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "resource_proofs",
+                                ":res_prf_id"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": [
+                                {
+                                    "disabled": false,
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "res_prf_id",
+                                    "description": "(Required) id of the resource proof"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "42b9d883-4534-4de5-9323-f9001e8421b8",
+                            "name": "Returns a resource proof object",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "resource_proofs",
+                                        ":res_prf_id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "disabled": false,
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "res_prf_id",
+                                            "description": "(Required) id of the resource proof"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: basic",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Basic <credentials>"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"id\": \"res_prf_example123\",\n  \"template_id\": null,\n  \"resource_type\": \"postcard\",\n  \"status\": \"completed\",\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_small_1.png\",\n      \"medium\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_medium_1.png\",\n      \"large\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_large_1.png\"\n    }\n  ],\n  \"url\": \"https://lob-assets.com/resource-proofs/res_prf_example123.pdf\",\n  \"errors\": [],\n  \"date_created\": \"2017-11-07T22:56:10.962Z\",\n  \"date_modified\": \"2017-11-07T22:56:10.962Z\",\n  \"object\": \"resource_proof\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "ba36b587-9961-45ea-83dc-3a5eebeac8b3",
+                            "name": "Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "resource_proofs",
+                                        ":res_prf_id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "disabled": false,
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "res_prf_id",
+                                            "description": "(Required) id of the resource proof"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: basic",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Basic <credentials>"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"not_found\",\n    \"message\": \"to address not found\",\n    \"status_code\": 404\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": []
+                },
+                {
+                    "id": "505ba842-2f2b-4906-8c04-fb66c9985bde",
+                    "name": "Update",
+                    "request": {
+                        "name": "Update",
+                        "description": {
+                            "content": "Updates the specified resource proof.",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "resource_proofs",
+                                ":res_prf_id"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": [
+                                {
+                                    "disabled": false,
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "res_prf_id",
+                                    "description": "(Required) id of the resource proof"
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "PATCH",
+                        "auth": null,
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"template_id\": \"<string>\"\n}",
+                            "options": {
+                                "raw": {
+                                    "language": "json"
+                                }
+                            }
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "db4ef691-2cdb-44b0-826a-1365f6c07841",
+                            "name": "Returns an updated resource proof object",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "resource_proofs",
+                                        ":res_prf_id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "disabled": false,
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "res_prf_id",
+                                            "description": "(Required) id of the resource proof"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: basic",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Basic <credentials>"
+                                    }
+                                ],
+                                "method": "PATCH",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"template_id\": \"tmpl_a1234dddg\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"id\": \"res_prf_example123\",\n  \"template_id\": null,\n  \"resource_type\": \"postcard\",\n  \"status\": \"completed\",\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_small_1.png\",\n      \"medium\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_medium_1.png\",\n      \"large\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_large_1.png\"\n    }\n  ],\n  \"url\": \"https://lob-assets.com/resource-proofs/res_prf_example123.pdf\",\n  \"errors\": [],\n  \"date_created\": \"2017-11-07T22:56:10.962Z\",\n  \"date_modified\": \"2017-11-07T22:56:10.962Z\",\n  \"object\": \"resource_proof\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9b90bf27-aef0-478e-9c8a-23d79f0b3353",
+                            "name": "Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "resource_proofs",
+                                        ":res_prf_id"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": [
+                                        {
+                                            "disabled": false,
+                                            "type": "any",
+                                            "value": "<string>",
+                                            "key": "res_prf_id",
+                                            "description": "(Required) id of the resource proof"
+                                        }
+                                    ]
+                                },
+                                "header": [
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: basic",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Basic <credentials>"
+                                    }
+                                ],
+                                "method": "PATCH",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"template_id\": \"tmpl_a1234dddg\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"not_found\",\n    \"message\": \"to address not found\",\n    \"status_code\": 404\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "902fe38f-7242-40db-99b8-e4be039e4c71",
+                    "name": "Create",
+                    "request": {
+                        "name": "Create",
+                        "description": {
+                            "content": "Creates a new resource proof with the provided properties.",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "resource_proofs"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "auth": null,
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"template_id\": \"<string>\",\n  \"resource_type\": \"<string>\",\n  \"resource_parameters\": {\n    \"front\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"back\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"size\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"merge_variables\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n  }\n}",
+                            "options": {
+                                "raw": {
+                                    "language": "json"
+                                }
+                            }
+                        }
+                    },
+                    "response": [
+                        {
+                            "id": "3ce98b5a-3fa0-40d7-a0c2-68e8084dbd14",
+                            "name": "Returns a resource proof object",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "resource_proofs"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: basic",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Basic <credentials>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"resource_type\": \"postcard\",\n  \"resource_parameters\": {\n    \"front\": \"tmpl_a1234dddg\",\n    \"back\": \"tmpl_a1234dddg\",\n    \"to\": \"adr_a1234dddg\"\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Created",
+                            "code": 201,
+                            "header": [
+                                {
+                                    "disabled": false,
+                                    "description": "The rate limit for a given endpoint.",
+                                    "key": "ratelimit-limit",
+                                    "value": "150"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": "The number of requests remaining in the current window.",
+                                    "key": "ratelimit-remaining",
+                                    "value": "100"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": "The time at which the rate limit window resets in  <a href=\"https://en.wikipedia.org/wiki/Unix_time\" target=\"_blank\">UTC epoch seconds</a>\n",
+                                    "key": "ratelimit-reset",
+                                    "value": "1528749846"
+                                },
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"id\": \"res_prf_example123\",\n  \"template_id\": null,\n  \"resource_type\": \"postcard\",\n  \"status\": \"completed\",\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_small_1.png\",\n      \"medium\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_medium_1.png\",\n      \"large\": \"https://lob-assets.com/resource-proofs/res_prf_example123_thumb_large_1.png\"\n    }\n  ],\n  \"url\": \"https://lob-assets.com/resource-proofs/res_prf_example123.pdf\",\n  \"errors\": [],\n  \"date_created\": \"2017-11-07T22:56:10.962Z\",\n  \"date_modified\": \"2017-11-07T22:56:10.962Z\",\n  \"object\": \"resource_proof\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d2e2fbd9-b636-4330-a4a8-87acd0ec913f",
+                            "name": "Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "resource_proofs"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: basic",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Basic <credentials>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"resource_type\": \"postcard\",\n  \"resource_parameters\": {\n    \"front\": \"tmpl_a1234dddg\",\n    \"back\": \"tmpl_a1234dddg\",\n    \"to\": \"adr_a1234dddg\"\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"not_found\",\n    \"message\": \"to address not found\",\n    \"status_code\": 404\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ],
+            "event": []
+        },
+        {
+            "id": "37d4ac6b-373b-4f85-87a0-07fbab1dd43e",
             "name": "Reverse Geocode Lookups",
             "description": {
                 "content": "Find a list of zip codes associated with a valid US location via latitude and longitude. <br> <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12021,7 +12570,7 @@
             },
             "item": [
                 {
-                    "id": "094e5456-bba1-4d66-b77d-ed5f57fb92b3",
+                    "id": "d7600f2c-9c7e-4273-8327-3b65b672180d",
                     "name": "Reverse Geocode Lookup",
                     "request": {
                         "name": "Reverse Geocode Lookup",
@@ -12078,7 +12627,7 @@
                     },
                     "response": [
                         {
-                            "id": "4bfb9e12-9ebf-4678-8025-8cc9b97203c9",
+                            "id": "2172e926-ed6d-400d-a638-bcb89c7a5eaf",
                             "name": "Returns a zip lookup object if a valid zip was provided.",
                             "originalRequest": {
                                 "url": {
@@ -12162,7 +12711,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "da7e4f97-b0f3-412b-a39c-2b4d27625e38",
+                            "id": "a79a52a7-f02c-435a-8c3e-9df5b3b81ca9",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12237,7 +12786,7 @@
             "event": []
         },
         {
-            "id": "f9677e41-f8de-4ff9-a879-5f3c4965da9e",
+            "id": "551ca4c0-05a2-432c-9862-ac33f9d5e070",
             "name": "SDKs and Tools",
             "description": {
                 "content": "Please visit our <a href=\"https://www.github.com/lob\" target=\"_blank\">Github</a> for a list of our supported libraries.\n- <a href=\"https://github.com/lob/lob-typescript-sdk\" target=\"_blank\">Typescript</a>\n- <a href=\"https://github.com/lob/lob-php\" target=\"_blank\">PHP</a>\n- <a href=\"https://github.com/lob/lob-python\" target=\"_blank\">Python</a>\n- <a href=\"https://github.com/lob/lob-java\" target=\"_blank\">Java</a>\n- <a href=\"https://github.com/lob/lob-ruby/tree/main\" target=\"_blank\">Ruby</a>\n- <a href=\"https://github.com/lob/lob-dotnet\" target=\"_blank\">CSharp</a>\n- <a href=\"https://github.com/lob/lob-elixir\" target=\"_blank\">Elixir</a>\n- <a href=\"https://github.com/lob/lob-go\" target=\"_blank\">Go</a>\n- <a href=\"https://github.com/lob/lob-node\" target=\"_blank\">Node.js (legacy)</a>\n- <a href=\"https://github.com/lob/lob-java/tree/12.3.7-Legacy\" target=\"_blank\">Java (legacy)</a>\n- <a href=\"https://github.com/lob/lob-php/tree/v3-legacy\" target=\"_blank\">PHP (legacy)</a>\n- <a href=\"https://github.com/lob/lob-python/tree/legacy_v4\" target=\"_blank\">Python (Legacy)</a>\n- <a href=\"https://github.com/lob/lob-ruby/tree/legacy-v5\" target=\"_blank\">Ruby (Legacy)</a>\n\n<br><br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12247,7 +12796,7 @@
             "event": []
         },
         {
-            "id": "6b70f1d2-0919-4699-813f-980be87f4f0c",
+            "id": "ce4cbf70-14cd-4dbf-bcb5-b48d4f1a961a",
             "name": "Self Mailers",
             "description": {
                 "content": "The self mailer endpoint allows you to easily print and mail self mailers. The API provides endpoints\nfor creating self mailers, retrieving individual self mailers, canceling self mailers, and retrieving a list of self mailers.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -12255,7 +12804,7 @@
             },
             "item": [
                 {
-                    "id": "445f9077-f1c1-4ab1-bc2e-bb069888accc",
+                    "id": "43d208c5-84ea-4202-97e6-e48c72edfb71",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -12293,7 +12842,7 @@
                     },
                     "response": [
                         {
-                            "id": "be954582-260d-4ff0-9781-e40fcd7df1fc",
+                            "id": "8316061b-89c6-402c-936a-031ac536b5ef",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -12336,12 +12885,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"sfm_8ffbe811dea49dcf\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"6x18_bifold\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"self_mailer\"\n}",
+                            "body": "{\n  \"id\": \"sfm_8ffbe811dea49dcf\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"6x18_bifold\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"self_mailer\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5a9a4255-3ac0-42cc-b354-0ab85621d44f",
+                            "id": "aaabd657-517a-410f-ab6e-65c758cdd053",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12392,7 +12941,7 @@
                     "event": []
                 },
                 {
-                    "id": "8f173806-a61b-46fe-8c2f-97da97f91c86",
+                    "id": "a1db79a6-0e50-4374-aee3-fd62dd0f6418",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -12430,7 +12979,7 @@
                     },
                     "response": [
                         {
-                            "id": "8e67a8b7-24fb-4880-9bc7-d8946f837127",
+                            "id": "3f2d93ea-b007-4a74-8b39-6632bc57a1b8",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -12478,7 +13027,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "230b9c23-e700-458a-ba0f-89079c3d7edf",
+                            "id": "c3427e36-ed4b-49d0-b767-b8847ac107f6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12529,7 +13078,7 @@
                     "event": []
                 },
                 {
-                    "id": "d39a2c3d-9bd7-48f0-afed-50626e12d305",
+                    "id": "1baaf1e8-97b6-4b72-ae3b-327d19966923",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -12577,19 +13126,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -12655,7 +13198,7 @@
                     },
                     "response": [
                         {
-                            "id": "4b157b8a-0853-4252-8783-baae78097e57",
+                            "id": "285cde6d-47d7-4aab-a6d0-6a89486b5b6a",
                             "name": "A dictionary with a data property that contains an array of up to `limit` self_mailers. Each entry in the array is a separate self_mailer. The previous and next page of self_mailers can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more self_mailers are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -12687,7 +13230,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -12751,7 +13298,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d193f029-cf99-4b5f-aedc-9027537fed4c",
+                            "id": "5916eb46-fa60-4b52-ba72-f8be1b07dd40",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -12783,7 +13330,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -12850,7 +13401,7 @@
                     "event": []
                 },
                 {
-                    "id": "8faf9c8a-2053-4648-a45a-b693cdf1a55a",
+                    "id": "7f3b008e-cc42-4542-a6c6-4efeaaeb7260",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -12943,6 +13494,11 @@
                                 },
                                 {
                                     "disabled": false,
+                                    "key": "print_speed",
+                                    "value": "core"
+                                },
+                                {
+                                    "disabled": false,
                                     "key": "value",
                                     "value": "<Error: Too many levels of nesting to fake this schema>"
                                 },
@@ -13016,7 +13572,7 @@
                     },
                     "response": [
                         {
-                            "id": "902b8153-cea0-4141-9537-0aac460ce8f5",
+                            "id": "7134ca9f-4d9e-49be-99ea-3ffc1b5c735e",
                             "name": "Returns a self_mailer object",
                             "originalRequest": {
                                 "url": {
@@ -13143,6 +13699,11 @@
                                             "disabled": false,
                                             "key": "fsc",
                                             "value": "true"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -13173,12 +13734,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"sfm_8ffbe811dea49dcf\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"6x18_bifold\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"self_mailer\"\n}",
+                            "body": "{\n  \"id\": \"sfm_8ffbe811dea49dcf\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/self-mailers/sfm_8ffbe811dea49dcf_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"6x18_bifold\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"self_mailer\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2c777fd6-654c-4b3b-969d-6d92f6856d23",
+                            "id": "07096959-621e-4254-8841-543648232472",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13305,6 +13866,11 @@
                                             "disabled": false,
                                             "key": "fsc",
                                             "value": "true"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -13331,7 +13897,7 @@
             "event": []
         },
         {
-            "id": "794f5037-6aae-4c23-9726-0e620994a661",
+            "id": "722535f0-f3b5-49ba-97d6-d043aaf90776",
             "name": "Template Design",
             "description": {
                 "content": "## HTML Templates\nYou can save commonly used HTML as templates within Lob to more easily manage them. You can reference\nyour saved templates in postcard, letter, and check requests instead of having to pass a long HTML\nstring on each request. Additionally, you can make changes to your HTML templates and update them\nindependently, without having to touch your API integration. Templates can be created, edited,\nand viewed on your <a href=\"https://dashboard.lob.com/#/templates\" target=\"_blank\">Dashboard</a>. To use a template in a postcard,\nletter, or check, see the documentation for each endpoint below. For help using templates, check out our\n<a href=\"https://help.lob.com/print-and-mail/designing-mail-creatives/dynamic-personalization#html-templates-1\" target=\"_blank\">HTML Templates Guide</a> or get started with a\n<a href=\"https://lob.com/template-gallery\" target=\"_blank\">pre-designed template from our gallery</a>. In Live mode, you can only have\nas many templates as allotted in your current\n<a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>. There is no limit in Test mode.\n\nIf you'd like to interact with templates programmatically, check out our Beta Program for API access\nto the [HTML Templates Endpoints](#tag/Templates).\n\n### Example Create Request using HTML Templates\n```bash\n  curl https://api.lob.com/v1/postcards \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -d \"description=Demo Postcard job\" \\\n    -d \"to=adr_78c304d54912c502\" \\\n    -d \"from=adr_61a0865c8c573139\" \\\n    -d \"front=tmpl_b846a20859ae11a\" \\\n    -d \"back=tmpl_01b0d396a10c268\" \\\n    -d \"merge_variables[name]=Harry\"\n```\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## HTML Examples\nUse a pre-designed template from our <a href=\"https://lob.com/resources/template-gallery\" target=\"_blank\">gallery</a> or follow these\nbasic <a href=\"https://github.com/lob/examples\" target=\"_blank\">guidelines</a> as starting points for creating custom Postcards,\nSelf Mailers, Letters, and Checks.\n\nPlease follow the standards used in these templates, such as:\n- For any linked assets, you must use a performant file hosting provider with no rate limits such as Amazon\nS3.\n- Use inline styles or an internal stylesheet, do not link to external stylesheets.\n- Link to images that are 300DPI and sized at the final desired size on the physical mailing. For example,\nfor a photo that is desired to be 1in x 1in on the final postcard, the image asset should be sized at 1in\nx 1in at 300DPI (which equates to 300px by 300px).\n- The sum of all linked assets should not exceed 5MB in file size.\n- Use `-webkit` prefixes for CSS properties when recommended <a href=\"http://shouldiprefix.com/\" target=\"_blank\">here</a>.\n\nBecause different browsers have varying user-agent styles, the HTML you see in your browser will not\nalways look identical to what is produced through the API. It is **strongly** recommended that you test all\nHTML requests by reviewing the final PDF files in your Test Environment, as these are the files that will be\nprinted.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Image Prepping\nCurrently we support the following file types for all endpoints:\n- PDF\n- PNG\n- JPEG\n\n**Templates**\n\nYou can find pre-made templates that already adhere to all of these guidelines here:\n- [Postcards](#tag/Postcards)\n- [Letters](#tag/Letters)\n- [Checks](#tag/Checks)\n- [Self Mailers](#tag/Self-Mailers)\n\n**Prepping All Images**\n\nThe following guidelines apply to image types:\n- Images should be 300 dpi or higher - PNG/JPEG files with less than 300 dpi will be rejected.\n- Your artwork should include a 1/8\" border around the final trim size. This means your final file size will be a total of 0.25\" larger than your expected printed piece (ie, a 4\"x6\" postcard should be submitted as 4.25\"x6.25\"). There is no need to include crop marks in your submitted content.\n- Include a safe zone – make sure no critical elements are within 1/8\" from the edge of the final size.\n- Do not include any additional postage marks or indicia.\n- File sizes should be no larger than 5MB.\n\n**Prepping PDFs**\n\nTo ensure that you are producing PDF's correctly please follow the guidelines [outlined in our help center here](https://help.lob.com/print-and-mail/designing-mail-creatives/creative-formatting/pdf-preflight-checklist#requirements-for-static-pdfs)\n\n**Prepping PNGs/JPEGs**\n\nTo ensure that you are producing PNG's/JPEG's correctly please follow the guidelines below:\n\n- Minimum 300 dpi. The dpi is calculated as (width of image in pixels) / (width of product in inches) and (length of image in pixels) / (length of product in inches). For Example: 1275px x 1875px image used to create a 4.25\" x 6.25\" postcard has a dpi of 300.\n- Submitted images must have the same length to width ratio as the chosen product. Images will not be cropped or stretched by the API.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## Standard PDF Fonts\nIdeally, all fonts in provided PDFs should be embedded. Embedding a font in a PDF ensures that the final\nprinted product will look as it was designed. Fonts can vary greatly in size and shape, even within the\nsame family. If the exact font that was used to design the artwork is not used to print, the look and\nplacement of the text is not guaranteed to be the same.\n\nIn general, requests that provide PDFs with un-embedded fonts will be rejected. We make an exception for\n\"standard fonts\", a set of fonts that we have identified as being common. PDFs that contain un-embedded\nfonts that are found in the list, and match the accepted <a href=\"https://en.wikipedia.org/wiki/Category:Font_formats\" target=\"_blank\">font type</a>\nwill be accepted. Otherwise, the request will be rejected.\n\nFont embedding is an essential part of standard PDF workflows. Fonts should be embedded automatically by\nPDF editing software that are compliant with PDF standards.\n\nPlease note, only standard base14 fonts can be Type 1.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">FONT NAME</th>\n    <th style=\"white-space: nowrap\">TYPES</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,BoldItalic</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial,Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-BoldItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Arial-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialNarrow</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ArialNarrow-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Calibri-Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-Oblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Courier-BoldOblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPSMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPS-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>CourierNewPS-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-BoldOblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Helvetica-Oblique</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>LucidaConsole</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>MsSansSerif</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>MsSansSerif,Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Symbol</code></td>\n    <td style=\"white-space: nowrap\">Type 1, TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Tahoma</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Tahoma-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Bold</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-BoldItalic</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Italic</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Times-Roman</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-BoldItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-BoldMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPS-ItalicMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPSMT</code></td>\n    <td style=\"white-space: nowrap\">TrueType, CID TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>TimesNewRomanPSMT,Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana-Bold</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>Verdana,Italic</code></td>\n    <td style=\"white-space: nowrap\">TrueType</td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\"><code>ZapfDingbats</code></td>\n    <td style=\"white-space: nowrap\">Type 1</td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -13341,7 +13907,7 @@
             "event": []
         },
         {
-            "id": "ba0a4016-3bd2-4a75-a466-a59c80ab7346",
+            "id": "c59338ec-a71a-4b88-8f9d-725b94bbdd15",
             "name": "Template Versions",
             "description": {
                 "content": "These API endpoints allow you to create, retrieve, update and delete versions of reusable HTML templates for use with the Print & Mail API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -13349,7 +13915,7 @@
             },
             "item": [
                 {
-                    "id": "c14c0a14-f249-4f76-8741-b04378a4f4d8",
+                    "id": "aeab576e-2f79-4b65-b65f-cebc5a74f9aa",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -13396,7 +13962,7 @@
                     },
                     "response": [
                         {
-                            "id": "1930330a-e877-4c8f-88d0-305c221a425a",
+                            "id": "02e0b0ee-ef68-40a6-bf4f-99b37c845f68",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -13453,7 +14019,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "776d4833-bc9d-406c-9050-4786c8e5d677",
+                            "id": "cde94a3c-02f9-4eda-ac3a-6e2bea0dee3a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13513,7 +14079,7 @@
                     "event": []
                 },
                 {
-                    "id": "c581da80-4619-4ae6-8071-0d1a3dd47d74",
+                    "id": "0248707a-f535-4cef-83a4-42a0297eef74",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -13589,7 +14155,7 @@
                     },
                     "response": [
                         {
-                            "id": "94699bb4-b9e1-4c0a-99b6-aa41b7878b73",
+                            "id": "1f16d4be-246c-43f9-b7ef-f19e9d3bca95",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -13673,7 +14239,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "07e585c6-21be-4598-9f9e-6dc4f76a6c3c",
+                            "id": "ab282b86-4fd8-4147-aa4b-fb959d61cdae",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13745,7 +14311,7 @@
                     }
                 },
                 {
-                    "id": "2922edab-d86e-4376-bb8a-c73953affde2",
+                    "id": "7dc8efa3-47fd-4dca-89b5-8162cc78facb",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -13792,7 +14358,7 @@
                     },
                     "response": [
                         {
-                            "id": "20472c85-d300-4630-ac97-9d1a984ecf51",
+                            "id": "27056cb1-26ff-4452-8f66-1800ad65d496",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -13849,7 +14415,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e6354a8c-b6e3-46db-ad29-803fb0bdc1ce",
+                            "id": "fd077633-a0b7-42df-a533-1c6c02f3b783",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -13909,7 +14475,7 @@
                     "event": []
                 },
                 {
-                    "id": "538e3d8f-32e1-4c11-8173-82f19197c1be",
+                    "id": "5ad39202-2dbd-4772-816b-d871f18fa0ca",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -13959,19 +14525,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -13997,7 +14557,7 @@
                     },
                     "response": [
                         {
-                            "id": "645499e8-1d42-4a88-9e37-af2b84d74494",
+                            "id": "f0a93cb8-030a-45f7-bcea-42cf1db71479",
                             "name": "A dictionary with a data property that contains an array of up to `limit` template versions. Each entry in the array is a separate template version object. The previous and next page of template versions can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more template versions are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -14031,7 +14591,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -14071,7 +14635,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2046ff09-e913-426b-b0d8-f2aa97e7bcb9",
+                            "id": "6f210fa5-abb8-4583-9266-c2812adaaf6d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14105,7 +14669,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -14148,7 +14716,7 @@
                     "event": []
                 },
                 {
-                    "id": "305749dc-a6af-46bf-be52-530f9098eca8",
+                    "id": "506dd74e-d0bf-4389-96b4-a9d89fbbc85b",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -14222,7 +14790,7 @@
                     },
                     "response": [
                         {
-                            "id": "8660c95b-1d47-4248-8833-812d8859a6f4",
+                            "id": "5805ed35-3b4d-4ad3-a339-cb61f45841fd",
                             "name": "Returns the template version with the given template and version ids.",
                             "originalRequest": {
                                 "url": {
@@ -14307,7 +14875,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bb80615b-4eef-44c4-abe8-b0b6c704bb4f",
+                            "id": "69062632-1748-48da-baab-d71fdb503b07",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14383,7 +14951,7 @@
             "event": []
         },
         {
-            "id": "a0fb2729-c996-4dc5-b22f-6acf13cd6504",
+            "id": "e3e999aa-b25d-4168-a648-2ba7c4fa92a7",
             "name": "Templates",
             "description": {
                 "content": "These API endpoints allow you to create, retrieve, update and delete reusable HTML templates for use with the Print & Mail API.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -14391,7 +14959,7 @@
             },
             "item": [
                 {
-                    "id": "edc24ef3-0e1d-437f-9a8d-aeb883700265",
+                    "id": "e1f4dc57-0a5b-40fd-9f41-4a709bab7758",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -14429,7 +14997,7 @@
                     },
                     "response": [
                         {
-                            "id": "138a5fde-4649-4e8a-b59f-e3a999754964",
+                            "id": "2dbcc7bc-0ff6-4dd6-8a1e-47f3ff513c81",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -14477,7 +15045,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9ba263b1-591b-47e0-8c02-a868f6208e37",
+                            "id": "f8186bd2-041a-45b4-ae72-b5fd18840803",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14528,7 +15096,7 @@
                     "event": []
                 },
                 {
-                    "id": "4876c286-f3ca-4310-baa2-9bf8fd16beb1",
+                    "id": "d07cd942-4a99-4def-a08e-8b331e6c0269",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -14585,7 +15153,7 @@
                     },
                     "response": [
                         {
-                            "id": "4db58e9e-2728-47c1-8849-890d49ed8979",
+                            "id": "472cc7de-0c41-4f52-ab32-20e13ad56e06",
                             "name": "Returns the updated template object",
                             "originalRequest": {
                                 "url": {
@@ -14665,7 +15233,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "18fc20d5-f80c-4a35-ba5a-f59745841484",
+                            "id": "1186ddf3-5019-43d7-81dd-e51f8f656a89",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14733,7 +15301,7 @@
                     }
                 },
                 {
-                    "id": "d22b6252-d0d5-48cc-a54c-cdf92b824dc2",
+                    "id": "3a28a456-0eb0-40d1-910c-ff1ac6d7bbd2",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -14771,7 +15339,7 @@
                     },
                     "response": [
                         {
-                            "id": "43713fe2-7f87-4145-b25d-3d9f2477d120",
+                            "id": "599508c2-a598-4a9a-bce8-8d05f5d381b4",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -14819,7 +15387,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f74316c4-c0a5-4d58-904c-30b4640cb438",
+                            "id": "93e109ef-bb12-4a91-88d6-dc1def92b3dd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -14870,7 +15438,7 @@
                     "event": []
                 },
                 {
-                    "id": "f619147b-d535-4826-aea0-a45001b1d94b",
+                    "id": "e317280b-f461-4976-9283-59a33262e579",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -14918,19 +15486,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 }
@@ -14948,7 +15510,7 @@
                     },
                     "response": [
                         {
-                            "id": "b19507fb-7373-45f6-948f-f4700281820e",
+                            "id": "193c5185-c830-468b-8bf2-093923d6e5c6",
                             "name": "A dictionary with a data property that contains an array of up to `limit` templates. Each entry in the array is a separate template. The previous and next page of templates can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more templates are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -14980,7 +15542,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -15012,7 +15578,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "32c71d53-6791-4580-afd4-6c07e824b908",
+                            "id": "81e5ae10-147c-4ed2-adfc-3124d9635723",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -15044,7 +15610,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         }
                                     ],
@@ -15079,7 +15649,7 @@
                     "event": []
                 },
                 {
-                    "id": "396aa7fb-aa54-45cd-b26a-e10281059f64",
+                    "id": "9ad4fe05-d77c-44ca-b23c-e986d84a0819",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -15126,7 +15696,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "_^,EdRMPL-Q`&YWlCmVt*wet_yASo(4n~8-b6U9=43iA-P.Ty&yA~Wv5}=N5b(h4PoRHDE@,Hp$gECxh'[}LuS9#dI9ay%g_n>(R(.{1$%;M:>ZZ! W|/_Db(r'sxFr/)L[J)mvHJ_i 6GgZLK(0QMO5D@<!n(|^_|&k>r1miCotic;;]:<38Jl?<c}FGc#!&X5"
+                                    "value": "[GuY#XI[Q/e]d(+V2yp4i/oyO5 ;pio^QFos2{ HfFN$-,~qb(8md0('3h<X#WYzR7ltfb!d?(Sv,=fO&,/Ou)[j>F~pgPQG7)RMF!%AFiY4+x e;&W:hr,/PNsD`uga4i>8hcf[%DwFf%g5G?W0]R`qa<N8 Gbj_S<qxnS*7&/m+cG=xJdC?4Dy8Oe`cp~uK)pZDL^CT<Z?MTcKx-~8gV+$z/M)!J0nP~J{+</$.;dtuV_eX2GuU#f?awHU@H4o!oYZx^6.t5XAfV'`cI]:RxY-DMm|&NJRD zPamGfkCl(;]v7P?N)X}<2!(KUWNomQ2E+SjXYB'%wGT}l4s,PrAd0(d%r11o 9#1{r5kL7=d2kn?)-,5gvfdDmwctKN)-[w^6<Ll[Hey#e9t8'7'KJ&=61omU]~DLfq{yY>R&UW@rBc+r'b7Hu;&2cT,J=?uFw,N[q)UgYIZ75@MU"
                                 },
                                 {
                                     "disabled": false,
@@ -15148,7 +15718,7 @@
                     },
                     "response": [
                         {
-                            "id": "392dcc5c-652e-4283-9e88-30bbdc8b3cbe",
+                            "id": "26c11029-edc6-4d66-a1f3-ef0d64dbe20e",
                             "name": "Returns a template object",
                             "originalRequest": {
                                 "url": {
@@ -15233,7 +15803,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2c91162b-9b39-4c41-8f68-1be3543b6d6c",
+                            "id": "28a04ea2-28a2-49ad-9169-472a8ca7a9be",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -15309,7 +15879,7 @@
             "event": []
         },
         {
-            "id": "42c44d8e-a80d-43ef-aa29-0feee4303ca7",
+            "id": "6d55b569-696c-4b5b-aec9-6ac7fbcdd124",
             "name": "Test and Live Environments",
             "description": {
                 "content": "To make the API as explorable as possible, accounts have test and live\nenvironment API keys. You're not charged any fees in the test environment,\nso we encourage you to use it to try out services, perform quality\nassurance, and run automated testing. Objects―addresses, letters, checks,\netc―in one environment cannot be manipulated by objects in the other.\n\nIn general, a payment method (either credit card or ACH account) must be\nadded to your account to make live API requests. However, a payment method\nis not required for the first 300 live requests per month to the\n`/v1/us_verifications` endpoint. After the first 300 requests, you will\nbegin receiving errors with status code `403`.\n\nRequests made in the test environment always validate request arguments,\nsimulate live environment behavior, and enforce rate limits. _They never\nprint, mail nor, for verification services, verify addresses._ The US &\nInternational verification services trigger behavior with specific\nargument values, and, if you plan on using those, we recommend reading\n[US Verification Test Environment](#tag/US-Verifications-Test-Environment)\nand [Intl Verification Test Environment](#tag/Intl-Verifications-Test-Environment).\n\nTo switch between environments, use the appropriate key for that\nenvironment when performing a request. You can find each environment's API\nkey in your dashboard under Settings; test API keys are always prefixed\nwith `test_` and production API keys with `live_`.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -15319,7 +15889,7 @@
             "event": []
         },
         {
-            "id": "1acdc5ac-ffd7-4a31-8ce2-11acb4cc1fae",
+            "id": "87f00a36-b2f0-4f17-8d90-05d7f8c09803",
             "name": "Tracking Events",
             "description": {
                 "content": "As mailpieces travel through the mail stream, USPS scans their unique barcodes, and Lob processes these mail scans to generate tracking events.\n\n<h3>Certified Tracking Event Details</h3>\n\nLetters sent with USPS Certified Mail are fully tracked by USPS, and\ntherefore their [tracking events](#operation/tracking_event) have an\nadditional `details` object with more detailed information about the\ntracking event. The following table shows the potential values for\nthe fields in the `details` object mapped to the tracking event `name`.\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">NAME</th>\n    <th style=\"white-space: nowrap\">EVENT</th>\n    <th style=\"white-space: nowrap\">DESCRIPTION</th>\n    <th style=\"white-space: nowrap\">ACTION REQUIRED</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Mailed</td>\n    <td style=\"white-space: nowrap\"><code>package_accepted</code></td>\n    <td>Package has been accepted into the carrier network for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_arrived</code></td>\n    <td>Package has arrived at an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_departed</code></td>\n    <td>Package has departed from an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_processing</code></td>\n    <td>Package is processing at an intermediate location in the carrier network.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Transit</td>\n    <td style=\"white-space: nowrap\"><code>package_processed</code></td>\n    <td>Package has been processed at an intermediate location.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">In Local Area</td>\n    <td style=\"white-space: nowrap\"><code>package_in_local_area</code></td>\n    <td>Package is at a location near the end destination.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Processed For Delivery</td>\n    <td style=\"white-space: nowrap\"><code>delivery_scheduled</code></td>\n    <td>Package is scheduled for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Processed For Delivery</td>\n    <td style=\"white-space: nowrap\"><code>out_for_delivery</code></td>\n    <td>Package is out for delivery.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Pickup Available</td>\n    <td style=\"white-space: nowrap\"><code>pickup_available</code></td>\n    <td>Package is available for pickup at carrier location.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Delivered</td>\n    <td style=\"white-space: nowrap\"><code>delivered</code></td>\n    <td>Package has been delivered.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Re-Routed</td>\n    <td style=\"white-space: nowrap\"><code>package_forwarded</code></td>\n    <td>Package has been forwarded.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Returned to Sender</td>\n    <td style=\"white-space: nowrap\"><code>returned_to_sender</code></td>\n    <td>Package is to be returned to sender.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>address_issue</code></td>\n    <td>Address information is incorrect. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>contact_carrier</code></td>\n    <td>Contact the carrier for more information.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delayed</code></td>\n    <td>Delivery of package is delayed.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delivery_attempted</code></td>\n    <td>Delivery of package has been attempted. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>delivery_rescheduled</code></td>\n    <td>Delivery of package has been rescheduled.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>location_inaccessible</code></td>\n    <td>Delivery location inaccessible to carrier. Contact carrier to ensure delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>notice_left</code></td>\n    <td>Carrier left notice during attempted delivery. Follow carrier instructions on notice.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_damaged</code></td>\n    <td>Package has been damaged. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_disposed</code></td>\n    <td>Package has been disposed.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_held</code></td>\n    <td>Package held at carrier location. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_lost</code></td>\n    <td>Package has been lost. Contact carrier for more details.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_unclaimed</code></td>\n    <td>Package is unclaimed.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>package_undeliverable</code></td>\n    <td>Package is not able to be delivered.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>reschedule_delivery</code></td>\n    <td>Contact carrier to reschedule delivery.</td>\n    <td style=\"white-space: nowrap\"><code>true</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Issue</td>\n    <td style=\"white-space: nowrap\"><code>other</code></td>\n    <td>Unrecognized carrier status.</td>\n    <td style=\"white-space: nowrap\"><code>false</code></td>\n  </tr>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -15329,7 +15899,7 @@
             "event": []
         },
         {
-            "id": "16cd4a7e-82d3-4daa-b5d2-395ed6a1e52f",
+            "id": "bae8a6c5-b257-409a-97fc-88d0303172b2",
             "name": "Uploads",
             "description": {
                 "content": "The uploads endpoint allows you to upload audience files that are then associated with a given campaign.\nAt this time, only CSV files are allowed. The API provides endpoints for creating uploads, uploading audience files,\nand marking uploaded files as ready for processing. The API also provides endpoints for downloading files that\ndescribe the results, both successful and not, of the processing.\n",
@@ -15337,7 +15907,7 @@
             },
             "item": [
                 {
-                    "id": "1a497d68-22d7-4ae3-b12c-d8699a0bd379",
+                    "id": "57cf60b0-c49e-4d57-96d4-cc266e5fee1b",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -15373,7 +15943,7 @@
                     },
                     "response": [
                         {
-                            "id": "78e7debd-7512-42d4-8ce3-9e804eb75b6f",
+                            "id": "d824e532-fcd1-4bb7-be4b-19390d1657b5",
                             "name": "An array of matching uploads. Each entry in the array is a separate upload.",
                             "originalRequest": {
                                 "url": {
@@ -15420,7 +15990,7 @@
                     "event": []
                 },
                 {
-                    "id": "3b9317c0-a6a7-4502-a3df-ac4322c8028d",
+                    "id": "98de0409-d3b3-4768-ac6d-198e8f87f1a4",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -15462,7 +16032,7 @@
                     },
                     "response": [
                         {
-                            "id": "da45b0a6-73f5-43bc-a77e-dc028d20fdb7",
+                            "id": "265b37b9-8346-4f1c-a5be-6e715d533074",
                             "name": "Upload created successfully",
                             "originalRequest": {
                                 "url": {
@@ -15509,7 +16079,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c043dfd8-25d6-46e1-a66e-063018a9ac3a",
+                            "id": "a02591df-e29a-4156-8054-b742a3d3b58a",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15551,7 +16121,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"minim veniam velit incidi\",\n        \"cillum reprehenderit elit ipsum\"\n      ],\n      \"msg\": \"Duis mollit sint\",\n      \"type\": \"consectetur enim dolore\"\n    },\n    {\n      \"loc\": [\n        \"est qui\",\n        \"fugiat consequat ut\"\n      ],\n      \"msg\": \"qui nisi\",\n      \"type\": \"dolore sint consequat consectetur ut\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"ad\",\n        \"do cillum\"\n      ],\n      \"msg\": \"ut nostrud ea\",\n      \"type\": \"est nisi nostrud laboris\"\n    },\n    {\n      \"loc\": [\n        \"sint\",\n        \"co\"\n      ],\n      \"msg\": \"tempor et\",\n      \"type\": \"aliquip esse \"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15562,7 +16132,7 @@
                     }
                 },
                 {
-                    "id": "d6b41b25-99bd-4bae-bffe-e4b61edc763a",
+                    "id": "d1b949c4-8f79-4b0f-875f-f3015b2d53ff",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -15600,7 +16170,7 @@
                     },
                     "response": [
                         {
-                            "id": "ee953016-9b1a-4f64-a499-d1e1ed0f30d2",
+                            "id": "c5dad107-97ed-4796-8223-8754064a0df7",
                             "name": "Returns an upload object",
                             "originalRequest": {
                                 "url": {
@@ -15648,7 +16218,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7f657f52-28f2-4725-83d5-3d7c3e97f5a9",
+                            "id": "e6fdc28e-2eb6-448d-bf1d-506adb975abe",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -15696,7 +16266,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "07959a3d-3bc0-4a03-8785-aa4c062f7b8d",
+                            "id": "40bf005f-5019-408a-9149-ad831170c2d1",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15739,7 +16309,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"nulla\",\n        \"eiusmod commodo\"\n      ],\n      \"msg\": \"pariatur ullamco\",\n      \"type\": \"pariatur in esse dolore in\"\n    },\n    {\n      \"loc\": [\n        \"laborum pariatur\",\n        \"culpa\"\n      ],\n      \"msg\": \"pariatur consectetur consequat\",\n      \"type\": \"labore officia ips\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"dolore\",\n        \"commodo Lorem\"\n      ],\n      \"msg\": \"incididunt minim\",\n      \"type\": \"consequat et non\"\n    },\n    {\n      \"loc\": [\n        \"qui elit ex mollit\",\n        \"velit voluptate dolor non\"\n      ],\n      \"msg\": \"Lorem dolore et ex\",\n      \"type\": \"ea consequat in sit eu\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15747,7 +16317,7 @@
                     "event": []
                 },
                 {
-                    "id": "a6705f41-6de9-4aaf-b33b-00a2566c9975",
+                    "id": "3279c83a-c8b7-4203-bc15-4be87c02215a",
                     "name": "Update",
                     "request": {
                         "name": "Update",
@@ -15798,7 +16368,7 @@
                     },
                     "response": [
                         {
-                            "id": "0c84a96b-8a91-4bb7-8f70-d09a1cc1f6c9",
+                            "id": "dac36f96-8338-4ca4-83a1-b19ccc45e274",
                             "name": "Returns an upload object",
                             "originalRequest": {
                                 "url": {
@@ -15854,7 +16424,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9c611bab-c6da-4a87-9e06-7e0dffc47c7e",
+                            "id": "2f954b39-eddd-48e8-8686-61958fe327bd",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -15910,7 +16480,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "db454093-dbdc-4803-a124-7b9319d0bd8b",
+                            "id": "edf9b1c2-43b4-4ef6-9721-ec60c336f82f",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -15961,7 +16531,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"nulla\",\n        \"eiusmod commodo\"\n      ],\n      \"msg\": \"pariatur ullamco\",\n      \"type\": \"pariatur in esse dolore in\"\n    },\n    {\n      \"loc\": [\n        \"laborum pariatur\",\n        \"culpa\"\n      ],\n      \"msg\": \"pariatur consectetur consequat\",\n      \"type\": \"labore officia ips\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"dolore\",\n        \"commodo Lorem\"\n      ],\n      \"msg\": \"incididunt minim\",\n      \"type\": \"consequat et non\"\n    },\n    {\n      \"loc\": [\n        \"qui elit ex mollit\",\n        \"velit voluptate dolor non\"\n      ],\n      \"msg\": \"Lorem dolore et ex\",\n      \"type\": \"ea consequat in sit eu\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -15972,7 +16542,7 @@
                     }
                 },
                 {
-                    "id": "6b159f3f-6f11-41ed-885b-6357d3f29dc5",
+                    "id": "8acb5232-0fc1-41bc-b058-e55ac610fc3b",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -16004,7 +16574,7 @@
                     },
                     "response": [
                         {
-                            "id": "326c9832-0266-4f87-b41e-4c87a02b8ff1",
+                            "id": "1a7f4509-dfd4-49df-bec8-8aeef35350cb",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -16055,7 +16625,7 @@
                     "event": []
                 },
                 {
-                    "id": "b77b3adf-9905-440a-831f-d73bcc745da6",
+                    "id": "b9c13a5c-3593-4111-aa52-5303f30df4b1",
                     "name": "Upload file",
                     "request": {
                         "name": "Upload file",
@@ -16108,7 +16678,7 @@
                     },
                     "response": [
                         {
-                            "id": "4e4d123d-3331-4e79-a225-6f1e9ec211a1",
+                            "id": "4d7110d4-2b67-460c-a573-3ff56c706556",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -16165,12 +16735,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"message\": \"File uploaded successfully\",\n  \"filename\": \"ut velit\"\n}",
+                            "body": "{\n  \"message\": \"File uploaded successfully\",\n  \"filename\": \"dolore\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "77b27739-8526-445e-a7bb-883523e458b1",
+                            "id": "65d253a1-3637-4c73-bffd-1311dd7fff87",
                             "name": "Validation Error",
                             "originalRequest": {
                                 "url": {
@@ -16227,7 +16797,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"nulla\",\n        \"eiusmod commodo\"\n      ],\n      \"msg\": \"pariatur ullamco\",\n      \"type\": \"pariatur in esse dolore in\"\n    },\n    {\n      \"loc\": [\n        \"laborum pariatur\",\n        \"culpa\"\n      ],\n      \"msg\": \"pariatur consectetur consequat\",\n      \"type\": \"labore officia ips\"\n    }\n  ]\n}",
+                            "body": "{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"dolore\",\n        \"commodo Lorem\"\n      ],\n      \"msg\": \"incididunt minim\",\n      \"type\": \"consequat et non\"\n    },\n    {\n      \"loc\": [\n        \"qui elit ex mollit\",\n        \"velit voluptate dolor non\"\n      ],\n      \"msg\": \"Lorem dolore et ex\",\n      \"type\": \"ea consequat in sit eu\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -16238,7 +16808,7 @@
                     }
                 },
                 {
-                    "id": "228ce447-e5eb-4a17-8700-3f95b0930deb",
+                    "id": "06ea116c-2b26-4a5b-8d8d-30aafe183fa7",
                     "name": "Create Export",
                     "request": {
                         "name": "Create Export",
@@ -16290,7 +16860,7 @@
                     },
                     "response": [
                         {
-                            "id": "62cd76dc-04c9-40c3-be3e-120ed2013123",
+                            "id": "30ef7ed7-95e3-497c-9084-e86cd993584a",
                             "name": "Successful Response",
                             "originalRequest": {
                                 "url": {
@@ -16347,7 +16917,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d7d240b3-aed7-4168-b738-03e56735600a",
+                            "id": "6d806b4a-c5e9-48ee-88e5-b5d01abc7555",
                             "name": "Create Export Error",
                             "originalRequest": {
                                 "url": {
@@ -16410,7 +16980,7 @@
                     }
                 },
                 {
-                    "id": "63957286-cb84-4392-b4d4-fe944e2190b1",
+                    "id": "c41f32bb-ba96-485c-ac10-f93b75dd5eb6",
                     "name": "Retrieve Line Item Report",
                     "request": {
                         "name": "Retrieve Line Item Report",
@@ -16468,7 +17038,7 @@
                     },
                     "response": [
                         {
-                            "id": "eb67910c-b26c-4050-b773-2dfcb1c2a3e1",
+                            "id": "8e5a715a-695a-41cc-96f6-5c70cd6691a6",
                             "name": "Returns an report object",
                             "originalRequest": {
                                 "url": {
@@ -16530,7 +17100,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2419b1c9-6e0c-4a80-9a45-b549106940ee",
+                            "id": "e0c0f25b-33af-4875-955c-17e2b4c88e6c",
                             "name": "Not Found Error",
                             "originalRequest": {
                                 "url": {
@@ -16595,7 +17165,7 @@
                     "event": []
                 },
                 {
-                    "id": "4e9333ca-4745-4f6d-8b8a-db5a2af3cfd0",
+                    "id": "4f483386-16b0-42d2-8940-4aa4fa22caf4",
                     "name": "Retrieve Export",
                     "request": {
                         "name": "Retrieve Export",
@@ -16642,7 +17212,7 @@
                     },
                     "response": [
                         {
-                            "id": "438e937d-bd6e-48aa-8874-028b10121b04",
+                            "id": "487e908f-cdd1-426b-9689-6320530468d4",
                             "name": "Returns an export object",
                             "originalRequest": {
                                 "url": {
@@ -16705,7 +17275,7 @@
             "event": []
         },
         {
-            "id": "6f93bb4d-4358-4932-bdb9-ad5a0b9260da",
+            "id": "1ada61ca-e9b4-420b-8ce3-330f770afc25",
             "name": "URL Shortener",
             "description": {
                 "content": "Lob's URL shortener allows you to generate unique short links, either with Lob's own domain or your own custom domains. Each custom link enables Lob to track mail individually and provide customers the relevant tracking data in their dashboard.\n\nWebhooks can be used to integrate Lob's URL Shortener scans into your omni channel marketing stratergy. See the <a href=\"#tag/Webhooks\">Webhooks</a> section of our documentation to learn how to enable the `letter.viewed`, `postcard.viewed` and `self_mailer.viewed` event notifications for your mail pieces.\n\nFurthermore, you can use our Retrieve endpoints to track the impact and engagement rate of links created. \n\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -16713,7 +17283,7 @@
             },
             "item": [
                 {
-                    "id": "061fd7a7-2785-4b90-9488-d396604cc0fa",
+                    "id": "c9ef3702-a6e2-4e0b-9749-125427e281f2",
                     "name": "Retrieve a domain",
                     "request": {
                         "name": "Retrieve a domain",
@@ -16751,7 +17321,7 @@
                     },
                     "response": [
                         {
-                            "id": "dad415a7-cbfe-40e2-8d27-b7701f50b37d",
+                            "id": "f3cd2a33-344f-44b4-b402-9f0e9d7369eb",
                             "name": "Returns domain related details.",
                             "originalRequest": {
                                 "url": {
@@ -16794,12 +17364,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"es\",\n  \"domain\": \"anim reprehenderit consequat veniam esse\",\n  \"error_redirect_link\": \"eiusmod\",\n  \"status\": \"configured\",\n  \"created_at\": \"tempor magna labore\",\n  \"updated_at\": \"minim cupidatat Duis ea culpa\"\n}",
+                            "body": "{\n  \"id\": \"consequat ex dolor est magna\",\n  \"domain\": \"Excepteur Lorem est anim\",\n  \"error_redirect_link\": \"laboris in officia\",\n  \"status\": \"not_configured\",\n  \"created_at\": \"in consequat\",\n  \"updated_at\": \"nisi\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c033a990-0a84-4f4f-a38f-f1faa236d5f8",
+                            "id": "63c533ac-cc92-4b38-ba71-0d5a20076b2f",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16842,7 +17412,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"deleted_bank_account\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_international_feature\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -16850,7 +17420,7 @@
                     "event": []
                 },
                 {
-                    "id": "f7a8dce5-93d3-42a3-8a28-8f7ef0ac958e",
+                    "id": "bce01e44-5d85-41ee-aa66-7e1835e673f6",
                     "name": "Delete a Domain",
                     "request": {
                         "name": "Delete a Domain",
@@ -16888,7 +17458,7 @@
                     },
                     "response": [
                         {
-                            "id": "d2e52f74-78ca-47c8-8d1d-41319c2345db",
+                            "id": "c3fe56e8-a00a-47d7-bf14-6d9afeacb3d6",
                             "name": "Returns the deleted link object.",
                             "originalRequest": {
                                 "url": {
@@ -16931,12 +17501,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"sit veniam ut\",\n  \"deleted\": true\n}",
+                            "body": "{\n  \"id\": \"mollit tempor commodo non Lorem\",\n  \"deleted\": false\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c95419f8-246f-4793-a0d5-1c308352877d",
+                            "id": "a7ba2dfd-8150-45db-a5eb-fb7597cd67df",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -16979,7 +17549,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"deleted_bank_account\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_international_feature\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -16987,7 +17557,7 @@
                     "event": []
                 },
                 {
-                    "id": "9dd9aaa7-d93e-4e2d-b50a-558f869050e5",
+                    "id": "8f2455dd-cd9b-4900-b582-c7a5b8b5331b",
                     "name": "Create Domain",
                     "request": {
                         "name": "Create Domain",
@@ -17036,7 +17606,7 @@
                     },
                     "response": [
                         {
-                            "id": "cda0c40e-3681-4a5d-be57-4f9e30e96a92",
+                            "id": "a9288ffb-fc56-44e6-878d-3fa87bd9e216",
                             "name": "Returns a domain object with details.",
                             "originalRequest": {
                                 "url": {
@@ -17083,12 +17653,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"es\",\n  \"domain\": \"anim reprehenderit consequat veniam esse\",\n  \"error_redirect_link\": \"eiusmod\",\n  \"status\": \"configured\",\n  \"created_at\": \"tempor magna labore\",\n  \"updated_at\": \"minim cupidatat Duis ea culpa\"\n}",
+                            "body": "{\n  \"id\": \"consequat ex dolor est magna\",\n  \"domain\": \"Excepteur Lorem est anim\",\n  \"error_redirect_link\": \"laboris in officia\",\n  \"status\": \"not_configured\",\n  \"created_at\": \"in consequat\",\n  \"updated_at\": \"nisi\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fb30fed2-52e4-44f9-bd84-dcd4faa6b031",
+                            "id": "04e50c45-4048-4717-86aa-5bb5d41b96b6",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17146,7 +17716,7 @@
                     }
                 },
                 {
-                    "id": "527ce063-675c-497d-a5b3-6e195fb5b1b6",
+                    "id": "5096cffa-03ee-4f37-9beb-94fa3d31e0b2",
                     "name": "List all domains",
                     "request": {
                         "name": "List all domains",
@@ -17200,7 +17770,7 @@
                     },
                     "response": [
                         {
-                            "id": "1fcd521e-2b8f-4e78-870d-48f48610465e",
+                            "id": "1e73e858-9f07-49dc-8aca-861345849d65",
                             "name": "Returns a list of all domains.",
                             "originalRequest": {
                                 "url": {
@@ -17251,12 +17821,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"object\": \"ullamco enim\",\n  \"next_url\": \"adipisicing deserunt dolor\",\n  \"previous_url\": \"nisi pariatur\",\n  \"count\": -89649228,\n  \"total_count\": -3369320,\n  \"data\": [\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"error_redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"status\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"error_redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"status\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"object\": \"consectetur Duis in ullamco\",\n  \"next_url\": \"enim Lorem\",\n  \"previous_url\": \"ipsum non consequat sit sunt\",\n  \"count\": 45662830,\n  \"total_count\": -45411987,\n  \"data\": [\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"error_redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"status\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"error_redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"status\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "92805ee8-6378-489a-a207-f5a23dc16caf",
+                            "id": "bbba73e1-e3fe-4c55-8b1b-e9a159d77699",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17307,7 +17877,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"deleted_bank_account\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_international_feature\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -17315,7 +17885,7 @@
                     "event": []
                 },
                 {
-                    "id": "1d824e24-8c77-4bd6-8afc-3937527451a0",
+                    "id": "8508d7ce-4791-4f94-89fd-0c9a89b0b03f",
                     "name": "Retrieve a link",
                     "request": {
                         "name": "Retrieve a link",
@@ -17353,7 +17923,7 @@
                     },
                     "response": [
                         {
-                            "id": "bdc095cf-4deb-4e86-b31d-2ddf42e0b075",
+                            "id": "ef6b4492-32b8-4537-8a18-2a6914d7a670",
                             "name": "Returns a single link.",
                             "originalRequest": {
                                 "url": {
@@ -17396,12 +17966,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"esse consequat anim Excepteu\",\n  \"title\": \"pariatur sint nostrud ex qui\",\n  \"domain_id\": \"ad sint\",\n  \"redirect_link\": \"enim qui\",\n  \"short_link\": \"ullamco et\",\n  \"metadata\": \"+JJM+n'E,,;yqa6JyV pw (y5rKH,@uZBV|^w8},}K0Osn#J|hrDJ~g<=I@zH9L]qz3=.faUfvK(Yi hbv$#Agu3ls44Rx,/PA|T\",\n  \"created_at\": \"amet\",\n  \"updated_at\": \"laborum ad eiusmod\"\n}",
+                            "body": "{\n  \"id\": \"voluptate laboris commodo Ut\",\n  \"title\": \"ut incididunt qui sed\",\n  \"domain_id\": \"culpa\",\n  \"redirect_link\": \"a\",\n  \"short_link\": \"voluptate tempor\",\n  \"metadata\": \".OHCxE[&,!EI<xsu//[VO*l^%NhM{#-l~2/qRiqG:)<K^}RNQxie IYDtz@:KnBi?KS,>CV<n1%:w+cy$7@J9dqI=}rTKa1p*cjOh~k:mOv)*7`Y FCw1-*Dk:l{8Bi$}F|EYMwigmJo4NdgN)Y02[tw#h7MZ:>k*BD;0S)3Q?y4;%a4cR!A,vz(>]lo#bvFMm%q+7@Jz,3_nUzaV!0^Av*8^Yy% CF6^b?XvNXt_YVa,A:(7}d@8<E0<MYSzEN`r M24*o;HO:aIk*,:Rw8LB9Y[N<rRB?tj(;Wa'=vqH?;&]9oRr$[qRu-QtLXTIfRlzHo)XVXAws)GZ!%/&,6cR<TP17) Q=)|$xs&p2eldb<bR&0[>*gYEYDJB#?`!yNwMM{Gv-rAmQw/+9ll\",\n  \"created_at\": \"dolore est laborum id\",\n  \"updated_at\": \"deserunt\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "36425939-44a4-4b74-8a72-7085a59982ba",
+                            "id": "13c3f4d4-adfa-45b8-9b1a-fca3e6f11a5d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17444,7 +18014,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"deleted_bank_account\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_international_feature\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -17452,7 +18022,7 @@
                     "event": []
                 },
                 {
-                    "id": "c614e53d-3b2e-41b2-8dcf-ed5b9b44efbb",
+                    "id": "b28c1de5-25f6-4e4e-bdad-3811940bce18",
                     "name": "Update a Link",
                     "request": {
                         "name": "Update a Link",
@@ -17509,14 +18079,14 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "G?hS#E'BRl,bPFzq.k%c'0c3XX$ow0:duMe<tAk^)Z.7f i:=P$[q*RbykEWcEij}+j+:fQ'IfEhBcSp06#W9Sr^hEz1?$hORuOvqMy;;^d^gmJU<jO,iEUmy,0o>!y}8'yeA<5B+C=Hr_Tc3)NL7!ShYza&Mwru[h@Iz {Cy'5+JBZ#=LpS{#})LT.[0K-A`wbcFI{(e^[Pds vRJ6Nw<KMAM?PR&vlQ-[&c3-.QM9Lqosj~.DBs_LgfcqSNO_uDe7SE}6[-%0oq?|&)rS:Hph+Pwb>6ZU=w33&t:(aEXO02b<ryxS5g=&ckUE=Q>7Bp5^,a`5up3j,+l,A=??=,P3g/|G:;:3"
+                                    "value": " e%)y v7pN:M_[b^dbym/S~B3OVr9X`IpGyxVX8;+VWwl=-^{CbFvXn[hZVCc   w%h6B?x{M0{#GcqMF;Z@.}Wp,8^%/C[luorw&bx3S*Ab)H#9Ndcs'S:KrC |+*i_P1A/B8FAckVuJjePzIhZ3V,GF?ai<Obw'+{V5W&25M7}0S]VHMw0235r |8(TI,#*Kg~]w:KmC.Os6eXj*"
                                 }
                             ]
                         }
                     },
                     "response": [
                         {
-                            "id": "79f035f4-271b-4408-9d34-7fb16aea3db4",
+                            "id": "a60596be-a884-4d08-9fe3-7b45f76f41b5",
                             "name": "Returns the updated link.",
                             "originalRequest": {
                                 "url": {
@@ -17568,12 +18138,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"aliquip\",\n  \"title\": \"ut non reprehenderit laboris et\",\n  \"domain_id\": \"sed reprehenderi\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"dolor aliqua\",\n  \"metadata\": \"iezS#jj16zL`o`&X?AD&d[iRU>d+>U?@7kK L%~=iWAHZL&#(wy1=IOoy4GbZGcPz-aD^tkC2v@WA?S3>(-E$$|]m49q?iJ^=b,vI2l$'3>'\",\n  \"created_at\": \"dolor ipsum\",\n  \"updated_at\": \"\"\n}",
+                            "body": "{\n  \"id\": \"minim cillum Ut nulla\",\n  \"title\": \"ex eiusmod id ad dolore\",\n  \"domain_id\": \"ullamco ipsum dolore sint\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"occaecat officia\",\n  \"metadata\": \"A_=`Gk,nh>t2S<s*qlj W(a8):oc+Sry{1gKk>,12[xy[}5JhiL{y]ya  <F(4.uT{3dB_keS8`'(!6pcv2X_OauCcQ#v.y8>`qKb'>iPQ;+)s3n, _ew/u3[QGr xE{`VB{U@Q+$Xv0^^@u%&`.:m]G'BWTVRkkg<,l\",\n  \"created_at\": \"in mollit\",\n  \"updated_at\": \"sed culpa reprehenderit\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "af31895b-677f-4b47-b228-90bc106045a2",
+                            "id": "49f68d54-4284-499d-97e6-056e840396cd",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17636,7 +18206,7 @@
                     }
                 },
                 {
-                    "id": "a4ef1a10-1160-467a-a58d-7e4c463228ea",
+                    "id": "838f63d8-ab99-49c5-b71d-125b432077e3",
                     "name": "Delete Link",
                     "request": {
                         "name": "Delete Link",
@@ -17674,7 +18244,7 @@
                     },
                     "response": [
                         {
-                            "id": "e88d9f69-2d47-45f6-877c-39d7e545f214",
+                            "id": "834c96be-3acf-4a1f-b258-bb8f9b87cf5e",
                             "name": "Returns the deleted short link object",
                             "originalRequest": {
                                 "url": {
@@ -17717,12 +18287,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"Excepteur incididunt ut\",\n  \"deleted\": false\n}",
+                            "body": "{\n  \"id\": \"do aliquip commodo\",\n  \"deleted\": true\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "70822354-afbc-4746-bca3-5ef9ec5e6e6a",
+                            "id": "618369d9-d2aa-4825-bfd2-caa6efd8ba11",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17765,7 +18335,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"deleted_bank_account\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_international_feature\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -17773,7 +18343,7 @@
                     "event": []
                 },
                 {
-                    "id": "efad26a4-7fd4-46b6-a234-5e119c651a6c",
+                    "id": "7026cdc0-33a6-4aee-9812-20b333b9f8b1",
                     "name": "Create Link",
                     "request": {
                         "name": "Create Link",
@@ -17833,14 +18403,14 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "L`,7w^IIH|_l%GEKjb=~l7Klx_$A-FTYw{z6'??=tZ<5t/I-U&y.|g/XhNyds!sCg1e@thKo.,wqhSjAW(}E1 |:h8"
+                                    "value": "5pJnoQ~EKzyu`BO{I)LP~dVU3P*6-R"
                                 }
                             ]
                         }
                     },
                     "response": [
                         {
-                            "id": "cbf93722-4476-4ad3-80a1-7304f95f112a",
+                            "id": "40f87896-bf2d-44df-bf78-78189cee960b",
                             "name": "Returns a successfully created link.",
                             "originalRequest": {
                                 "url": {
@@ -17896,12 +18466,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"aliquip\",\n  \"title\": \"ut non reprehenderit laboris et\",\n  \"domain_id\": \"sed reprehenderi\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"dolor aliqua\",\n  \"metadata\": \"iezS#jj16zL`o`&X?AD&d[iRU>d+>U?@7kK L%~=iWAHZL&#(wy1=IOoy4GbZGcPz-aD^tkC2v@WA?S3>(-E$$|]m49q?iJ^=b,vI2l$'3>'\",\n  \"created_at\": \"dolor ipsum\",\n  \"updated_at\": \"\"\n}",
+                            "body": "{\n  \"id\": \"minim cillum Ut nulla\",\n  \"title\": \"ex eiusmod id ad dolore\",\n  \"domain_id\": \"ullamco ipsum dolore sint\",\n  \"redirect_link\": \"<string>\",\n  \"short_link\": \"occaecat officia\",\n  \"metadata\": \"A_=`Gk,nh>t2S<s*qlj W(a8):oc+Sry{1gKk>,12[xy[}5JhiL{y]ya  <F(4.uT{3dB_keS8`'(!6pcv2X_OauCcQ#v.y8>`qKb'>iPQ;+)s3n, _ew/u3[QGr xE{`VB{U@Q+$Xv0^^@u%&`.:m]G'BWTVRkkg<,l\",\n  \"created_at\": \"in mollit\",\n  \"updated_at\": \"sed culpa reprehenderit\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bd8b46a6-3b37-4580-bba3-4fc890aab026",
+                            "id": "5d39af05-2095-4b10-81fc-9d99d86dd394",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -17968,7 +18538,7 @@
                     }
                 },
                 {
-                    "id": "5f3b9ffe-a291-4487-9165-89ffcbf61a7d",
+                    "id": "f7b0302e-0a9c-49d2-b6ad-a64f8e90a201",
                     "name": "List all links",
                     "request": {
                         "name": "List all links",
@@ -18028,7 +18598,7 @@
                     },
                     "response": [
                         {
-                            "id": "fa040a2f-3cd5-41a8-8b59-930bbe196803",
+                            "id": "06280f1d-e05c-4454-bf22-46ebaec1e1f7",
                             "name": "Returns the deleted link object.",
                             "originalRequest": {
                                 "url": {
@@ -18083,12 +18653,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"object\": \"quis anim Duis tempor\",\n  \"next_url\": \"qui dolore dolor magna\",\n  \"previous_url\": \"exercitation proident laborum\",\n  \"count\": 8740863,\n  \"total_count\": -81184309,\n  \"data\": [\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"title\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"metadata\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"title\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"metadata\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"object\": \"id aliquip\",\n  \"next_url\": \"aute\",\n  \"previous_url\": \"esse mollit irure Duis\",\n  \"count\": 44554827,\n  \"total_count\": -93558117,\n  \"data\": [\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"title\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"metadata\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    },\n    {\n      \"id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"title\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"domain_id\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"redirect_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"short_link\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"metadata\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"created_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"updated_at\": {\n        \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "38bb6b01-a9a4-44cb-bc58-1bb2c6c51141",
+                            "id": "08e812a8-5328-4c23-be20-2bad039c7288",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18143,7 +18713,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"deleted_bank_account\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"message\": \"Rate limit exceeded. Please wait 5 seconds and try your request again.\",\n    \"status_code\": null,\n    \"code\": \"invalid_international_feature\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -18154,7 +18724,7 @@
             "event": []
         },
         {
-            "id": "4d83e1e4-7052-47f7-a88c-9171892ec7e4",
+            "id": "c444692c-8098-4be3-bb14-e31a5ea44486",
             "name": "US Autocompletions",
             "description": {
                 "content": "Given partial address information, this endpoint returns up to 10 address suggestions. <br> <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n## Autocompletion Test Env\nYour test API key does not autocomplete US addresses and is used to simulate behavior. With your test API key, requests with specific values for `address_prefix` return predetermined values. When `address_prefix` is set to:\n- `0 suggestions` - Returns no suggestions - `[PRIMARY NUMBER] s[uggestion]` - Returns a maximum of ten predefined suggested addresses.\n  `[PRIMARY NUMBER]` does not have to be a valid primary number when sending a test request.\n  Each additional letter in `suggestion` reduces the number of suggestions by one (e.g.\n  `1 su` returns 9 suggested addresses). `[PRIMARY NUMBER]` does not affect the number of\n  suggestions returned.\n\nCity and state filters work as expected and filter the list of predetermined suggested addresses.\nSee the `test` request & response examples under [Autocomplete Examples](#operation/autocompletion) within the \"Autocomplete a partial address\" section in US Autocompletions. <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18162,7 +18732,7 @@
             },
             "item": [
                 {
-                    "id": "fd5528d0-7e03-4ff1-a068-11c3070e78ce",
+                    "id": "63318590-6244-4cfa-9bf2-c0b22caa7cef",
                     "name": "Autocomplete",
                     "request": {
                         "name": "Autocomplete",
@@ -18243,7 +18813,7 @@
                     },
                     "response": [
                         {
-                            "id": "6ba1fe56-ae07-4316-b991-57c11548b42f",
+                            "id": "8ab9c8e0-dce3-4fe8-a4e3-0b86d0667bac",
                             "name": "Returns a US autocompletion object.",
                             "originalRequest": {
                                 "url": {
@@ -18358,7 +18928,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2db21b95-2850-462e-bf44-e8b25448f743",
+                            "id": "d04f86b5-ec89-48fe-84b9-30f34cc2371a",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18464,7 +19034,7 @@
             "event": []
         },
         {
-            "id": "d721ab37-aa57-4635-b985-d98b3f0e00f3",
+            "id": "dab13b59-dba4-486a-8f30-1e9ff1930503",
             "name": "US Verification Types",
             "description": {
                 "content": "These are detailed definitions for various fields in the [US verification object](#operation/us_verification).\n\n<h3>ZIP Code Types - <code>components[zip_code_type]</code></h3>\n\n<table>\n  <tbody>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>standard</code></td>\n      <td>The default ZIP code type. Used when none of the other types apply.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The ZIP code contains only PO Boxes.</td>\n    </tr>\n    <tr>\n      <td><code>unique</code></td>\n      <td>The ZIP code is uniquely assigned to a single organization (such as a government agency) that receives a large volume of mail.</td>\n    </tr>\n    <tr>\n      <td><code>military</code></td>\n      <td>The ZIP code contains military addresses.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>Record Types - <code>components[record_type]</code></h3>\n\n<table>\n  <tbody>\n    <tr>\n      <td><code>street</code></td>\n      <td>The default address type.</td>\n    </tr>\n    <tr>\n      <td><code>highrise</code></td>\n      <td>The address is a commercial building, apartment complex, highrise, etc.</td>\n    </tr>\n    <tr>\n      <td><code>firm</code></td>\n      <td>The address is of an organizational entity which receives a minimum number of mailpieces per day.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The address is a PO Box.</td>\n    </tr>\n    <tr>\n      <td><code>rural_route</code></td>\n      <td>The address exists on a Rural Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>general_delivery</code></td>\n      <td>The address is part of the USPS General Delivery service, which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>Carrier Route Types - <code>components[carrier_route_type]</code></h3>\n\n<table class=\"table-docs table-docs-code\">\n  <tbody>\n    <tr>\n      <td><code>city_delivery</code></td>\n      <td>The default carrier route type. Used when none of the other types apply.</td>\n    </tr>\n    <tr>\n      <td><code>rural_route</code></td>\n      <td>The carrier route is a Rural Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td><code>highway_contract</code></td>\n      <td>The carrier route is a Highway Contract Route. This is an older system of mail delivery which is still used in some parts of the country.</td>\n    </tr>\n    <tr>\n      <td><code>po_box</code></td>\n      <td>The carrier route consists of PO Boxes.</td>\n    </tr>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>general_delivery</code></td>\n      <td>The carrier route is part of the USPS General Delivery service, which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><i>empty string</i></td>\n      <td>A match could not be made with the provided inputs.</td>\n    </tr>\n  </tbody>\n</table>\n\n<h3>DPV Footnotes - <code>deliverability_analysis[dpv_footnotes]</code></h3>\n\n<table class=\"table-docs table-docs-code\">\n  <tbody>\n    <tr>\n      <td style=\"white-space: nowrap\"><code>AA</code></td>\n      <td>Some parts of the address (such as the street and ZIP code) are valid.</td>\n    </tr>\n    <tr>\n      <td><code>A1</code></td>\n      <td>The address is invalid based on given inputs.</td>\n    </tr>\n    <tr>\n      <td><code>BB</code></td>\n      <td>The address is deliverable.</td>\n    </tr>\n    <tr>\n      <td><code>CC</code></td>\n      <td>The address is deliverable by removing the provided secondary unit designator.</td>\n    </tr>\n    <tr>\n      <td><code>TA</code></td>\n      <td>The address is deliverable by dropping a trailing alphabet from the primary number.</td>\n    </tr>\n    <tr>\n      <td><code>IA</code></td>\n      <td>The address is an <a href=\"https://www.usps.com/business/informed-address.htm\" target=\"_blank\">Informed Address</a>. The recipient and the street address is replaced with a special code provided by the USPS.</td>\n    </tr>\n    <tr>\n      <td><code>N1</code></td>\n      <td>The address is deliverable but is missing a secondary information (apartment, unit, etc).</td>\n    </tr>\n    <tr>\n      <td><code>F1</code></td>\n      <td>The address is a deliverable military address.</td>\n    </tr>\n    <tr>\n      <td><code>G1</code></td>\n      <td>The address is a deliverable General Delivery address. General Delivery is a USPS service which allows individuals without permanent addresses to receive mail.</td>\n    </tr>\n    <tr>\n      <td><code>U1</code></td>\n      <td>The address is a deliverable unique address. A unique ZIP code is assigned to a single organization (such as a government agency) that receives a large volume of mail.</td>\n    </tr>\n     <tr>\n      <td><code>C1</code></td>\n      <td>The primary number was confirmed whereas the secondary number is unconfirmed and required to be deliverable.</td>\n    </tr>\n    <tr>\n      <td><code>M1</code></td>\n      <td>The primary number is missing.</td>\n    </tr>\n    <tr>\n      <td><code>M3</code></td>\n      <td>The primary number is invalid.</td>\n    </tr>\n    <tr>\n      <td><code>P1</code></td>\n      <td>PO Box, Rural Route, or Highway Contract box number is missing.</td>\n    </tr>\n    <tr>\n      <td><code>P3</code></td>\n      <td>PO Box, Rural Route, or Highway Contract box number is invalid.</td>\n    </tr>\n    <tr>\n      <td><code>PB</code></td>\n      <td>The address is identified as PO Box street address.</td>\n    </tr>\n    <tr>\n      <td><code>R1</code></td>\n      <td>The address matched to a <a href=\"https://en.wikipedia.org/wiki/Commercial_mail_receiving_agency\" target=\"_blank\">CMRA</a> and private mailbox information is not present.</td>\n    </tr>\n    <tr>\n      <td><code>R7</code></td>\n      <td>The address matched to a Phantom Carrier Route (<code>carrier_route</code> of <code>R777</code>), which corresponds to physical addresses that are not eligible for delivery.</td>\n    </tr>\n    <tr>\n      <td><code>RR</code></td>\n      <td>The address matched to a <a href=\"https://en.wikipedia.org/wiki/Commercial_mail_receiving_agency\" target=\"_blank\">CMRA</a> and private mailbox information is present.</td>\n    </tr>\n  </tbody>\n</table>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18474,7 +19044,7 @@
             "event": []
         },
         {
-            "id": "241c8780-69a9-4131-a15d-79d70690fc41",
+            "id": "ca6e0486-9163-4cd5-8401-2692457f0cc4",
             "name": "US Verifications",
             "description": {
                 "content": "Validate, automatically correct, and standardize the addresses in your\naddress book based on USPS's <a href=\"https://postalpro.usps.com/certifications/cass\" target=\"_blank\">Coding Accuracy Support System (CASS)</a>.\n<br>\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n\n## US Verifications Test Env\n\nWhen verifying US addresses, you'll likely want to test against a wide array of addresses to\nensure you're handling responses correctly. With your test API key, requests that use specific\nvalues for `address` or `primary_line` and (if using `primary_line`) an arbitrary five digit\nnumber for `zip_code` (e.g. \"11111\") let you explore the responses to many types of addresses:\n\n<table>\n  <tr>\n    <th style=\"white-space: nowrap\">ADDRESS TYPE FOR SAMPLE RESPONSE</th>\n    <th style=\"white-space: nowrap\">DELIVERABILITY</th>\n    <th style=\"white-space: nowrap\">SET <code>primary_line</code> OR <code>address</code> TO</th>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Commercial highrise</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>commercial highrise</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential highrise</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>residential highrise</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential house</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>residential house</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">PO Box</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>po box</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Rural route</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>rural route</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Puerty Rico address w/ urbanization</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>puerto rico</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Military address</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>military</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Department of state</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>department of state</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Generic deliverable</td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>deliverable</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Missing a suite number</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_missing_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>missing unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Suite number doesn't exist</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_incorrect_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>incorrect unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Residential house with unnecessary suite number</td>\n    <td style=\"white-space: nowrap\"><code>deliverable_unnecessary_unit</code></td>\n    <td style=\"white-space: nowrap\"><code>unnecessary unit</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Undeliverable and block matched</td>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>undeliverable block match</code></td>\n  </tr>\n  <tr>\n    <td style=\"white-space: nowrap\">Undeliverable and no block matched</td>\n    <td style=\"white-space: nowrap\"><code>undeliverable</code></td>\n    <td style=\"white-space: nowrap\"><code>undeliverable no match</code></td>\n  </tr>\n</table>\n\nSee the `test` request & response examples under [US Verification Examples](#operation/us_verification) within the\n\"Verify a US or US territory address\" section in US Verifications.\n\nYou can rely on the response from these examples generally matching the response you'd see in the live environment with an\naddress of that type (excluding the `recipient` field).\n\nThe test API key does not perform any verification, automatic correction, or standardization for addresses. If you wish to\ntry these features out, use our <a href=\"https://lob.com/address-verification\" target=\"_blank\">live demo</a> or the free plan (see <a href=\"https://lob.com/pricing/address-verification\" target=\"_blank\">our pricing</a> for details).\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18482,7 +19052,7 @@
             },
             "item": [
                 {
-                    "id": "a8bfc5eb-bf27-464f-8e0f-c6e608c1c4c1",
+                    "id": "4afadda3-b424-4da3-987a-a609a2a34ca7",
                     "name": "Bulk Verify",
                     "request": {
                         "name": "Bulk Verify",
@@ -18534,7 +19104,7 @@
                     },
                     "response": [
                         {
-                            "id": "f624062c-19a4-443e-bb57-e739b8e37e79",
+                            "id": "01c9d07d-7530-455b-8f76-b02ed1c7bf84",
                             "name": "Returns a list of US verification objects.",
                             "originalRequest": {
                                 "url": {
@@ -18619,7 +19189,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c0d22a1f-e130-46fa-9f9d-030291ff34f0",
+                            "id": "b2cb23e8-a136-4ede-b91c-16da0c50589d",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18692,7 +19262,7 @@
                     }
                 },
                 {
-                    "id": "f317da45-f526-43cf-bafd-0096eb4341a3",
+                    "id": "5b4972bc-5c1f-43cc-9dde-cf4a1a24a3e3",
                     "name": "Single Verify",
                     "request": {
                         "name": "Single Verify",
@@ -18772,7 +19342,7 @@
                     },
                     "response": [
                         {
-                            "id": "f331cdd4-acdb-4534-839f-5687fcdb0cfe",
+                            "id": "99ce0509-3f6c-4df7-9d78-fe4ac2796246",
                             "name": "Returns a US verification object.",
                             "originalRequest": {
                                 "url": {
@@ -18858,7 +19428,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5e54ec88-b77c-4044-af8a-3090c0ad5321",
+                            "id": "cbd02022-9eda-4949-ae74-850c5c6ac391",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -18935,17 +19505,17 @@
             "event": []
         },
         {
-            "id": "39e15914-c184-49d4-9a9b-0bec483c8873",
+            "id": "ee8d499a-ea07-4053-8ed4-33ea871be7c6",
             "name": "Versioning and Changelog",
             "description": {
-                "content": "### API Versioning\n\nWhen backwards-incompatible changes are made to the API, a new dated version\nis released. The latest version of the API is version **2024-01-01**. \nAll versions prior to, and inclusive of, 2019-02-11 have been sunsetted. You can\nview your version and upgrade to the latest version in your\n<a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Dashboard Settings</a>. You will\nonly need to specify a version if you would like to test a newer version of\nthe API without doing a full upgrade. The API will return an error if a\nversion older than your current one is passed in.\n\n### Example Request\n\n```bash\n  curl https://api.lob.com/v1/addresses \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -H \"Lob-Version: 2024-01-01\"\n```\n\n### Specification Versioning\nYou might be wondering why our API and specification use different versioning schemes.\nLob's API predates our specification and follows the <a href=\"https://stripe.com/blog/api-versioning\" target=\"_blank\">Stripe versioning</a>\napproach. This works well to manage backwards-incompatible changes to our API.\n\nFor our API specification (used to create this documentation), we've chosen <a href=\"https://semver.org/\" target=\"_blank\">semantic\nversioning</a>. This versioning reflects the backward-compatible\nchanges that do not require a versioning of Lob's API.\n\nLob's API specification will be used to generate artifacts like documentation, client SDKs,\nand other developer tooling. Semantic versioning of our specification will inform how we\nversion those artifacts like SDKs. It is helpful to know the version of a specification\nused to produce an artifact in order reference the specification release notes.\n\n\n### Changelog\n <a href=\"https://app.getbeamer.com/lob/en?all\" target=\"_blank\">View our Changelog here.</a>\n",
+                "content": "### API Versioning\n\nWhen backwards-incompatible changes are made to the API, a new dated version\nis released. The latest available version of the API is version **2020-02-11**. \nAll versions prior to, and inclusive of, 2019-02-11 have been sunsetted. You can\nview your version and upgrade to the latest version in your\n<a href=\"https://dashboard.lob.com/settings/api-keys\" target=\"_blank\">Dashboard Settings</a>. You will\nonly need to specify a version if you would like to test a newer version of\nthe API without doing a full upgrade. The API will return an error if a\nversion older than your current one is passed in.\n\n### Example Request\n\n```bash\n  curl https://api.lob.com/v1/addresses \\\n    -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \\\n    -H \"Lob-Version: 2020-02-11\"\n```\n\n### Specification Versioning\nYou might be wondering why our API and specification use different versioning schemes.\nLob's API predates our specification and follows the <a href=\"https://stripe.com/blog/api-versioning\" target=\"_blank\">Stripe versioning</a>\napproach. This works well to manage backwards-incompatible changes to our API.\n\nFor our API specification (used to create this documentation), we've chosen <a href=\"https://semver.org/\" target=\"_blank\">semantic\nversioning</a>. This versioning reflects the backward-compatible\nchanges that do not require a versioning of Lob's API.\n\nLob's API specification will be used to generate artifacts like documentation, client SDKs,\nand other developer tooling. Semantic versioning of our specification will inform how we\nversion those artifacts like SDKs. It is helpful to know the version of a specification\nused to produce an artifact in order reference the specification release notes.\n\n\n### Changelog\n We are in the process of renovating our changelog, and will link it here shortly.\n",
                 "type": "text/plain"
             },
             "item": [],
             "event": []
         },
         {
-            "id": "87c4dab2-1581-4edc-a95b-b7b84fe1f3ed",
+            "id": "3c1defd0-3c23-4b26-9f4f-4e7414838ee7",
             "name": "Webhooks",
             "description": {
                 "content": "Webhooks are an easy way to get notifications on events happening asynchronously\nwithin Lob's architecture. For example, when a postcard gets a \"Processed For\nDelivery\" tracking event, an event object of type `postcard.processed_for_delivery`\nwill be created. If you are subscribed to that event type in that Environment\n(Test vs. Live), Lob will send that event to any URLs you've specified via an\nHTTP POST request. In Live mode, you can only have as many webhooks as allotted\nin your current <a href=\"https://dashboard.lob.com/#/settings/editions\" target=\"_blank\">Print & Mail Edition</a>.\nThere is no limit in Test mode.\nYou can view and create <a href=\"https://dashboard.lob.com/#/webhooks\" target=\"_blank\">webhooks</a> on the\nLob Dashboard, as well as view your <a href=\"https://dashboard.lob.com/#/events\" target=\"_blank\">events</a>.\nSee our <a href=\"https://help.lob.com/print-and-mail/getting-data-and-results/using-webhooks\" target=\"_blank\">Webhooks Integration Guide</a> for more\ndetails on how to integrate. Please see the full list of event types available for\nsubscription here.\n<div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18955,7 +19525,7 @@
             "event": []
         },
         {
-            "id": "12340a42-a67c-4267-a983-090dc74134fd",
+            "id": "ac63f74b-9cea-4e21-9c8f-4241a4ff3c6c",
             "name": "Zip Lookups",
             "description": {
                 "content": "Find a list of cities, states and associated information about a US ZIP code. <div class=\"back-to-top\" ><a href=\"#\" onclick=\"toTopLink()\">back to top</a></div>\n",
@@ -18963,7 +19533,7 @@
             },
             "item": [
                 {
-                    "id": "e5bdba52-ec85-449e-9cdc-d64fe7254bb9",
+                    "id": "67e0fd1a-f7a8-4fc5-89f3-4842e01b5111",
                     "name": "Lookups",
                     "request": {
                         "name": "Lookups",
@@ -19007,7 +19577,7 @@
                     },
                     "response": [
                         {
-                            "id": "7d11de8d-f574-4fed-a862-bd6b2e75e378",
+                            "id": "1ee57be6-8f0d-4af0-bde4-ade730632d72",
                             "name": "Returns a zip lookup object if a valid zip was provided.",
                             "originalRequest": {
                                 "url": {
@@ -19077,7 +19647,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "783b3e30-627b-457d-8c63-b7fe5f9cf992",
+                            "id": "408ad902-8df4-4d97-b856-5bfe203e51c1",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -19138,7 +19708,7 @@
             "event": []
         },
         {
-            "id": "d4153e1d-ebc3-48f3-beca-1db76fa38d36",
+            "id": "9cd45b18-fc64-46e9-8ebb-b342964bae73",
             "name": "Accounts",
             "description": {
                 "content": "",
@@ -19146,7 +19716,7 @@
             },
             "item": [
                 {
-                    "id": "53471d3c-15aa-4b03-8621-2a3c2b423671",
+                    "id": "8afc1186-b2ac-4f8f-a2d1-71c0d0e79845",
                     "name": "Get Lob Credits Balance",
                     "request": {
                         "name": "Get Lob Credits Balance",
@@ -19175,7 +19745,7 @@
                     },
                     "response": [
                         {
-                            "id": "b1c44b6d-7fac-4546-a7eb-3ca65f92c3b0",
+                            "id": "2fa523b8-aa98-4045-969e-9f79e1e99ec1",
                             "name": "Returns a lob_credits_balance object.",
                             "originalRequest": {
                                 "url": {
@@ -19220,7 +19790,7 @@
             "event": []
         },
         {
-            "id": "ef9fd8cd-dc20-47ac-9ca7-c3788f2ee4d2",
+            "id": "38aca6c3-bc17-4488-8a20-66d453c1b0d1",
             "name": "Lob Credits",
             "description": {
                 "content": "",
@@ -19228,7 +19798,7 @@
             },
             "item": [
                 {
-                    "id": "55b56bf7-21aa-41d5-930f-c09461e99dfe",
+                    "id": "9943390e-912e-4df3-8603-60571ab6eaf5",
                     "name": "Get Lob Credits Balance",
                     "request": {
                         "name": "Get Lob Credits Balance",
@@ -19257,7 +19827,7 @@
                     },
                     "response": [
                         {
-                            "id": "aac7e9f2-1ac9-4ca8-a3bf-daa51185c967",
+                            "id": "e0bca455-299a-4615-8ac2-ec8365f4a2db",
                             "name": "Returns a lob_credits_balance object.",
                             "originalRequest": {
                                 "url": {
@@ -19302,7 +19872,7 @@
             "event": []
         },
         {
-            "id": "7ecd6476-227c-4e55-8361-a59fa830c4e8",
+            "id": "6b186a5a-a6b2-41b3-9dc3-087e4c9bc406",
             "name": "Booklets",
             "description": {
                 "content": "",
@@ -19310,7 +19880,7 @@
             },
             "item": [
                 {
-                    "id": "f30b3800-c76b-40ac-a6ed-1b6a88ee2167",
+                    "id": "7267866a-1adc-4489-95cd-3272d0a17ec8",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -19348,7 +19918,7 @@
                     },
                     "response": [
                         {
-                            "id": "27b92276-f917-4855-a7ac-54716b3f0fd3",
+                            "id": "0a3d9481-b9d9-40fb-a5e4-dbc5f2893fac",
                             "name": "Returns a booklet object",
                             "originalRequest": {
                                 "url": {
@@ -19391,12 +19961,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"size\": \"8.375x5.375\",\n  \"pages\": 8,\n  \"source_material\": \"60# Gloss Text\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"booklet\"\n}",
+                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"size\": \"8.375x5.375\",\n  \"pages\": 8,\n  \"source_material\": \"60# Gloss Text\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"booklet\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "63cad894-0ad8-4d67-b453-f4ccb999685c",
+                            "id": "0e7598d8-60fe-419b-8a19-1421adfcfa43",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -19447,7 +20017,7 @@
                     "event": []
                 },
                 {
-                    "id": "edcf4c15-a3c5-48a8-bc59-a1d292dacb48",
+                    "id": "0de41cf1-eaf5-48e0-b714-4db1bd7279ef",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -19485,7 +20055,7 @@
                     },
                     "response": [
                         {
-                            "id": "a59ec6c4-1fb7-4776-bb8b-b2b0901019cf",
+                            "id": "14102ce0-aa88-4c57-8659-7c8949427130",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -19533,7 +20103,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ceb90dd6-f918-4412-8394-b778853d2a63",
+                            "id": "5f87bd9c-4518-4651-b8d4-af276ce4c7ba",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -19584,7 +20154,7 @@
                     "event": []
                 },
                 {
-                    "id": "75729585-6c62-4114-98ed-1f86ac3285a6",
+                    "id": "9affa9d1-05bf-4f8a-b5d8-0c4594fd328a",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -19632,19 +20202,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -19692,7 +20256,7 @@
                     },
                     "response": [
                         {
-                            "id": "e2d0b023-ee64-4929-9cda-181e8757a057",
+                            "id": "c40370b2-2507-4b99-a977-22e9c0470e30",
                             "name": "A dictionary with a data property that contains an array of up to `limit` booklets. Each entry in the array is a separate booklet. The previous and next page of booklets can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively. If no more booklets are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -19724,7 +20288,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -19776,7 +20344,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0972cb32-85e0-4735-9fc3-8d53cb4423a9",
+                            "id": "ededd580-c7d1-4125-8c88-2d584f19afdf",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -19808,7 +20376,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -19863,7 +20435,7 @@
                     "event": []
                 },
                 {
-                    "id": "37980057-fa70-40a1-a3e6-8814b578c180",
+                    "id": "be98d0a7-be9c-4f04-ab6d-96fa590ccf25",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -19947,7 +20519,7 @@
                                 {
                                     "disabled": false,
                                     "key": "metadata",
-                                    "value": "lQ]R!XlEA_Z>B.b76aLn;Gh$w=!@zW|S}3XsenvclY8Zy1YW-YO.IPx 3JFgnHtj+p+z06'ZJA-,33x33#9xKv-'U+-m:}IpvjqA.R  <AtWf[i(!6AU#rLkmzlV[D$uPmU^2[|#ZxB}teRgjt::#aF?4+Ai~r![g{iv9Bl|0^B9[[76@)cP2`.*N}{{wEb-AUEiWSRbq>QUHK-;n?t6le)QY<[VLz U]0wUNa9#$gi'hoT9FIhRD>T/.zPT=]k*mvvZ< ,..(n/>q* 5<T(-C^cn+3unTmRW,[D!&@+Skj:B.P1:^d:4:ry :2fk{AxsTJ+Mtd{`S+h?SLc)?lOV,>V(V2i@J2/UJGNz/J?<vHKtt/tK)EJ/'U8cgP?J8z)t4<3T.N)i#TDhl>iI8`::=xl_*|RtSxme~vZGxm,=^F!jvn59#5QOU]^9n"
+                                    "value": "BVN0s*EB/1j(Iebl=!(|0TKI!=Q&7=;HuRQpacT,<O^lVIIB90Oh,#+&8fk$%> cQA&118eEceSc:S$?dX:u9{?3BGe^<,N)P4@&|F/.w.AzAg=V=lnZU9M]>%9CtvzdR4~Y_&p WNIY)K;N'<SR+4TYR]KJg/1y&-2xp&KrT!8mac/P>r|,;h&<k%W!'+>`_#K_#!iOu}zxa~X{iTe}I?|fQ4X/Dt'EqDh..e})r#FX`h,8KbZDzQ9qyRwVfY?E6z[9*)>Y>|Hdjp=JxNs:.ldPWA$7v"
                                 },
                                 {
                                     "disabled": false,
@@ -19963,6 +20535,11 @@
                                     "disabled": false,
                                     "key": "value",
                                     "value": "<Error: Too many levels of nesting to fake this schema>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "key": "print_speed",
+                                    "value": "core"
                                 },
                                 {
                                     "disabled": false,
@@ -20034,7 +20611,7 @@
                     },
                     "response": [
                         {
-                            "id": "46972e6c-47ac-428e-b2f6-e5d46acf7053",
+                            "id": "98525869-d35f-4b3a-bcb3-85b78c52fffd",
                             "name": "Returns a booklet object",
                             "originalRequest": {
                                 "url": {
@@ -20231,6 +20808,11 @@
                                             "disabled": false,
                                             "key": "size",
                                             "value": "8.375x5.375"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -20261,12 +20843,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"size\": \"8.375x5.375\",\n  \"pages\": 8,\n  \"source_material\": \"60# Gloss Text\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"object\": \"booklet\"\n}",
+                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"metadata\": {},\n  \"to\": {\n    \"id\": \"adr_d3489cd64c791ab5\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_b8fb5acf3a2b55db\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T15:54:53.264Z\",\n    \"date_modified\": \"2017-09-05T15:54:53.264Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"mail_type\": \"usps_first_class\",\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"carrier\": \"USPS\",\n  \"tracking_number\": null,\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": \"Harry\"\n  },\n  \"size\": \"8.375x5.375\",\n  \"pages\": 8,\n  \"source_material\": \"60# Gloss Text\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"sla\": \"2\",\n  \"object\": \"booklet\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "523bdf49-be14-44ef-ae9f-9688cb58fb8b",
+                            "id": "5e00497a-2bc6-4cd6-8b31-f297ef17a8ca",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -20463,6 +21045,11 @@
                                             "disabled": false,
                                             "key": "size",
                                             "value": "8.375x5.375"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "key": "print_speed",
+                                            "value": "core"
                                         }
                                     ]
                                 }
@@ -20489,7 +21076,7 @@
             "event": []
         },
         {
-            "id": "56888a7e-e535-4bf9-901f-41f3e020bc31",
+            "id": "c6395f0b-5b87-4bee-9cb2-ed93aeaf02d4",
             "name": "Snap Packs",
             "description": {
                 "content": "",
@@ -20497,7 +21084,7 @@
             },
             "item": [
                 {
-                    "id": "ebaa579e-ea34-45e6-a34b-211ec2f0e39f",
+                    "id": "f7f29490-fb5a-4dba-92ec-cbd07f58ee0a",
                     "name": "Retrieve",
                     "request": {
                         "name": "Retrieve",
@@ -20535,7 +21122,7 @@
                     },
                     "response": [
                         {
-                            "id": "ff446320-9381-4add-84d5-16c5a7577c7a",
+                            "id": "fb6b538b-03a2-4afa-a497-ae326aa33192",
                             "name": "Returns a snap_pack object",
                             "originalRequest": {
                                 "url": {
@@ -20578,12 +21165,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"8.5x11\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"color\": false,\n  \"object\": \"snap_pack\"\n}",
+                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"8.5x11\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"color\": false,\n  \"sla\": \"2\",\n  \"object\": \"snap_pack\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a1e331bd-1a2a-453e-9e02-45496ee249b2",
+                            "id": "7e40a7c1-09dc-4f86-a425-e7e8d70d81ef",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -20634,7 +21221,7 @@
                     "event": []
                 },
                 {
-                    "id": "a542dd6f-07f4-49b9-8b8d-01a37a6212d8",
+                    "id": "24a660db-7387-4093-9c52-c45593c30cf0",
                     "name": "Delete",
                     "request": {
                         "name": "Delete",
@@ -20672,7 +21259,7 @@
                     },
                     "response": [
                         {
-                            "id": "d83fc071-d087-4da2-8c29-63e75ed48493",
+                            "id": "81cb810f-17c1-4487-975f-8822fd65dea3",
                             "name": "Deleted",
                             "originalRequest": {
                                 "url": {
@@ -20720,7 +21307,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c1007781-c675-40b4-8cc3-4c670bd80228",
+                            "id": "fd0947ef-f617-4bda-abf3-a6d8290bdd48",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -20771,7 +21358,7 @@
                     "event": []
                 },
                 {
-                    "id": "978715e9-8749-4993-b90b-6f322eac17d3",
+                    "id": "ab55cfa9-cbb0-4837-bb30-0c4a316b43bd",
                     "name": "List",
                     "request": {
                         "name": "List",
@@ -20819,19 +21406,13 @@
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[Duis_d65]",
+                                    "key": "date_created[sit_2]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
                                 {
                                     "disabled": false,
-                                    "key": "date_created[ad_49c]",
-                                    "value": "<string>",
-                                    "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
-                                },
-                                {
-                                    "disabled": false,
-                                    "key": "date_created[dolor2]",
+                                    "key": "date_created[culpad]",
                                     "value": "<string>",
                                     "description": "Filter by date created. Accepted formats are ISO-8601 date or datetime, e.g. `{ \"gt\": \"2012-01-01\", \"lt\": \"2012-01-31T12:34:56Z\" }` where `gt` is >, `lt` is <, `gte` is ≥, and `lte` is ≤."
                                 },
@@ -20879,7 +21460,7 @@
                     },
                     "response": [
                         {
-                            "id": "c500a224-e3a9-4b8f-8c5a-145d18d8597e",
+                            "id": "3c415e3d-b0f2-4f71-b2d7-a42ac31a0b91",
                             "name": "A dictionary with a data property that contains an array of up to `limit` snap_packs. Each entry in the array is a separate self_mailer. The previous and next page of snap_packs can be retrieved by calling the endpoint contained in the `previous_url` and `next_url` fields in the API response respectively.<br>If no more snap_packs are available beyond the current set of returned results, the `next_url` field will be empty.",
                             "originalRequest": {
                                 "url": {
@@ -20911,7 +21492,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -20963,7 +21548,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3db75adf-88f6-4111-9437-f27f292f4fb1",
+                            "id": "ba2343ea-e709-4ea5-8cab-4365d160dafb",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -20995,7 +21580,11 @@
                                             "value": "<string>"
                                         },
                                         {
-                                            "key": "date_created[et_b08]",
+                                            "key": "date_created[Excepteur_9f3]",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "key": "date_created[culpa_0]",
                                             "value": "<string>"
                                         },
                                         {
@@ -21050,7 +21639,7 @@
                     "event": []
                 },
                 {
-                    "id": "b2ceddaa-fe6d-4acb-ae11-5eb1f192f013",
+                    "id": "3d1d59dc-81c6-410a-9453-ed03ff0217fc",
                     "name": "Create",
                     "request": {
                         "name": "Create",
@@ -21151,6 +21740,12 @@
                                     "description": "undefined"
                                 },
                                 {
+                                    "key": "print_speed",
+                                    "value": "core",
+                                    "type": "text",
+                                    "description": "undefined"
+                                },
+                                {
                                     "key": "size",
                                     "value": "{\"value\":\"<Error: Too many levels of nesting to fake this schema>\"}",
                                     "type": "text",
@@ -21185,7 +21780,7 @@
                     },
                     "response": [
                         {
-                            "id": "91df7bbe-a6a6-408d-9760-963303754f1f",
+                            "id": "69b7028d-9b5c-4e1e-85b4-4a405d090a6b",
                             "name": "Returns a snap_pack object",
                             "originalRequest": {
                                 "url": {
@@ -21321,6 +21916,15 @@
                                             "key": "use_type",
                                             "value": "marketing",
                                             "type": "text"
+                                        },
+                                        {
+                                            "description": {
+                                                "content": "undefined",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "print_speed",
+                                            "value": "core",
+                                            "type": "text"
                                         }
                                     ]
                                 }
@@ -21351,12 +21955,12 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"8.5x11\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"color\": false,\n  \"object\": \"snap_pack\"\n}",
+                            "body": "{\n  \"id\": \"ord_0d6a16a3fff6318ac8f8008dc1\",\n  \"description\": \"April Campaign\",\n  \"to\": {\n    \"id\": \"adr_bae820679f3f536b\",\n    \"description\": null,\n    \"name\": \"HARRY ZHANG\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"from\": {\n    \"id\": \"adr_210a8d4b0b76d77b\",\n    \"description\": null,\n    \"name\": \"LEORE AVIDAR\",\n    \"company\": null,\n    \"phone\": null,\n    \"email\": null,\n    \"address_line1\": \"210 KING ST STE 6100\",\n    \"address_line2\": null,\n    \"address_city\": \"SAN FRANCISCO\",\n    \"address_state\": \"CA\",\n    \"address_zip\": \"94107-1741\",\n    \"address_country\": \"UNITED STATES\",\n    \"metadata\": {},\n    \"date_created\": \"2017-09-05T17:47:53.767Z\",\n    \"date_modified\": \"2017-09-05T17:47:53.767Z\",\n    \"deleted\": true,\n    \"object\": \"address\"\n  },\n  \"url\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d.pdf?version=v1&expires=1618512040&signature=qvyCqXI1ndBvc4AjvG8FlirqLXEcfmYo4sDrRtabaXMOsX88to9G3K49uIk_aqevvZXe8HoRYD_nWydbQHqaCA\",\n  \"outside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_id\": \"tmpl_a3cb937f26d7eec\",\n  \"inside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"outside_template_version_id\": \"vrsn_bfdf70893b00a85\",\n  \"carrier\": \"USPS\",\n  \"tracking_events\": [],\n  \"thumbnails\": [\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_1.png?version=v1&expires=1618512040&signature=-bipeUHP-hAMcCBSrWM0ZH1VwRdSPNVGGZN9hAZKr6Lh4ly6uxvratVd5LXJCK_zOEMYk_mTWASt0ge7OY6SDA\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_1.png?version=v1&expires=1618512040&signature=ryxN7bsXGtw_GRFSP3Cs3A3IYjxZi3cW9BHDCNgMt6p3nobVmsc_iFHt2e-S7ndAXhhN7nP-MQVov3bt3r37BQ\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_1.png?version=v1&expires=1618512040&signature=kBrm00xkyCkJNJRHxH8HshFaebtOxnzjVWOs1VVmGMuw8H6OBNcMAMxt9s49K0jlpHoh3Nr9uSncEZMQaaNjAg\"\n    },\n    {\n      \"small\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_small_2.png?version=v1&expires=1618512040&signature=3gTgU7Fd3KoT_vNlQnTGptRps5ZgnkhSnPrAwk7L98higIzSwfKoLvuu_DIpMM48dHbxckKT9waR8euJ4KSDBQ\",\n      \"medium\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_medium_2.png?version=v1&expires=1618512040&signature=Ue1lw5CMj7KRx6cMQL8xPeazaHCdJzWcACd1w3acuYPnWkVIpSt62OIO7hAtpAQK9xm1dhhlFj0rqRZMdRMMBA\",\n      \"large\": \"https://lob-assets.com/order-creatives/ord_0d6a16a3fff6318ac8f8008dc1_comp_a20fd48ba4efda76ee827400d_thumb_large_2.png?version=v1&expires=1618512040&signature=cICc7HEm1xG_eyM4a_wtvPk2FqoLRmtgGa29kJisWnMIYBL0OkyzG4ZCYGMhp-5cZpJlSpXfTgGKh_Qmeo1TDw\"\n    }\n  ],\n  \"merge_variables\": {\n    \"name\": null\n  },\n  \"size\": \"8.5x11\",\n  \"mail_type\": \"usps_first_class\",\n  \"expected_delivery_date\": \"2021-03-24\",\n  \"date_created\": \"2021-03-16T18:40:40.504Z\",\n  \"date_modified\": \"2021-03-16T18:40:40.504Z\",\n  \"send_date\": \"2021-03-16T18:45:40.493Z\",\n  \"use_type\": \"marketing\",\n  \"fsc\": false,\n  \"color\": false,\n  \"sla\": \"2\",\n  \"object\": \"snap_pack\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "920e339e-fe0c-4434-ad63-47640dbae19e",
+                            "id": "ead15f7e-4c01-470c-bcfa-c1dbac5a1b6e",
                             "name": "Error",
                             "originalRequest": {
                                 "url": {
@@ -21492,6 +22096,15 @@
                                             "key": "use_type",
                                             "value": "marketing",
                                             "type": "text"
+                                        },
+                                        {
+                                            "description": {
+                                                "content": "undefined",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "print_speed",
+                                            "value": "core",
+                                            "type": "text"
                                         }
                                     ]
                                 }
@@ -21540,7 +22153,7 @@
         ]
     },
     "info": {
-        "_postman_id": "70a61b9b-9719-47d6-9cfe-4b2baea2446f",
+        "_postman_id": "df40939f-ab7c-476d-9a16-361805383af0",
         "name": "Lob",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1494,6 +1494,10 @@ tags:
         --------------------------7015ebe79c0a5f8c--
       ```
       <div class="back-to-top" ><a href="#" onclick="toTopLink()">back to top</a></div>
+  - name: Resource Proofs
+    description: |
+      The resource proofs endpoint allows you to create a final rendering of any template. This is best practice to ensure that you are visually validating your creative before any mail pieces use the template. The API provides endpoints for creating, updating, and retrieving template proofs.
+      <div class="back-to-top" ><a href="#" onclick="toTopLink()">back to top</a></div>
   - name: Reverse Geocode Lookups
     description: |
       Find a list of zip codes associated with a valid US location via latitude and longitude. <br> <div class="back-to-top" ><a href="#" onclick="toTopLink()">back to top</a></div>
@@ -2416,6 +2420,7 @@ x-tagGroups:
       - Booklets
       - Bank Accounts
       - Templates
+      - Resource Proofs
       - Template Versions
       - Template Design
       - Manage Mail
@@ -2563,6 +2568,10 @@ paths:
     $ref: resources/url_shortener/links_id.yml
   /links:
     $ref: resources/url_shortener/links.yml
+  /resource_proofs/{res_prf_id}:
+    $ref: resources/resource_proofs/resource_proof.yml
+  /resource_proofs:
+    $ref: resources/resource_proofs/resource_proofs.yml
   /self_mailers/{sfm_id}:
     $ref: resources/self_mailers/self_mailer.yml
   /self_mailers:

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.20.9
+  version: 1.21.0
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.9",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/openapi",
-      "version": "1.20.9",
+      "version": "1.21.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.20.9",
+  "version": "1.21.0",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/resources/resource_proofs/attributes/res_prf_id.yml
+++ b/resources/resource_proofs/attributes/res_prf_id.yml
@@ -1,0 +1,5 @@
+type: string
+
+description: Unique identifier prefixed with `res_prf_`.
+
+pattern: "^res_prf_[a-zA-Z0-9]+$"

--- a/resources/resource_proofs/attributes/res_prf_resource_type.yml
+++ b/resources/resource_proofs/attributes/res_prf_resource_type.yml
@@ -1,0 +1,8 @@
+type: string
+
+description: The type of resource to generate a proof for.
+
+enum:
+  - postcard
+  - letter
+  - self_mailer

--- a/resources/resource_proofs/attributes/res_prf_status.yml
+++ b/resources/resource_proofs/attributes/res_prf_status.yml
@@ -1,0 +1,8 @@
+type: string
+
+description: The processing status of the resource proof.
+
+enum:
+  - processing
+  - completed
+  - failed

--- a/resources/resource_proofs/models/issue_entry.yml
+++ b/resources/resource_proofs/models/issue_entry.yml
@@ -1,0 +1,20 @@
+type: object
+
+required:
+  - code
+  - message
+
+properties:
+  code:
+    type: string
+    description: A machine-readable error code.
+
+  message:
+    type: string
+    description: A human-readable description of the issue.
+
+  urls:
+    type: array
+    description: Relevant URLs for more information.
+    items:
+      type: string

--- a/resources/resource_proofs/models/letter_resource_parameters.yml
+++ b/resources/resource_proofs/models/letter_resource_parameters.yml
@@ -1,0 +1,32 @@
+allOf:
+  - $ref: "../../../shared/models/form_factor/input_to.yml"
+  - $ref: "../../../shared/models/form_factor/input_from.yml"
+
+  - type: object
+
+    required:
+      - to
+      - from
+      - file
+      - color
+
+    properties:
+      merge_variables:
+        $ref: "../../../shared/models/merge_variables.yml"
+
+      file:
+        $ref: "../../letters/attributes/ltr_file.yml"
+
+      color:
+        allOf:
+          - $ref: "../../letters/attributes/color.yml"
+          - default: false
+
+      double_sided:
+        $ref: "../../letters/attributes/double_sided.yml"
+
+      address_placement:
+        $ref: "../../letters/attributes/address_placement.yml"
+
+      size:
+        $ref: "../../letters/attributes/ltr_size.yml"

--- a/resources/resource_proofs/models/postcard_resource_parameters.yml
+++ b/resources/resource_proofs/models/postcard_resource_parameters.yml
@@ -1,0 +1,23 @@
+allOf:
+  - $ref: "../../../shared/models/form_factor/input_to.yml"
+  - $ref: "../../../shared/models/form_factor/input_from_us.yml"
+
+  - type: object
+
+    required:
+      - to
+      - front
+      - back
+
+    properties:
+      size:
+        $ref: "../../postcards/attributes/postcard_size.yml"
+
+      merge_variables:
+        $ref: "../../../shared/models/merge_variables.yml"
+
+      front:
+        $ref: "../../postcards/attributes/psc_front.yml"
+
+      back:
+        $ref: "../../postcards/attributes/psc_back.yml"

--- a/resources/resource_proofs/models/resource_proof.yml
+++ b/resources/resource_proofs/models/resource_proof.yml
@@ -1,0 +1,27 @@
+allOf:
+  - $ref: "resource_proof_base.yml"
+
+  - type: object
+    required:
+      - id
+      - resource_type
+      - status
+      - thumbnails
+      - errors
+      - date_created
+      - date_modified
+      - object
+    properties:
+      id:
+        $ref: "../attributes/res_prf_id.yml"
+
+      date_created:
+        $ref: "../../../shared/attributes/timestamps.yml#/date_created"
+
+      date_modified:
+        $ref: "../../../shared/attributes/timestamps.yml#/date_modified"
+
+      object:
+        type: string
+        description: Value is resource type.
+        default: "resource_proof"

--- a/resources/resource_proofs/models/resource_proof_base.yml
+++ b/resources/resource_proofs/models/resource_proof_base.yml
@@ -1,0 +1,30 @@
+type: object
+
+properties:
+  template_id:
+    type: string
+    nullable: true
+    description: The template ID associated with the resource proof, if any.
+
+  resource_type:
+    $ref: "../attributes/res_prf_resource_type.yml"
+
+  status:
+    $ref: "../attributes/res_prf_status.yml"
+
+  thumbnails:
+    type: array
+    description: Thumbnail images of the resource proof.
+    items:
+      $ref: "../../../shared/models/thumbnail.yml"
+
+  url:
+    type: string
+    nullable: true
+    description: A URL to the resource proof PDF.
+
+  errors:
+    type: array
+    description: Errors encountered during processing.
+    items:
+      $ref: "issue_entry.yml"

--- a/resources/resource_proofs/models/resource_proof_editable.yml
+++ b/resources/resource_proofs/models/resource_proof_editable.yml
@@ -1,0 +1,56 @@
+required:
+  - resource_type
+  - resource_parameters
+
+oneOf:
+  - title: Postcard Resource Proof
+    type: object
+    properties:
+      template_id:
+        type: string
+        nullable: true
+        description: The template ID to associate with the resource proof.
+      resource_type:
+        type: string
+        enum:
+          - postcard
+        description: The type of resource to generate a proof for.
+      resource_parameters:
+        $ref: "postcard_resource_parameters.yml"
+
+  - title: Letter Resource Proof
+    type: object
+    properties:
+      template_id:
+        type: string
+        nullable: true
+        description: The template ID to associate with the resource proof.
+      resource_type:
+        type: string
+        enum:
+          - letter
+        description: The type of resource to generate a proof for.
+      resource_parameters:
+        $ref: "letter_resource_parameters.yml"
+
+  - title: Self Mailer Resource Proof
+    type: object
+    properties:
+      template_id:
+        type: string
+        nullable: true
+        description: The template ID to associate with the resource proof.
+      resource_type:
+        type: string
+        enum:
+          - self_mailer
+        description: The type of resource to generate a proof for.
+      resource_parameters:
+        $ref: "self_mailer_resource_parameters.yml"
+
+discriminator:
+  propertyName: resource_type
+  mapping:
+    postcard: "#/oneOf/0"
+    letter: "#/oneOf/1"
+    self_mailer: "#/oneOf/2"

--- a/resources/resource_proofs/models/resource_proof_updatable.yml
+++ b/resources/resource_proofs/models/resource_proof_updatable.yml
@@ -1,0 +1,7 @@
+type: object
+
+properties:
+  template_id:
+    type: string
+    nullable: true
+    description: The template ID to associate with the resource proof.

--- a/resources/resource_proofs/models/self_mailer_resource_parameters.yml
+++ b/resources/resource_proofs/models/self_mailer_resource_parameters.yml
@@ -1,0 +1,63 @@
+allOf:
+  - $ref: "../../../shared/models/form_factor/input_to.yml"
+  - $ref: "../../../shared/models/form_factor/input_from_us.yml"
+
+  - type: object
+
+    required:
+      - to
+      - inside
+      - outside
+
+    properties:
+      size:
+        $ref: "../../self_mailers/attributes/self_mailer_size.yml"
+
+      merge_variables:
+        $ref: "../../../shared/models/merge_variables.yml"
+
+      inside:
+        description: >
+          The artwork to use as the inside of your self mailer.
+
+
+          Notes:
+
+          - HTML merge variables should not include delimiting whitespace.
+
+          - PDF, PNG, and JPGs must be sized at 6"x18" at 300 DPI, while supplied
+          HTML will be rendered to the specified `size`.
+
+          - Be sure to leave room for address and postage information by following
+          the templates provided here:
+            - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_bifold_template.pdf" target="_blank">6x18 bifold template</a>
+            - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/12x9_sfm_bifold_template.pdf" target="_blank">12x9 bifold template</a>
+            - <a href="https://s3-us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/17_75x9_trifold_sfm_template.pdf" target="_blank">17.75x9 trifold template</a>
+
+
+          See [here](#section/HTML-Examples) for HTML examples.
+        oneOf:
+          - $ref: "../../../shared/attributes/html_string.yml"
+          - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+          - $ref: "../../../shared/attributes/remote_file_url.yml"
+          - $ref: "../../../shared/attributes/local_file_path.yml"
+
+      outside:
+        description: >
+          The artwork to use as the outside of your self mailer.
+
+
+          Notes:
+
+          - HTML merge variables should not include delimiting whitespace.
+
+          - PDF, PNG, and JPGs must be sized at 6"x18" at 300 DPI, while supplied
+          HTML will be rendered to the specified `size`.
+
+
+          See [here](#section/HTML-Examples) for HTML examples.
+        oneOf:
+          - $ref: "../../../shared/attributes/html_string.yml"
+          - $ref: "../../../shared/attributes/model_ids/tmpl_id.yml"
+          - $ref: "../../../shared/attributes/remote_file_url.yml"
+          - $ref: "../../../shared/attributes/local_file_path.yml"

--- a/resources/resource_proofs/resource_proof.yml
+++ b/resources/resource_proofs/resource_proof.yml
@@ -1,0 +1,73 @@
+parameters:
+  - in: path
+    name: res_prf_id
+    description: id of the resource proof
+    required: true
+    schema:
+      $ref: "attributes/res_prf_id.yml"
+
+get:
+  operationId: resource_proof_retrieve
+
+  summary: Retrieve
+
+  description: >-
+    Retrieves the details of an existing resource proof. You need only supply
+    the unique resource proof identifier.
+
+  tags:
+    - Resource Proofs
+
+  responses:
+    "200":
+      description: Returns a resource proof object
+      content:
+        $ref: "responses/resource_proof.yml"
+
+    default:
+      $ref: "../../shared/responses/mailpiece_error.yml"
+
+  x-codeSamples:
+    - lang: Shell
+      source: |
+        curl https://api.lob.com/v1/resource_proofs/res_prf_example123 \
+          -u <YOUR API KEY>:
+      label: CURL
+
+patch:
+  operationId: resource_proof_update
+
+  summary: Update
+
+  description: >-
+    Updates the specified resource proof.
+
+  tags:
+    - Resource Proofs
+
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "models/resource_proof_updatable.yml"
+        example:
+          template_id: "tmpl_a1234dddg"
+
+  responses:
+    "200":
+      description: Returns an updated resource proof object
+      content:
+        $ref: "responses/resource_proof.yml"
+
+    default:
+      $ref: "../../shared/responses/mailpiece_error.yml"
+
+  x-codeSamples:
+    - lang: Shell
+      source: |
+        curl -X PATCH https://api.lob.com/v1/resource_proofs/res_prf_example123 \
+          -u <YOUR API KEY>: \
+          -H "Content-Type: application/json" \
+          -d '{"template_id": "tmpl_a1234dddg"}'
+      label: CURL

--- a/resources/resource_proofs/resource_proofs.yml
+++ b/resources/resource_proofs/resource_proofs.yml
@@ -1,0 +1,46 @@
+post:
+  operationId: resource_proof_create
+
+  summary: Create
+
+  description: >-
+    Creates a new resource proof with the provided properties.
+
+  tags:
+    - Resource Proofs
+
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "models/resource_proof_editable.yml"
+        example:
+          resource_type: postcard
+          resource_parameters:
+            front: "tmpl_a1234dddg"
+            back: "tmpl_a1234dddg"
+            to: "adr_a1234dddg"
+
+  responses:
+    "201":
+      $ref: responses/post_resource_proof.yml
+
+    default:
+      $ref: "../../shared/responses/mailpiece_error.yml"
+
+  x-codeSamples:
+    - lang: Shell
+      source: |
+        curl https://api.lob.com/v1/resource_proofs \
+          -u <YOUR API KEY>: \
+          -H "Content-Type: application/json" \
+          -d '{
+            "resource_type": "postcard",
+            "resource_parameters": {
+              "front": "tmpl_a1234dddg",
+              "back": "tmpl_a1234dddg",
+              "to": "adr_a1234dddg"
+            }
+          }'
+      label: CURL

--- a/resources/resource_proofs/responses/post_resource_proof.yml
+++ b/resources/resource_proofs/responses/post_resource_proof.yml
@@ -1,0 +1,12 @@
+description: Returns a resource proof object
+
+headers:
+  ratelimit-limit:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-limit"
+  ratelimit-remaining:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-remaining"
+  ratelimit-reset:
+    $ref: "../../../shared/headers/ratelimit.yml#/ratelimit-reset"
+
+content:
+  $ref: "resource_proof.yml"

--- a/resources/resource_proofs/responses/resource_proof.yml
+++ b/resources/resource_proofs/responses/resource_proof.yml
@@ -1,0 +1,18 @@
+application/json:
+  schema:
+    $ref: "../models/resource_proof.yml"
+
+  example:
+    id: "res_prf_example123"
+    template_id: null
+    resource_type: "postcard"
+    status: "completed"
+    thumbnails:
+      - small: "https://lob-assets.com/resource-proofs/res_prf_example123_thumb_small_1.png"
+        medium: "https://lob-assets.com/resource-proofs/res_prf_example123_thumb_medium_1.png"
+        large: "https://lob-assets.com/resource-proofs/res_prf_example123_thumb_large_1.png"
+    url: "https://lob-assets.com/resource-proofs/res_prf_example123.pdf"
+    errors: []
+    date_created: "2017-11-07T22:56:10.962Z"
+    date_modified: "2017-11-07T22:56:10.962Z"
+    object: "resource_proof"


### PR DESCRIPTION
Fixes #FD-164

## Checklist

- [x] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [x] `npm run bundle` outputs nothing suspect
- [x] `npm run postman` outputs nothing suspect

## Changes

Adds complete OpenAPI specification for the Resource Proofs resource, enabling users to create proofs for reviewing mailpiece creatives. The implementation includes:

**New Endpoints:**
- `POST /resource_proofs` - Create a new resource proof
- `GET /resource_proofs/{res_prf_id}` - Retrieve a resource proof
- `PATCH /resource_proofs/{res_prf_id}` - Update a resource proof (template_id only)

**Resource Types Supported:**
- Postcard
- Letter
- Self Mailer

**Schema Features:**
- Discriminated `oneOf` pattern for the three resource types
- Proper error handling with detailed issue entries
- Thumbnail support (small, medium, large)
- Complete model composition using `allOf` for reusability
- Consistent response formats aligned with existing Lob API patterns

**Files Added:**
- 16 new OpenAPI definition files under `resources/resource_proofs/`
  - Models (base, editable, updatable, resource-type-specific parameters)
  - Attributes (id, status, resource_type)
  - Responses (resource_proof, post_resource_proof)
  - Endpoint definitions

**Files Modified:**
- `lob-api-public.yml` - Added tag definition, tagGroup reference, and path definitions
- `docs/index.html` - Auto-generated from updated spec

## Areas of Concern (optional)

- Response example in `resources/resource_proofs/responses/resource_proof.yml` is missing `resource_parameters` and `url` fields (see code review findings)
- Top-level `required` in `resource_proof_editable.yml` may need alignment with how other discriminated schemas handle this constraint
- Some unstaged changes needed (description replacement and example adjustments)