### PR TITLE
BILL-5564: Update bank account spec for microdeposit_type response field and descriptor_code verify input

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,13 +18,3 @@ import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
-
-// The Redoc search index (lunr.js) throws "Out of order word insertion" as an
-// unhandled promise rejection when building its client-side index. This is a
-// known lunr issue with the word ordering in the generated index and does not
-// affect page functionality or any assertion made by these tests.
-Cypress.on("uncaught:exception", (err) => {
-  if (err.message.includes("Out of order word insertion")) {
-    return false;
-  }
-});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,3 +18,13 @@ import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// The Redoc search index (lunr.js) throws "Out of order word insertion" as an
+// unhandled promise rejection when building its client-side index. This is a
+// known lunr issue with the word ordering in the generated index and does not
+// affect page functionality or any assertion made by these tests.
+Cypress.on("uncaught:exception", (err) => {
+  if (err.message.includes("Out of order word insertion")) {
+    return false;
+  }
+});

--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.21.0
+  version: 1.22.0
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:
@@ -3141,7 +3141,18 @@ paths:
     post:
       operationId: bank_account_verify
       summary: Verify
-      description: Verify a bank account in order to create a check.
+      description: |-
+        Verify a bank account in order to create a check.
+
+        Check the `microdeposit_type` field returned by `GET /v1/bank_accounts/:id` to determine which parameter to submit:
+        - `amounts` — provide the two microdeposit amounts (in cents) that appeared
+          in the bank account statement.
+
+        - `descriptor_code` — provide the 6-character code (beginning with `SM`)
+          from the bank statement descriptor of the single $0.01 microdeposit.
+
+
+        Submitting the wrong parameter type for the account's `microdeposit_type` will return an error.
       tags:
         - Bank Accounts
       requestBody:
@@ -3150,24 +3161,45 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bank_account_verify'
-            example:
+            examples:
               amounts:
-                - 1
-                - 100
+                summary: Verify with two deposit amounts
+                value:
+                  amounts:
+                    - 25
+                    - 63
+              descriptor_code:
+                summary: Verify with a statement descriptor code
+                value:
+                  descriptor_code: SMABCD
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/bank_account_verify'
-            example:
+            examples:
               amounts:
-                - 1
-                - 100
+                summary: Verify with two deposit amounts
+                value:
+                  amounts:
+                    - 25
+                    - 63
+              descriptor_code:
+                summary: Verify with a statement descriptor code
+                value:
+                  descriptor_code: SMABCD
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/bank_account_verify'
-            example:
+            examples:
               amounts:
-                - 1
-                - 100
+                summary: Verify with two deposit amounts
+                value:
+                  amounts:
+                    - 25
+                    - 63
+              descriptor_code:
+                summary: Verify with a statement descriptor code
+                value:
+                  descriptor_code: SMABCD
       responses:
         '200':
           $ref: '#/components/responses/post_bank_account'
@@ -3176,16 +3208,32 @@ paths:
       x-codeSamples:
         - lang: Shell
           source: |
+            # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            # microdeposit_type: amounts
             curl https://api.lob.com/v1/bank_accounts/bank_dfceb4a2a05b57e/verify \
               -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
               -d "amounts[]=25" \
               -d "amounts[]=63"
+
+            # microdeposit_type: descriptor_code
+            curl https://api.lob.com/v1/bank_accounts/bank_dfceb4a2a05b57e/verify \
+              -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
+              -d "descriptor_code=SMABCD"
           label: CURL
         - lang: Typescript
           source: |
+            // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            // microdeposit_type: amounts
             const verificationData = new BankAccountVerify({
-              amounts: [11, 35],
+              amounts: [25, 63],
             });
+
+            // microdeposit_type: descriptor_code
+            // const verificationData = new BankAccountVerify({
+            //   descriptor_code: 'SMABCD',
+            // });
 
             try {
               const verifiedAccount = await new BankAccountsApi(config).verify('bank_xxxx', verificationData);
@@ -3195,20 +3243,35 @@ paths:
           label: TYPESCRIPT
         - lang: Javascript
           source: |
+            // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            // microdeposit_type: amounts
             Lob.bankAccounts.verify('bank_dfceb4a2a05b57e', {
               amounts: [25, 63]
             }, function (err, res) {
               console.log(err, res);
             });
+
+            // microdeposit_type: descriptor_code
+            // Lob.bankAccounts.verify('bank_dfceb4a2a05b57e', {
+            //   descriptor_code: 'SMABCD'
+            // }, function (err, res) {
+            //   console.log(err, res);
+            // });
           label: NODE
         - lang: Ruby
           source: |
+            # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            # microdeposit_type: amounts
             verificationData = BankAccountVerify.new({
-              amounts: [
-                25,
-                63,
-              ],
+              amounts: [25, 63],
             })
+
+            # microdeposit_type: descriptor_code
+            # verificationData = BankAccountVerify.new({
+            #   descriptor_code: 'SMABCD',
+            # })
 
             bankAccountsApi = BankAccountsApi.new(config)
 
@@ -3220,12 +3283,17 @@ paths:
           label: RUBY
         - lang: Python
           source: |
+            # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            # microdeposit_type: amounts
             verification_data = BankAccountVerify(
-              amounts = [
-                25,
-                63,
-              ],
+              amounts=[25, 63],
             )
+
+            # microdeposit_type: descriptor_code
+            # verification_data = BankAccountVerify(
+            #   descriptor_code='SMABCD',
+            # )
 
             with ApiClient(configuration) as api_client:
               api = BankAccountsApi(api_client)
@@ -3239,11 +3307,15 @@ paths:
           source: |
             $apiInstance = new OpenAPI\Client\Api\BankAccountsApi($config, new GuzzleHttp\Client());
 
+            // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            // microdeposit_type: amounts
             $bankVerify = new OpenAPI\Client\Model\BankAccountVerify();
-            $bankVerify->setAmounts([
-              25,
-              63,
-            ]);
+            $bankVerify->setAmounts([25, 63]);
+
+            // microdeposit_type: descriptor_code
+            // $bankVerify = new OpenAPI\Client\Model\BankAccountVerify();
+            // $bankVerify->setDescriptorCode('SMABCD');
 
             try {
                 $result = $apiInstance->verify(
@@ -3254,9 +3326,16 @@ paths:
             }
         - lang: Java
           source: |
+            // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            // microdeposit_type: amounts
             BankAccountVerify verification = new BankAccountVerify();
             verification.addAmountsItem(25);
             verification.addAmountsItem(63);
+
+            // microdeposit_type: descriptor_code
+            // BankAccountVerify verification = new BankAccountVerify();
+            // verification.setDescriptorCode("SMABCD");
 
             BankAccountsApi apiInstance = new BankAccountsApi(config);
 
@@ -3268,15 +3347,27 @@ paths:
           label: JAVA
         - lang: Elixir
           source: |
+            # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            # microdeposit_type: amounts
             Lob.BankAccount.verify("bank_dfceb4a2a05b57e", %{amounts: [25, 63]})
+
+            # microdeposit_type: descriptor_code
+            # Lob.BankAccount.verify("bank_dfceb4a2a05b57e", %{descriptor_code: "SMABCD"})
           label: ELIXIR
         - lang: CSharp
           source: |
+            // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            // microdeposit_type: amounts
             List<int> amounts = new List<int>();
             amounts.Add(25);
             amounts.Add(63);
-
             BankAccountVerify verification = new BankAccountVerify(amounts);
+
+            // microdeposit_type: descriptor_code
+            // BankAccountVerify verification = new BankAccountVerify();
+            // verification.DescriptorCode = "SMABCD";
 
             BankAccountsApi api = new BankAccountsApi(config);
 
@@ -3297,8 +3388,15 @@ paths:
 
             createdBankAccount, _, _ := apiClient.BankAccountsApi.Create(context).BankAccountWritable(bankAccountWritable).Execute()
 
-            verifyAmounts := []int32{11, 35}
+            // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+            // microdeposit_type: amounts
+            verifyAmounts := []int32{25, 63}
             verify := *lob.NewBankAccountVerify(verifyAmounts)
+
+            // microdeposit_type: descriptor_code
+            // verify := *lob.NewBankAccountVerify(nil)
+            // verify.DescriptorCode = lob.PtrString("SMABCD")
 
             verifiedAccount, _, err := apiClient.BankAccountsApi.Verify(context, createdBankAccount.Id).BankAccountVerify(verify).Execute()
 
@@ -3342,7 +3440,8 @@ paths:
                 bank_city: Columbus
                 bank_state: OH
                 bank_zip: '43240'
-                verified: false
+                verified: true
+                microdeposit_type: null
                 date_created: '2015-11-06T19:24:24.440Z'
                 date_modified: '2015-11-06T19:24:24.440Z'
                 object: bank_account
@@ -16818,17 +16917,32 @@ components:
       minimum: 1
       maximum: 100
     bank_account_verify:
-      type: object
-      required:
-        - amounts
-      properties:
-        amounts:
-          description: In live mode, an array containing the two micro deposits (in cents) placed in the bank account. In test mode, no micro deposits will be placed, so any two integers between `1` and `100` will work.
-          type: array
-          minItems: 2
-          maxItems: 2
-          items:
-            $ref: '#/components/schemas/cents'
+      oneOf:
+        - title: BankAccountVerifyAmounts
+          type: object
+          additionalProperties: false
+          required:
+            - amounts
+          properties:
+            amounts:
+              description: In live mode, an array containing the two microdeposit amounts (in cents) placed in the bank account. In test mode, no microdeposits will be placed, so any two integers between `1` and `100` will work.
+              type: array
+              minItems: 2
+              maxItems: 2
+              items:
+                $ref: '#/components/schemas/cents'
+        - title: BankAccountVerifyDescriptorCode
+          type: object
+          additionalProperties: false
+          required:
+            - descriptor_code
+          properties:
+            descriptor_code:
+              description: The 6-character code (beginning with `SM`) found in the statement descriptor of the $0.01 microdeposit placed in the bank account.
+              type: string
+              minLength: 6
+              maxLength: 6
+              pattern: ^[Ss][Mm][A-Za-z0-9]{4}$
     bank_account_base:
       type: object
       required:
@@ -16904,6 +17018,13 @@ components:
               description: A bank account must be verified before a check can be created. More info [here](#operation/bank_account_verify).
               type: boolean
               default: false
+            microdeposit_type:
+              description: 'The type of microdeposit verification required for this bank account. Always present when `verified` is `false`; `null` once the account is verified. Use this value to determine which field to submit to `POST /v1/bank_accounts/:id/verify`: `amounts` (an array of two integers) or `descriptor_code` (the 6-character code from the bank statement).'
+              type: string
+              nullable: true
+              enum:
+                - amounts
+                - descriptor_code
             object:
               type: string
               description: Value is resource type.
@@ -16914,14 +17035,15 @@ components:
         id: bank_a
         signature_url: https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf
         bank_name: JPMORGAN CHASE BANK
-        verified: true
+        verified: false
+        microdeposit_type: amounts
         object: bank_account
         description: Test Bank Account
         routing_number: '322271627'
         account_number: '123456789'
         signatory: Jane Doe
         account_type: individual
-        metadat:
+        metadata:
           spiffy: 'true'
         date_created: '2019-08-08T19:34:47.571Z'
         date_modified: '2019-08-08T19:34:47.571Z'
@@ -22825,7 +22947,8 @@ components:
             bank_city: Columbus
             bank_state: OH
             bank_zip: '43240'
-            verified: false
+            verified: true
+            microdeposit_type: null
             date_created: '2015-11-06T19:24:24.440Z'
             date_modified: '2015-11-06T19:24:24.440Z'
             object: bank_account

--- a/lob-api-public.yml
+++ b/lob-api-public.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Lob
-  version: 1.21.0
+  version: 1.22.0
   description: |
     The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p>
   license:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lob/openapi",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lob/openapi",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11615,6 +11615,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
+    },
+    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "extraneous": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/redoc-cli/node_modules/@types/node": {
       "version": "15.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lob/openapi",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "engines": {
     "node": ">=14.16.0",
     "npm": ">=7.9.0"

--- a/resources/bank_accounts/bank_account_verify.yml
+++ b/resources/bank_accounts/bank_account_verify.yml
@@ -99,7 +99,7 @@ post:
 
         # microdeposit_type: descriptor_code
         curl https://api.lob.com/v1/bank_accounts/bank_dfceb4a2a05b57e/verify \
-          -u <YOUR_TEST_API_KEY>: \
+          -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
           -d "descriptor_code=SMABCD"
       label: CURL
     - lang: Typescript

--- a/resources/bank_accounts/bank_account_verify.yml
+++ b/resources/bank_accounts/bank_account_verify.yml
@@ -18,11 +18,11 @@ post:
     Check the `microdeposit_type` field on the bank account to determine which
     parameter to submit:
 
-    - `amounts` — provide the two micro deposit amounts (in cents) that appeared
+    - `amounts` — provide the two microdeposit amounts (in cents) that appeared
       in the bank account statement.
 
     - `descriptor_code` — provide the 6-character code (beginning with `SM`)
-      from the bank statement descriptor of the single $0.01 micro deposit.
+      from the bank statement descriptor of the single $0.01 microdeposit.
 
 
     Submitting the wrong parameter type for the account's `microdeposit_type`

--- a/resources/bank_accounts/bank_account_verify.yml
+++ b/resources/bank_accounts/bank_account_verify.yml
@@ -47,7 +47,7 @@ post:
           descriptor_code:
             summary: Verify with a statement descriptor code
             value:
-              descriptor_code: SMXXXX
+              descriptor_code: SMABCD
 
       application/x-www-form-urlencoded:
         schema:
@@ -62,7 +62,7 @@ post:
           descriptor_code:
             summary: Verify with a statement descriptor code
             value:
-              descriptor_code: SMXXXX
+              descriptor_code: SMABCD
 
       multipart/form-data:
         schema:
@@ -77,7 +77,7 @@ post:
           descriptor_code:
             summary: Verify with a statement descriptor code
             value:
-              descriptor_code: SMXXXX
+              descriptor_code: SMABCD
 
   responses:
     "200":

--- a/resources/bank_accounts/bank_account_verify.yml
+++ b/resources/bank_accounts/bank_account_verify.yml
@@ -11,7 +11,22 @@ post:
 
   summary: Verify
 
-  description: Verify a bank account in order to create a check.
+  description: >-
+    Verify a bank account in order to create a check.
+
+
+    Check the `microdeposit_type` field on the bank account to determine which
+    parameter to submit:
+
+    - `amounts` — provide the two micro deposit amounts (in cents) that appeared
+      in the bank account statement.
+
+    - `descriptor_code` — provide the 6-character code (beginning with `SM`)
+      from the bank statement descriptor of the single $0.01 micro deposit.
+
+
+    Submitting the wrong parameter type for the account's `microdeposit_type`
+    will return an error.
 
   tags:
     - Bank Accounts
@@ -22,26 +37,47 @@ post:
       application/json:
         schema:
           $ref: "models/bank_account_verify.yml"
-        example:
+        examples:
           amounts:
-            - 1
-            - 100
+            summary: Verify with two deposit amounts
+            value:
+              amounts:
+                - 25
+                - 63
+          descriptor_code:
+            summary: Verify with a statement descriptor code
+            value:
+              descriptor_code: SMXXXX
 
       application/x-www-form-urlencoded:
         schema:
           $ref: "models/bank_account_verify.yml"
-        example:
+        examples:
           amounts:
-            - 1
-            - 100
+            summary: Verify with two deposit amounts
+            value:
+              amounts:
+                - 25
+                - 63
+          descriptor_code:
+            summary: Verify with a statement descriptor code
+            value:
+              descriptor_code: SMXXXX
 
       multipart/form-data:
         schema:
           $ref: "models/bank_account_verify.yml"
-        example:
+        examples:
           amounts:
-            - 1
-            - 100
+            summary: Verify with two deposit amounts
+            value:
+              amounts:
+                - 25
+                - 63
+          descriptor_code:
+            summary: Verify with a statement descriptor code
+            value:
+              descriptor_code: SMXXXX
 
   responses:
     "200":
@@ -53,16 +89,28 @@ post:
   x-codeSamples:
     - lang: Shell
       source: |
+        # Verify with amounts (microdeposit_type: amounts)
         curl https://api.lob.com/v1/bank_accounts/bank_dfceb4a2a05b57e/verify \
           -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
           -d "amounts[]=25" \
           -d "amounts[]=63"
+
+        # Verify with descriptor code (microdeposit_type: descriptor_code)
+        curl https://api.lob.com/v1/bank_accounts/bank_dfceb4a2a05b57e/verify \
+          -u <YOUR_TEST_API_KEY>: \
+          -d "descriptor_code=SMXXXX"
       label: CURL
     - lang: Typescript
       source: |
+        // Verify with amounts (microdeposit_type: amounts)
         const verificationData = new BankAccountVerify({
           amounts: [11, 35],
         });
+
+        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // const verificationData = new BankAccountVerify({
+        //   descriptor_code: 'SMXXXX',
+        // });
 
         try {
           const verifiedAccount = await new BankAccountsApi(config).verify('bank_xxxx', verificationData);
@@ -72,20 +120,31 @@ post:
       label: TYPESCRIPT
     - lang: Javascript
       source: |
+        // Verify with amounts (microdeposit_type: amounts)
         Lob.bankAccounts.verify('bank_dfceb4a2a05b57e', {
           amounts: [25, 63]
         }, function (err, res) {
           console.log(err, res);
         });
+
+        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // Lob.bankAccounts.verify('bank_dfceb4a2a05b57e', {
+        //   descriptor_code: 'SMXXXX'
+        // }, function (err, res) {
+        //   console.log(err, res);
+        // });
       label: NODE
     - lang: Ruby
       source: |
+        # Verify with amounts (microdeposit_type: amounts)
         verificationData = BankAccountVerify.new({
-          amounts: [
-            25,
-            63,
-          ],
+          amounts: [25, 63],
         })
+
+        # Verify with descriptor code (microdeposit_type: descriptor_code)
+        # verificationData = BankAccountVerify.new({
+        #   descriptor_code: 'SMXXXX',
+        # })
 
         bankAccountsApi = BankAccountsApi.new(config)
 
@@ -97,12 +156,15 @@ post:
       label: RUBY
     - lang: Python
       source: |
+        # Verify with amounts (microdeposit_type: amounts)
         verification_data = BankAccountVerify(
-          amounts = [
-            25,
-            63,
-          ],
+          amounts=[25, 63],
         )
+
+        # Verify with descriptor code (microdeposit_type: descriptor_code)
+        # verification_data = BankAccountVerify(
+        #   descriptor_code='SMXXXX',
+        # )
 
         with ApiClient(configuration) as api_client:
           api = BankAccountsApi(api_client)
@@ -116,11 +178,13 @@ post:
       source: |
         $apiInstance = new OpenAPI\Client\Api\BankAccountsApi($config, new GuzzleHttp\Client());
 
+        // Verify with amounts (microdeposit_type: amounts)
         $bankVerify = new OpenAPI\Client\Model\BankAccountVerify();
-        $bankVerify->setAmounts([
-          25,
-          63,
-        ]);
+        $bankVerify->setAmounts([25, 63]);
+
+        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // $bankVerify = new OpenAPI\Client\Model\BankAccountVerify();
+        // $bankVerify->setDescriptorCode('SMXXXX');
 
         try {
             $result = $apiInstance->verify(
@@ -131,9 +195,14 @@ post:
         }
     - lang: Java
       source: |
+        // Verify with amounts (microdeposit_type: amounts)
         BankAccountVerify verification = new BankAccountVerify();
         verification.addAmountsItem(25);
         verification.addAmountsItem(63);
+
+        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // BankAccountVerify verification = new BankAccountVerify();
+        // verification.setDescriptorCode("SMXXXX");
 
         BankAccountsApi apiInstance = new BankAccountsApi(config);
 
@@ -145,15 +214,23 @@ post:
       label: JAVA
     - lang: Elixir
       source: |
+        # Verify with amounts (microdeposit_type: amounts)
         Lob.BankAccount.verify("bank_dfceb4a2a05b57e", %{amounts: [25, 63]})
+
+        # Verify with descriptor code (microdeposit_type: descriptor_code)
+        # Lob.BankAccount.verify("bank_dfceb4a2a05b57e", %{descriptor_code: "SMXXXX"})
       label: ELIXIR
     - lang: CSharp
       source: |
+        // Verify with amounts (microdeposit_type: amounts)
         List<int> amounts = new List<int>();
         amounts.Add(25);
         amounts.Add(63);
-
         BankAccountVerify verification = new BankAccountVerify(amounts);
+
+        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // BankAccountVerify verification = new BankAccountVerify();
+        // verification.DescriptorCode = "SMXXXX";
 
         BankAccountsApi api = new BankAccountsApi(config);
 
@@ -174,8 +251,12 @@ post:
 
         createdBankAccount, _, _ := apiClient.BankAccountsApi.Create(context).BankAccountWritable(bankAccountWritable).Execute()
 
+        // Verify with amounts (microdeposit_type: amounts)
         verifyAmounts := []int32{11, 35}
         verify := *lob.NewBankAccountVerify(verifyAmounts)
+
+        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // verify := *lob.NewBankAccountVerifyDescriptorCode("SMXXXX")
 
         verifiedAccount, _, err := apiClient.BankAccountsApi.Verify(context, createdBankAccount.Id).BankAccountVerify(verify).Execute()
 

--- a/resources/bank_accounts/bank_account_verify.yml
+++ b/resources/bank_accounts/bank_account_verify.yml
@@ -15,8 +15,8 @@ post:
     Verify a bank account in order to create a check.
 
 
-    Check the `microdeposit_type` field on the bank account to determine which
-    parameter to submit:
+    Check the `microdeposit_type` field returned by `GET /v1/bank_accounts/:id`
+    to determine which parameter to submit:
 
     - `amounts` — provide the two microdeposit amounts (in cents) that appeared
       in the bank account statement.
@@ -89,27 +89,31 @@ post:
   x-codeSamples:
     - lang: Shell
       source: |
-        # Verify with amounts (microdeposit_type: amounts)
+        # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        # microdeposit_type: amounts
         curl https://api.lob.com/v1/bank_accounts/bank_dfceb4a2a05b57e/verify \
           -u test_0dc8d51e0acffcb1880e0f19c79b2f5b0cc: \
           -d "amounts[]=25" \
           -d "amounts[]=63"
 
-        # Verify with descriptor code (microdeposit_type: descriptor_code)
+        # microdeposit_type: descriptor_code
         curl https://api.lob.com/v1/bank_accounts/bank_dfceb4a2a05b57e/verify \
           -u <YOUR_TEST_API_KEY>: \
-          -d "descriptor_code=SMXXXX"
+          -d "descriptor_code=SMABCD"
       label: CURL
     - lang: Typescript
       source: |
-        // Verify with amounts (microdeposit_type: amounts)
+        // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        // microdeposit_type: amounts
         const verificationData = new BankAccountVerify({
-          amounts: [11, 35],
+          amounts: [25, 63],
         });
 
-        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // microdeposit_type: descriptor_code
         // const verificationData = new BankAccountVerify({
-        //   descriptor_code: 'SMXXXX',
+        //   descriptor_code: 'SMABCD',
         // });
 
         try {
@@ -120,30 +124,34 @@ post:
       label: TYPESCRIPT
     - lang: Javascript
       source: |
-        // Verify with amounts (microdeposit_type: amounts)
+        // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        // microdeposit_type: amounts
         Lob.bankAccounts.verify('bank_dfceb4a2a05b57e', {
           amounts: [25, 63]
         }, function (err, res) {
           console.log(err, res);
         });
 
-        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // microdeposit_type: descriptor_code
         // Lob.bankAccounts.verify('bank_dfceb4a2a05b57e', {
-        //   descriptor_code: 'SMXXXX'
+        //   descriptor_code: 'SMABCD'
         // }, function (err, res) {
         //   console.log(err, res);
         // });
       label: NODE
     - lang: Ruby
       source: |
-        # Verify with amounts (microdeposit_type: amounts)
+        # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        # microdeposit_type: amounts
         verificationData = BankAccountVerify.new({
           amounts: [25, 63],
         })
 
-        # Verify with descriptor code (microdeposit_type: descriptor_code)
+        # microdeposit_type: descriptor_code
         # verificationData = BankAccountVerify.new({
-        #   descriptor_code: 'SMXXXX',
+        #   descriptor_code: 'SMABCD',
         # })
 
         bankAccountsApi = BankAccountsApi.new(config)
@@ -156,14 +164,16 @@ post:
       label: RUBY
     - lang: Python
       source: |
-        # Verify with amounts (microdeposit_type: amounts)
+        # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        # microdeposit_type: amounts
         verification_data = BankAccountVerify(
           amounts=[25, 63],
         )
 
-        # Verify with descriptor code (microdeposit_type: descriptor_code)
+        # microdeposit_type: descriptor_code
         # verification_data = BankAccountVerify(
-        #   descriptor_code='SMXXXX',
+        #   descriptor_code='SMABCD',
         # )
 
         with ApiClient(configuration) as api_client:
@@ -178,13 +188,15 @@ post:
       source: |
         $apiInstance = new OpenAPI\Client\Api\BankAccountsApi($config, new GuzzleHttp\Client());
 
-        // Verify with amounts (microdeposit_type: amounts)
+        // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        // microdeposit_type: amounts
         $bankVerify = new OpenAPI\Client\Model\BankAccountVerify();
         $bankVerify->setAmounts([25, 63]);
 
-        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // microdeposit_type: descriptor_code
         // $bankVerify = new OpenAPI\Client\Model\BankAccountVerify();
-        // $bankVerify->setDescriptorCode('SMXXXX');
+        // $bankVerify->setDescriptorCode('SMABCD');
 
         try {
             $result = $apiInstance->verify(
@@ -195,14 +207,16 @@ post:
         }
     - lang: Java
       source: |
-        // Verify with amounts (microdeposit_type: amounts)
+        // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        // microdeposit_type: amounts
         BankAccountVerify verification = new BankAccountVerify();
         verification.addAmountsItem(25);
         verification.addAmountsItem(63);
 
-        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // microdeposit_type: descriptor_code
         // BankAccountVerify verification = new BankAccountVerify();
-        // verification.setDescriptorCode("SMXXXX");
+        // verification.setDescriptorCode("SMABCD");
 
         BankAccountsApi apiInstance = new BankAccountsApi(config);
 
@@ -214,23 +228,27 @@ post:
       label: JAVA
     - lang: Elixir
       source: |
-        # Verify with amounts (microdeposit_type: amounts)
+        # Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        # microdeposit_type: amounts
         Lob.BankAccount.verify("bank_dfceb4a2a05b57e", %{amounts: [25, 63]})
 
-        # Verify with descriptor code (microdeposit_type: descriptor_code)
-        # Lob.BankAccount.verify("bank_dfceb4a2a05b57e", %{descriptor_code: "SMXXXX"})
+        # microdeposit_type: descriptor_code
+        # Lob.BankAccount.verify("bank_dfceb4a2a05b57e", %{descriptor_code: "SMABCD"})
       label: ELIXIR
     - lang: CSharp
       source: |
-        // Verify with amounts (microdeposit_type: amounts)
+        // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        // microdeposit_type: amounts
         List<int> amounts = new List<int>();
         amounts.Add(25);
         amounts.Add(63);
         BankAccountVerify verification = new BankAccountVerify(amounts);
 
-        // Verify with descriptor code (microdeposit_type: descriptor_code)
+        // microdeposit_type: descriptor_code
         // BankAccountVerify verification = new BankAccountVerify();
-        // verification.DescriptorCode = "SMXXXX";
+        // verification.DescriptorCode = "SMABCD";
 
         BankAccountsApi api = new BankAccountsApi(config);
 
@@ -251,12 +269,15 @@ post:
 
         createdBankAccount, _, _ := apiClient.BankAccountsApi.Create(context).BankAccountWritable(bankAccountWritable).Execute()
 
-        // Verify with amounts (microdeposit_type: amounts)
-        verifyAmounts := []int32{11, 35}
+        // Check microdeposit_type from GET /v1/bank_accounts/:id to choose the right variant:
+
+        // microdeposit_type: amounts
+        verifyAmounts := []int32{25, 63}
         verify := *lob.NewBankAccountVerify(verifyAmounts)
 
-        // Verify with descriptor code (microdeposit_type: descriptor_code)
-        // verify := *lob.NewBankAccountVerifyDescriptorCode("SMXXXX")
+        // microdeposit_type: descriptor_code
+        // verify := *lob.NewBankAccountVerify(nil)
+        // verify.DescriptorCode = lob.PtrString("SMABCD")
 
         verifiedAccount, _, err := apiClient.BankAccountsApi.Verify(context, createdBankAccount.Id).BankAccountVerify(verify).Execute()
 

--- a/resources/bank_accounts/models/bank_account.yml
+++ b/resources/bank_accounts/models/bank_account.yml
@@ -36,13 +36,13 @@ allOf:
 
       microdeposit_type:
         description: >-
-          The type of micro deposit verification required for this bank account.
-          Present only while the account is unverified. Use this value to
-          determine which field to submit to `POST /v1/bank_accounts/:id/verify`:
-          `amounts` (an array of two integers) or `descriptor_code` (the 6-character
-          code from the bank statement). Defaults to `amounts` for bank accounts
-          created before this field was introduced.
+          The type of microdeposit verification required for this bank account.
+          Always present when `verified` is `false`; `null` once the account is
+          verified. Use this value to determine which field to submit to
+          `POST /v1/bank_accounts/:id/verify`: `amounts` (an array of two integers)
+          or `descriptor_code` (the 6-character code from the bank statement).
         type: string
+        nullable: true
         enum:
           - amounts
           - descriptor_code

--- a/resources/bank_accounts/models/bank_account.yml
+++ b/resources/bank_accounts/models/bank_account.yml
@@ -34,6 +34,19 @@ allOf:
         type: boolean
         default: false
 
+      microdeposit_type:
+        description: >-
+          The type of micro deposit verification required for this bank account.
+          Present only while the account is unverified. Use this value to
+          determine which field to submit to `POST /v1/bank_accounts/:id/verify`:
+          `amounts` (an array of two integers) or `descriptor_code` (the 6-character
+          code from the bank statement). Defaults to `amounts` for bank accounts
+          created before this field was introduced.
+        type: string
+        enum:
+          - amounts
+          - descriptor_code
+
       object:
         type: string
         description: Value is resource type.
@@ -45,14 +58,15 @@ example:
   id: bank_a
   signature_url: https://lob-assets.com/bank-accounts/asd_asdfghjkqwertyui.pdf?expires=1234567890&signature=aksdf
   bank_name: JPMORGAN CHASE BANK
-  verified: true
+  verified: false
+  microdeposit_type: amounts
   object: bank_account
   description: "Test Bank Account"
   routing_number: "322271627"
   account_number: "123456789"
   signatory: "Jane Doe"
   account_type: "individual"
-  metadat:
+  metadata:
     spiffy: "true"
   date_created: "2019-08-08T19:34:47.571Z"
   date_modified: "2019-08-08T19:34:47.571Z"

--- a/resources/bank_accounts/models/bank_account_verify.yml
+++ b/resources/bank_accounts/models/bank_account_verify.yml
@@ -7,8 +7,8 @@ oneOf:
     properties:
       amounts:
         description: >-
-          In live mode, an array containing the two micro deposits (in cents)
-          placed in the bank account. In test mode, no micro deposits will be
+          In live mode, an array containing the two microdeposit amounts (in cents)
+          placed in the bank account. In test mode, no microdeposits will be
           placed, so any two integers between `1` and `100` will work.
         type: array
         minItems: 2
@@ -25,8 +25,7 @@ oneOf:
       descriptor_code:
         description: >-
           The 6-character code (beginning with `SM`) found in the statement
-          descriptor of the micro deposit Stripe placed in the bank account.
-          Used when `microdeposit_type` is `descriptor_code`.
+          descriptor of the $0.01 microdeposit placed in the bank account.
         type: string
         minLength: 6
         maxLength: 6

--- a/resources/bank_accounts/models/bank_account_verify.yml
+++ b/resources/bank_accounts/models/bank_account_verify.yml
@@ -1,6 +1,7 @@
 oneOf:
   - title: BankAccountVerifyAmounts
     type: object
+    additionalProperties: false
     required:
       - amounts
     properties:
@@ -17,6 +18,7 @@ oneOf:
 
   - title: BankAccountVerifyDescriptorCode
     type: object
+    additionalProperties: false
     required:
       - descriptor_code
     properties:
@@ -28,4 +30,4 @@ oneOf:
         type: string
         minLength: 6
         maxLength: 6
-        pattern: "^SM[A-Z0-9]{4}$"
+        pattern: "^[Ss][Mm][A-Za-z0-9]{4}$"

--- a/resources/bank_accounts/models/bank_account_verify.yml
+++ b/resources/bank_accounts/models/bank_account_verify.yml
@@ -1,16 +1,31 @@
-type: object
+oneOf:
+  - title: BankAccountVerifyAmounts
+    type: object
+    required:
+      - amounts
+    properties:
+      amounts:
+        description: >-
+          In live mode, an array containing the two micro deposits (in cents)
+          placed in the bank account. In test mode, no micro deposits will be
+          placed, so any two integers between `1` and `100` will work.
+        type: array
+        minItems: 2
+        maxItems: 2
+        items:
+          $ref: "cents.yml"
 
-required:
-  - amounts
-
-properties:
-  amounts:
-    description: >-
-      In live mode, an array containing the two micro deposits (in cents)
-      placed in the bank account. In test mode, no micro deposits will be
-      placed, so any two integers between `1` and `100` will work.
-    type: array
-    minItems: 2
-    maxItems: 2
-    items:
-      $ref: "cents.yml"
+  - title: BankAccountVerifyDescriptorCode
+    type: object
+    required:
+      - descriptor_code
+    properties:
+      descriptor_code:
+        description: >-
+          The 6-character code (beginning with `SM`) found in the statement
+          descriptor of the micro deposit Stripe placed in the bank account.
+          Used when `microdeposit_type` is `descriptor_code`.
+        type: string
+        minLength: 6
+        maxLength: 6
+        pattern: "^SM[A-Z0-9]{4}$"

--- a/resources/bank_accounts/responses/bank_account.yml
+++ b/resources/bank_accounts/responses/bank_account.yml
@@ -18,6 +18,7 @@ application/json:
     bank_state: OH
     bank_zip: "43240"
     verified: false
+    microdeposit_type: amounts
     date_created: "2015-11-06T19:24:24.440Z"
     date_modified: "2015-11-06T19:24:24.440Z"
     object: bank_account

--- a/resources/bank_accounts/responses/bank_account.yml
+++ b/resources/bank_accounts/responses/bank_account.yml
@@ -17,8 +17,8 @@ application/json:
     bank_city: Columbus
     bank_state: OH
     bank_zip: "43240"
-    verified: false
-    microdeposit_type: amounts
+    verified: true
+    microdeposit_type: null
     date_created: "2015-11-06T19:24:24.440Z"
     date_modified: "2015-11-06T19:24:24.440Z"
     object: bank_account


### PR DESCRIPTION
Fixes #BILL-5564

## Checklist

- [x] Up to date with `main`
- [ ] All the tests are passing
  - [ ] Delete all resources created in tests
- [x] Prettier
- [x] Spectral Lint
- [ ] `npm run bundle` outputs nothing suspect
- [ ] `npm run postman` outputs nothing suspect

## Changes

**Problem**

Stripe routes some banks to a `descriptor_code` microdeposit verification path instead of the legacy two-amount `amounts` path. The existing spec only documents the `amounts` path: the verify endpoint schema requires `amounts`, and the bank account response has no field indicating which path applies. Clients have no way to know which input to send, and any bank routed to `descriptor_code` fails verification entirely.

**Solution**

Two connected spec changes close the gap:

1. **`models/bank_account.yml`** — adds a `microdeposit_type` field (`enum: amounts | descriptor_code`, `nullable: true`) to the bank account response. The field is always present while the account is unverified and `null` once verified. Clients read this value to determine which parameter to send to the verify endpoint.

2. **`models/bank_account_verify.yml`** — replaces the flat `amounts`-only schema with a `oneOf` containing two titled, mutually exclusive variants (`BankAccountVerifyAmounts` and `BankAccountVerifyDescriptorCode`). `additionalProperties: false` on each branch enforces the "never both" constraint across all validators.

Supporting updates:
- Endpoint description, request body examples, and all nine language code samples updated to document both paths and direct developers to check `microdeposit_type` from `GET /v1/bank_accounts/:id` before calling verify.
- Verify endpoint 200 response example updated to reflect post-verification state (`verified: true`, `microdeposit_type: null`).

> ⚠️ **Dependency notice:** This documentation is only accurate once the following lob-api PRs have landed:
> - [lob-api#13088 — BILL-5559: Persist and expose microdeposit type on bank account creation](https://github.com/lob/lob-api/pull/13088)
> - [lob-api#13089 — BILL-5560: Update verify endpoint to accept descriptor_code](https://github.com/lob/lob-api/pull/13089)
>
> This spec PR can be reviewed and approved ahead of those merges but should not be deployed to production docs until both backend PRs are live.
